### PR TITLE
Fix issue around apps and routes missing from space entity

### DIFF
--- a/components/cloud-foundry/frontend/src/model/space.model.js
+++ b/components/cloud-foundry/frontend/src/model/space.model.js
@@ -595,7 +595,7 @@
 
         // Set memory utilisation
         details.memUsed = 0;
-        _.forEach(space.entity.apps, function (app) {
+        _.forEach(vals.apps, function (app) {
           // Only count running apps, like the CF API would do
           if (app.entity.state === 'STARTED') {
             details.memUsed += parseInt(app.entity.memory, 10);

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/cluster.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/cluster.module.js
@@ -49,9 +49,9 @@
       var orgPromise = cfOrganizationModel.listAllOrganizations(that.guid, inDepthParams).then(function (orgs) {
         var allDetailsP = [];
         _.forEach(orgs, function (org) {
-          var orgDetailsP = cfOrganizationModel.getOrganizationDetails(that.guid, org).catch(function () {
+          var orgDetailsP = cfOrganizationModel.getOrganizationDetails(that.guid, org).catch(function (err) {
             // Swallow errors for individual orgs
-            $log.error('Failed to fetch details for org - ' + org.entity.name);
+            $log.error('Failed to fetch details for org - ' + org.entity.name, err);
           });
           allDetailsP.push(orgDetailsP);
         });

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/cluster-organization.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/cluster-organization.module.js
@@ -33,9 +33,9 @@
 
       // Fetch details for every space
       _.forEach(_.get(that.cfOrganizationModel, that.spacesPath), function (space) {
-        var promiseForDetails = that.spaceModel.getSpaceDetails(that.clusterGuid, space).catch(function () {
+        var promiseForDetails = that.spaceModel.getSpaceDetails(that.clusterGuid, space).catch(function (err) {
           //Swallow errors for individual spaces
-          $log.error('Failed to fetch details for space - ' + space.entity.name);
+          $log.error('Failed to fetch details for space - ' + space.entity.name, err);
         });
         initPromises.push(promiseForDetails);
       });


### PR DESCRIPTION
- Missing apps and routes from space entity resulted in CF pages failing to load (no error on page, generic error in console)
- Could be missing due to the space entity being supplied from a request without inline depth OR apps/routes count more than 50
- In most cases we catch this. For some get count like functions we weren't handling this well
- This was an issue if any space OTHER than the first had over 50 apps or spaces
- We now handle these cases correctly
