### PR TITLE
Change the navbar-brand to match the same colour as the rest of the nav…

### DIFF
--- a/components/app-core/frontend/src/view/navbar/navbar.scss
+++ b/components/app-core/frontend/src/view/navbar/navbar.scss
@@ -324,7 +324,7 @@ nav.secondary-nav {
   }
 
   .navbar-brand {
-    color: $white;
+    color: $navbar-text-color;
     font-size: $font-size-large2;
     font-weight: 500;
     padding: 0 $console-unit-space;


### PR DESCRIPTION
## Description
The scss already provided a variable to override the navbar menu text that could be specified in os-branding. The title was exempt from this change, which meant it may not match the menu or work well with the background.

## Motivation and Context
When the background navbar colour is changed, the nav-brand remained white. This adjusts the color based on the navbar choice.

## How Has This Been Tested?
Built the Docker container van validated that the text could be changed from white to black.

## Types of changes
Substitutes the $white varibable with the text variable, that is by default set to $white.

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message