### PR TITLE
Create app-routes entity relationship, ensure app routes table uses new pagination section

### DIFF
--- a/src/frontend/app/core/entity-service-factory.service.ts
+++ b/src/frontend/app/core/entity-service-factory.service.ts
@@ -20,14 +20,15 @@ export class EntityServiceFactory {
     schema: schema.Entity,
     entityId: string,
     action: IRequestAction,
-    entitySection: TRequestTypeKeys = RequestSectionKeys.CF
+    validateRelations = false,
+    entitySection: TRequestTypeKeys = RequestSectionKeys.CF,
   ) {
     const entityMonitor = this.entityMonitorFactory.create<T>(
       entityId,
       entityKey,
       schema
     );
-    return new EntityService<T>(this.store, entityMonitor, action, entitySection);
+    return new EntityService<T>(this.store, entityMonitor, action, validateRelations, entitySection);
   }
 
 }

--- a/src/frontend/app/features/applications/application.service.ts
+++ b/src/frontend/app/features/applications/application.service.ts
@@ -16,7 +16,7 @@ import {
   GetAppStatsAction,
   GetAppSummaryAction,
 } from '../../store/actions/app-metadata.actions';
-import { GetApplication, UpdateApplication, UpdateExistingApplication } from '../../store/actions/application.actions';
+import { GetApplication, UpdateApplication, UpdateExistingApplication, AppRouteRelation } from '../../store/actions/application.actions';
 import { ApplicationSchema } from '../../store/actions/application.actions';
 import { AppState } from '../../store/app-state';
 import { ActionState } from '../../store/reducers/api-request-reducer/types';
@@ -75,7 +75,9 @@ export class ApplicationService {
       ApplicationSchema.key,
       ApplicationSchema,
       appGuid,
-      new GetApplication(appGuid, cfGuid));
+      new GetApplication(appGuid, cfGuid, [AppRouteRelation.key], true),
+      true
+    );
 
     this.appSummaryEntityService = this.entityServiceFactory.create(
       AppSummarySchema.key,

--- a/src/frontend/app/features/applications/routes/add-routes/add-routes.component.ts
+++ b/src/frontend/app/features/applications/routes/add-routes/add-routes.component.ts
@@ -5,27 +5,20 @@ import { MatSnackBar } from '@angular/material';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { Observable } from 'rxjs/Observable';
 import { filter, map, take, tap } from 'rxjs/operators';
 import { Subscription } from 'rxjs/Subscription';
 
-import { AssociateRouteWithAppApplication } from '../../../../store/actions/application.actions';
-import {
-  CreateRoute,
-  GetAppRoutes,
-} from '../../../../store/actions/route.actions';
+import { RouteSchema } from '../../../../store/actions/action-types';
+import { AssociateRouteWithAppApplication, GetAppRoutes } from '../../../../store/actions/application.actions';
+import { CreateRoute } from '../../../../store/actions/route.actions';
 import { RouterNav } from '../../../../store/actions/router.actions';
 import { AppState } from '../../../../store/app-state';
-import {
-  selectEntity,
-  selectNestedEntity,
-  selectRequestInfo
-} from '../../../../store/selectors/api.selectors';
+import { selectEntity, selectNestedEntity, selectRequestInfo } from '../../../../store/selectors/api.selectors';
 import { APIResource } from '../../../../store/types/api.types';
 import { Domain } from '../../../../store/types/domain.types';
 import { Route, RouteMode } from '../../../../store/types/route.types';
 import { ApplicationService } from '../../application.service';
-import { Observable } from 'rxjs/Observable';
-import { RouteSchema } from '../../../../store/actions/action-types';
 
 @Component({
   selector: 'app-add-routes',

--- a/src/frontend/app/shared/components/list/list-types/app-route/cf-app-routes-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-route/cf-app-routes-list-config.service.ts
@@ -181,7 +181,12 @@ export class CfAppRoutesListConfigService implements IListConfig<APIResource> {
     this.routesDataSource = new CfAppRoutesDataSource(
       this.store,
       this.appService,
-      new GetAppRoutes(appService.appGuid, appService.cfGuid, EntityRelation.createPaginationKey(applicationSchemaKey, appService.appGuid), appService.appGuid),
+      new GetAppRoutes(
+        appService.appGuid,
+        appService.cfGuid,
+        EntityRelation.createPaginationKey(applicationSchemaKey, appService.appGuid),
+        appService.appGuid
+      ),
       EntityRelation.createPaginationKey(applicationSchemaKey, appService.appGuid),
       false,
       this

--- a/src/frontend/app/shared/components/list/list-types/app-route/cf-app-routes-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-route/cf-app-routes-list-config.service.ts
@@ -4,10 +4,12 @@ import { take, tap } from 'rxjs/operators';
 
 import { ApplicationService } from '../../../../../features/applications/application.service';
 import { getRoute } from '../../../../../features/applications/routes/routes.helper';
+import { applicationSchemaKey, GetAppRoutes } from '../../../../../store/actions/application.actions';
 import { getPaginationKey } from '../../../../../store/actions/pagination.actions';
-import { DeleteRoute, GetAppRoutes, UnmapRoute } from '../../../../../store/actions/route.actions';
+import { DeleteRoute, UnmapRoute } from '../../../../../store/actions/route.actions';
 import { RouterNav } from '../../../../../store/actions/router.actions';
 import { AppState } from '../../../../../store/app-state';
+import { EntityRelation } from '../../../../../store/helpers/entity-relations.helpers';
 import { selectEntity } from '../../../../../store/selectors/api.selectors';
 import { APIResource, EntityInfo } from '../../../../../store/types/api.types';
 import { ConfirmationDialog, ConfirmationDialogService } from '../../../confirmation-dialog.service';
@@ -87,22 +89,22 @@ export class CfAppRoutesListConfigService implements IListConfig<APIResource> {
     action: () => {
       this.appService.application$
         .pipe(
-        take(1),
-        tap(app => {
-          this.store.dispatch(
-            new RouterNav({
-              path: [
-                'applications',
-                this.appService.cfGuid,
-                this.appService.appGuid,
-                'add-route'
-              ],
-              query: {
-                spaceGuid: app.app.entity.space_guid
-              }
-            })
-          );
-        })
+          take(1),
+          tap(app => {
+            this.store.dispatch(
+              new RouterNav({
+                path: [
+                  'applications',
+                  this.appService.cfGuid,
+                  this.appService.appGuid,
+                  'add-route'
+                ],
+                query: {
+                  spaceGuid: app.app.entity.space_guid
+                }
+              })
+            );
+          })
         )
         .subscribe();
     },
@@ -179,8 +181,8 @@ export class CfAppRoutesListConfigService implements IListConfig<APIResource> {
     this.routesDataSource = new CfAppRoutesDataSource(
       this.store,
       this.appService,
-      new GetAppRoutes(appService.appGuid, appService.cfGuid),
-      getPaginationKey('route', appService.cfGuid, appService.appGuid),
+      new GetAppRoutes(appService.appGuid, appService.cfGuid, EntityRelation.createPaginationKey(applicationSchemaKey, appService.appGuid), appService.appGuid),
+      EntityRelation.createPaginationKey(applicationSchemaKey, appService.appGuid),
       false,
       this
     );
@@ -190,18 +192,18 @@ export class CfAppRoutesListConfigService implements IListConfig<APIResource> {
     this.store
       .select(selectEntity<EntityInfo>('domain', item.entity.domain_guid))
       .pipe(
-      take(1),
-      tap(domain => {
-        const routeUrl = getRoute(item, false, false, domain);
-        const confirmation = new ConfirmationDialog(
-          'Delete Route',
-          `Are you sure you want to delete the route \'${routeUrl}\'?`,
-          'Delete'
-        );
-        this.confirmDialog.open(confirmation, () =>
-          this.dispatchDeleteAction(item)
-        );
-      })
+        take(1),
+        tap(domain => {
+          const routeUrl = getRoute(item, false, false, domain);
+          const confirmation = new ConfirmationDialog(
+            'Delete Route',
+            `Are you sure you want to delete the route \'${routeUrl}\'?`,
+            'Delete'
+          );
+          this.confirmDialog.open(confirmation, () =>
+            this.dispatchDeleteAction(item)
+          );
+        })
       )
       .subscribe();
   }
@@ -210,18 +212,18 @@ export class CfAppRoutesListConfigService implements IListConfig<APIResource> {
     this.store
       .select(selectEntity<EntityInfo>('domain', item.entity.domain_guid))
       .pipe(
-      take(1),
-      tap(domain => {
-        const routeUrl = getRoute(item, false, false, domain);
-        const confirmation = new ConfirmationDialog(
-          'Unmap Route from Application',
-          `Are you sure you want to unmap the route \'${routeUrl}\'?`,
-          'Unmap'
-        );
-        this.confirmDialog.open(confirmation, () =>
-          this.dispatchUnmapAction(item)
-        );
-      })
+        take(1),
+        tap(domain => {
+          const routeUrl = getRoute(item, false, false, domain);
+          const confirmation = new ConfirmationDialog(
+            'Unmap Route from Application',
+            `Are you sure you want to unmap the route \'${routeUrl}\'?`,
+            'Unmap'
+          );
+          this.confirmDialog.open(confirmation, () =>
+            this.dispatchUnmapAction(item)
+          );
+        })
       )
       .subscribe();
   }

--- a/src/frontend/app/store/actions/action-types.ts
+++ b/src/frontend/app/store/actions/action-types.ts
@@ -2,22 +2,37 @@ import { schema } from 'normalizr';
 
 import { getAPIResourceGuid } from '../selectors/api.selectors';
 import { RoutesInSpaceSchema } from './space.actions';
+import { DomainSchema } from './domains.actions';
+import { ApplicationSchema } from './application.actions';
 
-export const organisationSchemaKey = 'organization';
-export const OrganisationSchema = new schema.Entity(organisationSchemaKey, {}, {
+export const QuotaDefinitionSchema = new schema.Entity('quota_definition', {}, {
   idAttribute: getAPIResourceGuid
 });
+
+export const organisationSchemaKey = 'organization';
+export const OrganisationSchema = new schema.Entity(organisationSchemaKey, {
+  entity: {
+    quota_definition: QuotaDefinitionSchema
+  }
+}, {
+    idAttribute: getAPIResourceGuid
+  });
 
 export const spaceSchemaKey = 'space';
 
 export const SpaceWithOrganisationSchema = new schema.Entity(spaceSchemaKey, {
   entity: {
+    apps: ApplicationSchema,
     organization: OrganisationSchema
   }
 }, {
     idAttribute: getAPIResourceGuid
   });
 
-export const RouteSchema = new schema.Entity('route', {}, {
-  idAttribute: getAPIResourceGuid
-});
+export const RouteSchema = new schema.Entity('route', {
+  entity: {
+    domain: DomainSchema
+  }
+}, {
+    idAttribute: getAPIResourceGuid
+  });

--- a/src/frontend/app/store/actions/action-types.ts
+++ b/src/frontend/app/store/actions/action-types.ts
@@ -1,7 +1,7 @@
 import { schema } from 'normalizr';
 
 import { getAPIResourceGuid } from '../selectors/api.selectors';
-import { RoutesSchema } from './space.actions';
+import { RoutesInSpaceSchema } from './space.actions';
 
 export const organisationSchemaKey = 'organization';
 export const OrganisationSchema = new schema.Entity(organisationSchemaKey, {}, {

--- a/src/frontend/app/store/actions/application.actions.ts
+++ b/src/frontend/app/store/actions/application.actions.ts
@@ -130,6 +130,7 @@ export class GetApplication extends CFStartAction implements ICFAction, EntityIn
     this.options.method = 'get';
     this.options.params = new URLSearchParams();
     this.options.params.set('inline-relations-depth', '2');
+    this.options.params.set('include-relations', 'space,organization,routes,domain');
   }
   actions = [GET, GET_SUCCESS, GET_FAILED];
   entity = [ApplicationSchema];

--- a/src/frontend/app/store/actions/organisation.actions.ts
+++ b/src/frontend/app/store/actions/organisation.actions.ts
@@ -11,7 +11,7 @@ import {
 import { getAPIResourceGuid } from '../selectors/api.selectors';
 import { PaginatedAction } from '../types/pagination.types';
 import { CFStartAction, ICFAction } from '../types/request.types';
-import { OrganisationSchema, organisationSchemaKey, spaceSchemaKey } from './action-types';
+import { OrganisationSchema, organisationSchemaKey, spaceSchemaKey, QuotaDefinitionSchema } from './action-types';
 import { getActions } from './action.helper';
 import { SpaceSchema } from './space.actions';
 
@@ -101,6 +101,7 @@ export class GetAllOrganisationSpaces extends CFStartAction implements Paginated
 
 export const OrganisationWithSpaceSchema = new schema.Entity(organisationSchemaKey, {
   entity: {
+    quota_definition: QuotaDefinitionSchema,
     spaces: SpacesSchema
   }
 }, {

--- a/src/frontend/app/store/actions/organisation.actions.ts
+++ b/src/frontend/app/store/actions/organisation.actions.ts
@@ -9,7 +9,6 @@ import {
   EntityRelation,
 } from '../helpers/entity-relations.helpers';
 import { getAPIResourceGuid } from '../selectors/api.selectors';
-import { APIResource } from '../types/api.types';
 import { PaginatedAction } from '../types/pagination.types';
 import { CFStartAction, ICFAction } from '../types/request.types';
 import { OrganisationSchema, organisationSchemaKey, spaceSchemaKey } from './action-types';
@@ -49,7 +48,7 @@ export const OrgSpaceRelation: EntityRelation = {
   key: 'org-space-relation',
   parentEntityKey: organisationSchemaKey,
   childEntity: SpaceSchema,
-  createParentWithChildren: (state, parentGuid, response) => {
+  createParentWithChild: (state, parentGuid, response) => {
     const parentEntity = pathGet(`${organisationSchemaKey}.${parentGuid}`, state);
     const newParentEntity = {
       ...parentEntity,

--- a/src/frontend/app/store/actions/route.actions.ts
+++ b/src/frontend/app/store/actions/route.actions.ts
@@ -6,6 +6,7 @@ import { PaginatedAction } from '../types/pagination.types';
 import { CFStartAction, ICFAction } from '../types/request.types';
 import { RouteSchema } from './action-types';
 import { getPaginationKey } from './pagination.actions';
+import { EntityInlineParentAction, EntityInlineChildAction } from '../helpers/entity-relations.helpers';
 
 export const CREATE_ROUTE = '[Route] Create start';
 export const CREATE_ROUTE_SUCCESS = '[Route] Create success';
@@ -13,9 +14,6 @@ export const CREATE_ROUTE_ERROR = '[Route] Create error';
 
 export const MAP_ROUTE_SELECTED = '[Map Route] Selected route';
 export const RouteEvents = {
-  GET_APP_ALL: '[Application Routes] Get all',
-  GET_APP_ALL_SUCCESS: '[Application Routes] Get all success',
-  GET_APP_ALL_FAILED: '[Application Routes] Get all failed',
   GET_SPACE_ALL: '[Space Routes] Get all',
   GET_SPACE_ALL_SUCCESS: '[Space Routes] Get all success',
   GET_SPACE_ALL_FAILED: '[Space Routes] Get all failed',
@@ -26,7 +24,6 @@ export const RouteEvents = {
   UNMAP_ROUTE_SUCCESS: '[Application Routes] Unmap route success',
   UNMAP_ROUTE_FAILED: '[Application Routes] Unmap route failed'
 };
-
 
 export interface NewRoute {
   domain_guid: string;
@@ -123,37 +120,6 @@ export class CheckRouteExists extends CFStartAction implements ICFAction {
   options: RequestOptions;
   endpointGuid: string;
 }
-
-export class GetAppRoutes extends CFStartAction implements PaginatedAction {
-  constructor(public guid: string, public cfGuid: string) {
-    super();
-    this.options = new RequestOptions();
-    this.options.url = `apps/${guid}/routes`;
-    this.options.method = 'get';
-    this.options.params = new URLSearchParams();
-    this.endpointGuid = cfGuid;
-    this.paginationKey = getPaginationKey(this.entityKey, cfGuid, guid);
-  }
-  actions = [
-    RouteEvents.GET_APP_ALL,
-    RouteEvents.GET_APP_ALL_SUCCESS,
-    RouteEvents.GET_APP_ALL_FAILED
-  ];
-  initialParams = {
-    'results-per-page': 100,
-    'inline-relations-depth': '1',
-    page: 1,
-    'order-direction': 'desc',
-    'order-direction-field': 'route',
-  };
-  paginationKey: string;
-  entity = RouteSchema;
-  entityKey = RouteSchema.key;
-  options: RequestOptions;
-  endpointGuid: string;
-  flattenPagination = true;
-}
-
 
 export class MapRouteSelected implements Action {
   constructor(routeEntity: EntityInfo) { }

--- a/src/frontend/app/store/actions/space.actions.ts
+++ b/src/frontend/app/store/actions/space.actions.ts
@@ -9,7 +9,6 @@ import {
   EntityRelation,
 } from '../helpers/entity-relations.helpers';
 import { getAPIResourceGuid } from '../selectors/api.selectors';
-import { APIResource } from '../types/api.types';
 import { PaginatedAction } from '../types/pagination.types';
 import { CFStartAction, ICFAction } from '../types/request.types';
 import { RouteSchema, spaceSchemaKey, SpaceWithOrganisationSchema } from './action-types';
@@ -27,7 +26,7 @@ export const SpaceRouteRelation: EntityRelation = {
   key: 'space-route-relation',
   parentEntityKey: spaceSchemaKey,
   childEntity: RouteSchema,
-  createParentWithChildren: (state, parentGuid, response) => {
+  createParentWithChild: (state, parentGuid, response) => {
     const parentEntity = pathGet(`${spaceSchemaKey}.${parentGuid}`, state);
     const newParentEntity = {
       ...parentEntity,
@@ -49,11 +48,11 @@ export const SpaceRouteRelation: EntityRelation = {
   },
 };
 
-export const RoutesSchema = new EntityInlineChild([SpaceRouteRelation], RouteSchema);
+export const RoutesInSpaceSchema = new EntityInlineChild([SpaceRouteRelation], RouteSchema);
 
 export const SpaceSchema = new schema.Entity(spaceSchemaKey, {
   entity: {
-    routes: RoutesSchema
+    routes: RoutesInSpaceSchema
   }
 }, {
     idAttribute: getAPIResourceGuid
@@ -94,6 +93,7 @@ export class GetAllSpaces extends CFStartAction implements PaginatedAction {
   };
 }
 
+// TODO: RC REmove parent?
 export class GetSpaceRoutes extends CFStartAction implements PaginatedAction, EntityInlineParentAction, EntityInlineChildAction {
   constructor(
     public spaceGuid: string,
@@ -122,7 +122,7 @@ export class GetSpaceRoutes extends CFStartAction implements PaginatedAction, En
     'order-direction-field': 'attachedApps',
   };
   parentGuid: string;
-  entity = RoutesSchema;
+  entity = RoutesInSpaceSchema;
   entityKey = RouteSchema.key;
   options: RequestOptions;
   endpointGuid: string;

--- a/src/frontend/app/store/actions/space.actions.ts
+++ b/src/frontend/app/store/actions/space.actions.ts
@@ -13,6 +13,7 @@ import { PaginatedAction } from '../types/pagination.types';
 import { CFStartAction, ICFAction } from '../types/request.types';
 import { RouteSchema, spaceSchemaKey, SpaceWithOrganisationSchema } from './action-types';
 import { RouteEvents } from './route.actions';
+import { ApplicationSchema } from './application.actions';
 
 export const GET_SPACES = '[Space] Get all';
 export const GET_SPACES_SUCCESS = '[Space] Get all success';
@@ -52,6 +53,7 @@ export const RoutesInSpaceSchema = new EntityInlineChild([SpaceRouteRelation], R
 
 export const SpaceSchema = new schema.Entity(spaceSchemaKey, {
   entity: {
+    apps: ApplicationSchema,
     routes: RoutesInSpaceSchema
   }
 }, {
@@ -93,7 +95,6 @@ export class GetAllSpaces extends CFStartAction implements PaginatedAction {
   };
 }
 
-// TODO: RC REmove parent?
 export class GetSpaceRoutes extends CFStartAction implements PaginatedAction, EntityInlineParentAction, EntityInlineChildAction {
   constructor(
     public spaceGuid: string,

--- a/src/frontend/app/store/reducers/api-request-data-reducer/request-data-reducer.factory.ts
+++ b/src/frontend/app/store/reducers/api-request-data-reducer/request-data-reducer.factory.ts
@@ -93,7 +93,7 @@ function populateParentEntity(state, successAction, params: {
   // For each parent-child relationship
   parentRelations.forEach(relation => {
     // Create a new entity with the inline result. For instance an new organisation containing a list of spaces
-    const newParentEntity = relation.createParentWithChildren(state, parentEntityGuid, successAction.response);
+    const newParentEntity = relation.createParentWithChild(state, parentEntityGuid, successAction.response);
     if (!newParentEntity) {
       return;
     }

--- a/src/frontend/app/store/reducers/api-request-reducers.generator.ts
+++ b/src/frontend/app/store/reducers/api-request-reducers.generator.ts
@@ -20,6 +20,7 @@ import {
 } from '../types/deploy-application.types';
 import { CF_INFO_ENTITY_KEY } from '../actions/cloud-foundry.actions';
 import { GITHUB_REPO_ENTITY_KEY } from '../types/github.types';
+import { organisationSchemaKey, QuotaDefinitionSchema } from '../actions/action-types';
 /**
  * This module uses the request data reducer and request reducer factories to create
  * the reducers to be used when making http requests
@@ -32,7 +33,7 @@ const requestActions = [
 ] as IRequestArray;
 
 function chainReducers(baseReducer, extraReducers) {
-  return function(state, action) {
+  return function (state, action) {
     let newState = baseReducer(state, action);
     let nextState;
     Object.keys(extraReducers).forEach(key => {
@@ -56,7 +57,7 @@ const entities = [
   'application',
   'stack',
   'space',
-  'organization',
+  organisationSchemaKey,
   'route',
   'event',
   endpointStoreNames.type,
@@ -72,7 +73,8 @@ const entities = [
   GITHUB_COMMIT_ENTITY_KEY,
   AppEnvVarSchema.key,
   AppStatSchema.key,
-  AppSummarySchema.key
+  AppSummarySchema.key,
+  QuotaDefinitionSchema.key
 ];
 const _requestReducer = requestReducerFactory(entities, requestActions);
 

--- a/src/frontend/app/test-framework/entity-service.helper.ts
+++ b/src/frontend/app/test-framework/entity-service.helper.ts
@@ -21,6 +21,7 @@ export function generateTestEntityServiceProvider(
       schema,
       guid,
       action,
+      false,
       RequestSectionKeys.CF
     );
   };


### PR DESCRIPTION
Note - When routes param is missing (50+) two calls are made. The inline depth stuff hasn't finished
working before the list tries to access the entities .. so fires off another. This will be solved in #1641
