### PR TITLE
Ensure app polling stops when navigating away from app summary pages

### DIFF
--- a/src/frontend/app/core/entity-service.ts
+++ b/src/frontend/app/core/entity-service.ts
@@ -3,7 +3,7 @@ import { Store } from '@ngrx/store';
 import { denormalize, Schema } from 'normalizr';
 import { tag } from 'rxjs-spy/operators/tag';
 import { interval } from 'rxjs/observable/interval';
-import { filter, map, publishReplay, refCount, shareReplay, tap, withLatestFrom } from 'rxjs/operators';
+import { filter, map, publishReplay, refCount, shareReplay, tap, withLatestFrom, share } from 'rxjs/operators';
 import { Observable } from 'rxjs/Rx';
 
 import { AppState } from '../store/app-state';
@@ -172,8 +172,7 @@ export class EntityService {
       filter(({ resource, updatingSection }) => {
         return !!updatingSection;
       }),
-      publishReplay(1),
-      refCount(),
+      share(),
     );
   }
 

--- a/src/frontend/app/core/entity-service.ts
+++ b/src/frontend/app/core/entity-service.ts
@@ -3,7 +3,7 @@ import { Store } from '@ngrx/store';
 import { denormalize, Schema } from 'normalizr';
 import { tag } from 'rxjs-spy/operators/tag';
 import { interval } from 'rxjs/observable/interval';
-import { debounceTime, filter, map, share, shareReplay, tap, withLatestFrom } from 'rxjs/operators';
+import { filter, map, publishReplay, refCount, shareReplay, tap, withLatestFrom } from 'rxjs/operators';
 import { Observable } from 'rxjs/Rx';
 
 import { AppState } from '../store/app-state';
@@ -172,8 +172,9 @@ export class EntityService {
       filter(({ resource, updatingSection }) => {
         return !!updatingSection;
       }),
-      shareReplay(1)
-      );
+      publishReplay(1),
+      refCount(),
+    );
   }
 
 }


### PR DESCRIPTION
- in 5.5 shareReplay behaviour changed
- See https://blog.angularindepth.com/rxjs-how-to-use-refcount-73a0c6619a4e
- TLDR shareReplay no longer unsubs from root observable when there are no subscriptions left
- This meant interval with app request kept firing... whilst higher up summary/stats stopped