### PR TITLE
Show memory and disk usage with respect to number of running instances

### DIFF
--- a/components/cloud-foundry/frontend/src/model/application/application.model.js
+++ b/components/cloud-foundry/frontend/src/model/application/application.model.js
@@ -295,10 +295,14 @@
     function _sortFilteredApplications() {
       var path = model.currentSortOption;
       var sortOrder = model.sortAscending ? 'asc' : 'desc';
+      var multipleByInstances = path === 'entity.memory' || path === 'entity.disk_quota';
       model.filteredApplications = _.orderBy(model.filteredApplications, function (app) {
         var value = _.get(app, path);
         if (_.isString(value)) {
           return value.toLowerCase();
+        }
+        if (_.isNumber(value) && multipleByInstances) {
+          return value * app.entity.instances;
         }
         return value;
       }, sortOrder);

--- a/components/cloud-foundry/frontend/src/model/organization-model.factory.js
+++ b/components/cloud-foundry/frontend/src/model/organization-model.factory.js
@@ -377,7 +377,7 @@
             _.forEach(space.entity.apps, function (app) {
               // Only count running apps, like the CF API would do
               if (app.entity.state === 'STARTED') {
-                total += parseInt(app.entity.memory, 10);
+                total += app.entity.instances * parseInt(app.entity.memory, 10);
               }
             });
           } else {

--- a/components/cloud-foundry/frontend/src/model/space.model.js
+++ b/components/cloud-foundry/frontend/src/model/space.model.js
@@ -598,7 +598,7 @@
         _.forEach(vals.apps, function (app) {
           // Only count running apps, like the CF API would do
           if (app.entity.state === 'STARTED') {
-            details.memUsed += parseInt(app.entity.memory, 10);
+            details.memUsed += app.entity.instances * parseInt(app.entity.memory, 10);
           }
         });
         details.memQuota = _.get(vals.quota, 'entity.memory_limit', -1);

--- a/components/cloud-foundry/frontend/src/view/applications/application/summary/summary.html
+++ b/components/cloud-foundry/frontend/src/view/applications/application/summary/summary.html
@@ -129,12 +129,12 @@
       <dl class="dl-horizontal">
         <dt translate>app.app-info.app-tabs.summary.summary-panel.memory-label</dt>
         <dd id="app-memory-value" class="pull-right">
-          {{ applicationSummaryCtrl.appUtilsService.mbToHumanSize(appCtrl.model.application.summary.memory)}}
+          {{ applicationSummaryCtrl.appUtilsService.mbToHumanSize(appCtrl.model.application.summary.instances * appCtrl.model.application.summary.memory)}}
         </dd>
 
         <dt translate>app.app-info.app-tabs.summary.summary-panel.disk-quota-label</dt>
         <dd class="pull-right">
-          {{ applicationSummaryCtrl.appUtilsService.mbToHumanSize(appCtrl.model.application.summary.disk_quota)}}
+          {{ applicationSummaryCtrl.appUtilsService.mbToHumanSize(appCtrl.model.application.summary.instances * appCtrl.model.application.summary.disk_quota)}}
         </dd>
 
         <dt translate>app.app-info.app-tabs.summary.summary-panel.buildpack-label</dt>

--- a/components/cloud-foundry/frontend/src/view/applications/list/gallery-view/application-gallery-card/application-gallery-card.html
+++ b/components/cloud-foundry/frontend/src/view/applications/list/gallery-view/application-gallery-card/application-gallery-card.html
@@ -13,8 +13,8 @@
     <dd ng-if="applicationGalleryCardCtrl.canShowStats">{{ applicationGalleryCardCtrl.app.instanceCount }} / {{ applicationGalleryCardCtrl.app.entity.instances }}</dd>
     <dd ng-if="!applicationGalleryCardCtrl.canShowStats">0 / {{ applicationGalleryCardCtrl.app.entity.instances }}</dd>
     <dt translate>app-wall.disk-quota</dt>
-    <dd>{{ applicationGalleryCardCtrl.app.entity.disk_quota | mbToHumanSize }}</dd>
+    <dd>{{ (applicationGalleryCardCtrl.app.entity.instances * applicationGalleryCardCtrl.app.entity.disk_quota) | mbToHumanSize }}</dd>
     <dt translate>app-wall.memory</dt>
-    <dd>{{ applicationGalleryCardCtrl.app.entity.memory | mbToHumanSize }}</dd>
+    <dd>{{ (applicationGalleryCardCtrl.app.entity.instances * applicationGalleryCardCtrl.app.entity.memory) | mbToHumanSize }}</dd>
   </dl>
 </gallery-card>

--- a/components/cloud-foundry/frontend/src/view/applications/list/table-view/table-view.html
+++ b/components/cloud-foundry/frontend/src/view/applications/list/table-view/table-view.html
@@ -39,8 +39,8 @@
         </div>
       </td>
       <td class="text-uppercase">{{ app.instanceCount || 0 }}/{{ app.entity.instances }}</td>
-      <td>{{ app.entity.disk_quota | mbToHumanSize }}</td>
-      <td>{{ app.entity.memory | mbToHumanSize }}</td>
+      <td>{{ (app.entity.instances * app.entity.disk_quota) | mbToHumanSize }}</td>
+      <td>{{ (app.entity.instances * app.entity.memory) | mbToHumanSize }}</td>
       <td>{{ app.metadata.created_at | momentDateFormat }}</td>
     </tr>
     </tbody>


### PR DESCRIPTION
- Fixed in a basic way
- Ensure that all display and cumulative values * by instance value in app
- Values show in app wall (card + table), app summary, org tile, org summary, space tile, space summary