### PR TITLE
Allow for a longer animation for app status card colour transistions

### DIFF
--- a/src/frontend/app/shared/components/cards/card-status/card-status.component.scss
+++ b/src/frontend/app/shared/components/cards/card-status/card-status.component.scss
@@ -4,5 +4,5 @@
   position: absolute;
   right: 0;
   top: 0;
-  transition: background-color .5s ease-in-out;
+  transition: background-color 1s ease-in-out;
 }


### PR DESCRIPTION
This reduces the grey-->colour blip on the app wall