### PR TITLE
Fix navigation to app wall on app delete

### DIFF
--- a/src/frontend/app/store/reducers/api-request-reducer/request-helpers.ts
+++ b/src/frontend/app/store/reducers/api-request-reducer/request-helpers.ts
@@ -85,10 +85,23 @@ export function modifyRequestWithRequestType(requestState: RequestInfoState, typ
   return requestState;
 }
 
-export function mergeInnerObject(key, state, newState) {
+/**
+ * Merge the content of a new object into another object
+ */
+export function mergeObject(coreObject, newObject) {
+  return {
+    ...coreObject,
+    ...newObject
+  };
+}
+
+/**
+ * Merge the content of a new object into a property of another's
+ */
+export function mergeInnerObject(key, state, newObject) {
   return {
     ...state,
-    ...{ [key]: newState }
+    [key]: mergeObject(state[key], newObject)
   };
 }
 

--- a/src/frontend/app/store/reducers/api-request-reducer/succeed-request.ts
+++ b/src/frontend/app/store/reducers/api-request-reducer/succeed-request.ts
@@ -5,6 +5,7 @@ import {
   mergeInnerObject,
   mergeUpdatingState,
   setEntityRequestState,
+  mergeObject,
 } from './request-helpers';
 import { mergeState } from '../../helpers/reducer.helper';
 import { IRequestTypeState } from '../../app-state';
@@ -26,14 +27,10 @@ export function succeedRequest(state: IRequestTypeState, action: ISuccessRequest
         }
       );
     } else if (action.requestType === 'delete' && !action.apiAction.updatingKey) {
-      requestSuccessState.deleting = mergeInnerObject(
-        'deleting',
-        requestSuccessState.deleting,
-        {
-          busy: false,
-          deleted: true
-        }
-      );
+      requestSuccessState.deleting = mergeObject(requestSuccessState.deleting, {
+        busy: false,
+        deleted: true
+      });
     } else {
       requestSuccessState.fetching = false;
       requestSuccessState.error = false;


### PR DESCRIPTION
- When setting request flags delete was working in the same way as update (with a custom key)
- There's no support for custom deleting key yet, so apply flags to root deleting object