### PR TITLE
Fix two app wall filter issues

### DIFF
--- a/src/frontend/app/features/applications/application-wall/application-wall.component.html
+++ b/src/frontend/app/features/applications/application-wall/application-wall.component.html
@@ -11,5 +11,5 @@
 </app-page-header>
 <app-endpoints-missing #appEndpointsMissing></app-endpoints-missing>
 <!-- <p *ngIf="error">We're sorry, we couldn't fetch all of your applications. Please try again later.</p> -->
-<app-list [text]="{ title: '', filter: 'Filter Applications'}" [enableFilter]="true" [cardComponent]="cardComponent" [hidden]="!(endpointsService.haveRegistered$ | async) || !(endpointsService.haveConnected$ | async)">
+<app-list [text]="{ title: '', filter: 'Search by name'}" [enableFilter]="true" [cardComponent]="cardComponent" [hidden]="!(endpointsService.haveRegistered$ | async) || !(endpointsService.haveConnected$ | async)">
 </app-list>

--- a/src/frontend/app/shared/components/list/list.component.html
+++ b/src/frontend/app/shared/components/list/list.component.html
@@ -49,7 +49,7 @@
         </div>
         <div class="listComponent__header__bottom">
           <div class="listComponent__header__left spacer">
-            <div class="multi-filters" [hidden]="(dataSource.isSelecting$ | async) || (!(dataSource.isLoadingPage$ | async) && (dataSource.pagination$ | async)?.totalResults === 0)">
+            <div class="multi-filters" [hidden]="((dataSource.pagination$ | async)?.totalResults === 0 && !filter) || (dataSource.isSelecting$ | async)">
               <mat-form-field *ngFor="let multiFilterConfig of multiFilterConfigs">
                 <mat-select matInput shouldLabelFloat="false" [(value)]="multiFilters[multiFilterConfig.key]" placeholder="{{multiFilterConfig.label}}" [disabled]="(dataSource.isLoadingPage$ | async)" (change)="multiFilterConfig.select.next($event.value)">
                   <mat-option>All</mat-option>

--- a/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-set-client-filter.ts
+++ b/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-set-client-filter.ts
@@ -9,6 +9,7 @@ export function paginationSetClientFilter(state: PaginationEntityState, action: 
       ...state.clientPagination,
       filter: {
         ...state.clientPagination.filter,
+        ...action.filter,
         items: {
           ...state.clientPagination.filter.items,
           ...action.filter.items


### PR DESCRIPTION
- Filter by app name now works again (and is titled 'Search by name' as per v1)
- Can now filter by cf/org/space to an empty result set and back to a populated result set again
