### PR TITLE
Tweak list paginator

### DIFF
--- a/src/frontend/app/shared/components/list/list.component.html
+++ b/src/frontend/app/shared/components/list/list.component.html
@@ -95,8 +95,10 @@
     <app-cards *ngIf="(dataSource.view$ | async) === 'cards'" #cards [dataSource]="dataSource" [component]="cardComponent" [hidden]="!(dataSource.isLoadingPage$ | async) && (dataSource.pagination$ | async)?.totalResults === 0"></app-cards>
     <app-table *ngIf="(dataSource.view$ | async) === 'table'" #table [dataSource]="dataSource" [paginationController]="paginationController" [columns]="columns" [text]="text" [enableFilter]="true" [fixedRowHeight]="tableFixedRowHeight" [hidden]="!(dataSource.isLoadingPage$ | async) && (dataSource.pagination$ | async)?.totalResults === 0">
     </app-table>
-    <mat-paginator #paginator [hidden]="(dataSource.pagination$ | async)?.totalResults === 0 || (dataSource.pagination$ | async)?.totalResults < (dataSource.pagination$ | async)?.pageSize" [pageSizeOptions]="paginator.pageSizeOptions" [pageSize]="paginator.pageSizeOptions[0]">
-    </mat-paginator>
+    <mat-card class="listComponent__paginator" [hidden]="(dataSource.pagination$ | async)?.totalResults === 0 || (dataSource.pagination$ | async)?.totalResults < (dataSource.pagination$ | async)?.pageSize">
+      <mat-paginator #paginator [pageSizeOptions]="paginator.pageSizeOptions" [pageSize]="paginator.pageSizeOptions[0]">
+      </mat-paginator>
+    </mat-card>
     <mat-card [hidden]="(dataSource.isLoadingPage$ | async) || (dataSource.pagination$ | async)?.totalResults > 0">
       <mat-card-content>
         <div class="no-rows">There are no entries.</div>

--- a/src/frontend/app/shared/components/list/list.component.scss
+++ b/src/frontend/app/shared/components/list/list.component.scss
@@ -70,4 +70,10 @@
       display: none;
     }
   }
+  &__paginator {
+    padding: 4px;
+    mat-paginator-container {
+      padding: 0;
+    }
+  }
 }


### PR DESCRIPTION
- An update to the material libary gave this a white background
- Make this into a card so that it's border is nicer
- In table view this now sits flush with bottom of actual table
- Think we still need to look again at this once we address the list top card