### PR TITLE
Breadcrumbs

### DIFF
--- a/src/frontend/app/core/cf-api.types.ts
+++ b/src/frontend/app/core/cf-api.types.ts
@@ -11,7 +11,7 @@ export interface IRoute {
   domain_url: string;
   domain?: APIResource<IDomain>;
   space_url: string;
-  space: APIResource<ISpace>;
+  space?: APIResource<ISpace>;
   apps_url: string;
   apps?: APIResource<IApp>[];
   route_mappings_url: string;
@@ -28,24 +28,24 @@ export interface ISpace {
   organization_url: string;
   organization?: APIResource<IOrganization>;
   developers_url: string;
-  developers?: IDeveloper[];
+  developers?: APIResource<IDeveloper>[];
   managers_url: string;
-  managers?: IDeveloper[];
+  managers?: APIResource<IDeveloper>[];
   auditors_url: string;
   auditors?: any[];
   apps_url: string;
   apps?: APIResource<IApp>[];
   routes_url: string;
   domains_url: string;
-  domains?: IDomain[];
+  domains?: APIResource<IDomain>[];
   service_instances_url: string;
   service_instances?: any[];
   app_events_url: string;
   events_url?: string;
   security_groups_url: string;
-  security_groups?: ISecurityGroup[];
+  security_groups?: APIResource<ISecurityGroup>[];
   staging_security_groups_url: string;
-  staging_security_groups?: ISecurityGroup[];
+  staging_security_groups?: APIResource<ISecurityGroup>[];
   space_quota_definition?: APIResource<IQuotaDefinition>;
   routes?: APIResource<IRoute>[];
   cfGuid?: string;
@@ -157,8 +157,8 @@ export interface IOrganization {
   auditors_url?: string;
   app_events_url?: string;
   space_quota_definitions_url?: string;
-  guid: string;
-  cfGuid: string;
+  guid?: string;
+  cfGuid?: string;
   spaces?: APIResource<ISpace>[];
   private_domains?: APIResource<IPrivateDomain>[];
   quota_definition?: APIResource<IQuotaDefinition>;
@@ -208,13 +208,13 @@ export interface IFeatureFlag {
   error_message?: string;
 }
 export interface IServiceInstance {
-  guid: string;
-  cfGuid: string;
+  guid?: string;
+  cfGuid?: string;
 }
 
 export interface IPrivateDomain {
-  guid: string;
-  cfGuid: string;
+  guid?: string;
+  cfGuid?: string;
 }
 
 export interface IQuotaDefinition {

--- a/src/frontend/app/core/cf-api.types.ts
+++ b/src/frontend/app/core/cf-api.types.ts
@@ -1,3 +1,4 @@
+import { IRoute } from './cf-api.types';
 import { APIResource } from '../store/types/api.types';
 
 export interface IRoute {
@@ -8,14 +9,14 @@ export interface IRoute {
   service_instance_guid?: any;
   port?: any;
   domain_url: string;
-  domain: IDomain;
+  domain?: APIResource<IDomain>;
   space_url: string;
   space: APIResource<ISpace>;
   apps_url: string;
-  apps: APIResource<IApp>[];
+  apps?: APIResource<IApp>[];
   route_mappings_url: string;
-  guid: string;
-  cfGuid: string;
+  guid?: string;
+  cfGuid?: string;
 }
 
 export interface ISpace {
@@ -25,30 +26,30 @@ export interface ISpace {
   isolation_segment_guid?: any;
   allow_ssh: boolean;
   organization_url: string;
-  organization: IOrganization;
+  organization?: APIResource<IOrganization>;
   developers_url: string;
-  developers: IDeveloper[];
+  developers?: IDeveloper[];
   managers_url: string;
-  managers: IDeveloper[];
+  managers?: IDeveloper[];
   auditors_url: string;
-  auditors: any[];
+  auditors?: any[];
   apps_url: string;
-  apps: APIResource<IApp>[];
+  apps?: APIResource<IApp>[];
   routes_url: string;
   domains_url: string;
-  domains: IDomain[];
+  domains?: IDomain[];
   service_instances_url: string;
-  service_instances: any[];
+  service_instances?: any[];
   app_events_url: string;
-  events_url: string;
+  events_url?: string;
   security_groups_url: string;
-  security_groups: ISecurityGroup[];
+  security_groups?: ISecurityGroup[];
   staging_security_groups_url: string;
-  staging_security_groups: ISecurityGroup[];
+  staging_security_groups?: ISecurityGroup[];
   space_quota_definition?: APIResource<IQuotaDefinition>;
   routes?: APIResource<IRoute>[];
-  guid: string;
-  cfGuid: string;
+  cfGuid?: string;
+  guid?: string;
 }
 
 export interface ISecurityGroup {
@@ -81,6 +82,7 @@ export interface IApp {
   detected_buildpack?: string;
   detected_buildpack_guid?: string;
   environment_json?: IEnvironmentjson;
+  enable_ssh?: boolean;
   memory?: number;
   instances?: number;
   disk_quota?: number;
@@ -103,12 +105,18 @@ export interface IApp {
   detected_start_command?: string;
   allow_ssh?: boolean;
   ports?: number[];
+  service_bindings?: APIResource[];
+  routes?: APIResource<IRoute>[];
+  stack?: string | APIResource<IStack>;
+  space?: string | APIResource<ISpace>;
   space_url?: string;
   stack_url?: string;
   routes_url?: string;
   events_url?: string;
   service_bindings_url?: string;
   route_mappings_url?: string;
+  cfGuid?: string;
+  guid?: string;
 }
 
 export interface IDockercredentials {

--- a/src/frontend/app/features/applications/application.service.ts
+++ b/src/frontend/app/features/applications/application.service.ts
@@ -164,7 +164,7 @@ export class ApplicationService {
         switchMap(orgGuid => {
           return this.store.select(selectEntity(organisationSchemaKey, orgGuid));
         })
-      ))
+      ));
 
     this.isDeletingApp$ = this.appEntityService.isDeletingEntity$.shareReplay(1);
 

--- a/src/frontend/app/features/applications/application.service.ts
+++ b/src/frontend/app/features/applications/application.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
-import { map, mergeMap } from 'rxjs/operators';
+import { map, mergeMap, switchMap } from 'rxjs/operators';
 
 import { EntityService } from '../../core/entity-service';
 import { EntityServiceFactory } from '../../core/entity-service-factory.service';
@@ -46,6 +46,7 @@ import {
 import { getRoute, isTCPRoute } from './routes/routes.helper';
 import { PaginationMonitor } from '../../shared/monitors/pagination-monitor';
 import { spaceSchemaKey, organisationSchemaKey } from '../../store/actions/action-types';
+import { IApp, IOrganization, ISpace } from '../../core/cf-api.types';
 
 export interface ApplicationData {
   fetching: boolean;
@@ -71,7 +72,7 @@ export class ApplicationService {
     private paginationMonitorFactory: PaginationMonitorFactory
   ) {
 
-    this.appEntityService = this.entityServiceFactory.create(
+    this.appEntityService = this.entityServiceFactory.create<APIResource<IApp>>(
       ApplicationSchema.key,
       ApplicationSchema,
       appGuid,
@@ -98,14 +99,14 @@ export class ApplicationService {
   isUpdatingEnvVars$: Observable<boolean>;
   isFetchingStats$: Observable<boolean>;
 
-  app$: Observable<EntityInfo>;
-  waitForAppEntity$: Observable<EntityInfo>;
+  app$: Observable<EntityInfo<APIResource<IApp>>>;
+  waitForAppEntity$: Observable<EntityInfo<APIResource<IApp>>>;
   appSummary$: Observable<EntityInfo<AppSummary>>;
   appStats$: Observable<APIResource<AppStat>[]>;
   private appStatsFetching$: Observable<PaginationEntityState>; // Use isFetchingStats$ which is properly gated
   appEnvVars: PaginationObservables<APIResource>;
-  appOrg$: Observable<APIResource<any>>;
-  appSpace$: Observable<APIResource<any>>;
+  appOrg$: Observable<APIResource<IOrganization>>;
+  appSpace$: Observable<APIResource<ISpace>>;
 
   application$: Observable<ApplicationData>;
   applicationStratProject$: Observable<EnvVarStratosProject>;
@@ -126,7 +127,7 @@ export class ApplicationService {
   static getApplicationState(
     store: Store<AppState>,
     appStateService: ApplicationStateService,
-    app,
+    app: APIResource<IApp>,
     appGuid: string,
     cfGuid: string): Observable<ApplicationStateData> {
     const dummyAction = new GetAppStatsAction(appGuid, cfGuid);
@@ -150,22 +151,20 @@ export class ApplicationService {
   private constructCoreObservables() {
     // First set up all the base observables
     this.app$ = this.appEntityService.waitForEntity$;
-
-    // App org and space
-    this.app$
-      .filter(entityInfo => entityInfo.entity && entityInfo.entity.entity && entityInfo.entity.entity.cfGuid)
-      .map(entityInfo => entityInfo.entity.entity)
-      .do(app => {
-        this.appSpace$ = this.store.select(selectEntity(spaceSchemaKey, app.space_guid));
-        this.appOrg$ = this.appSpace$.pipe(
-          map(space => space.entity.organization_guid),
-          mergeMap(orgGuid => {
-            return this.store.select(selectEntity(organisationSchemaKey, orgGuid));
-          })
-        );
-      })
-      .take(1)
-      .subscribe();
+    const moreWaiting$ = this.app$
+      .filter(entityInfo => !!(entityInfo.entity && entityInfo.entity.entity && entityInfo.entity.entity.cfGuid))
+      .map(entityInfo => entityInfo.entity.entity);
+    this.appSpace$ = moreWaiting$
+      .first()
+      .switchMap(app => this.store.select(selectEntity(spaceSchemaKey, app.space_guid)));
+    this.appOrg$ = moreWaiting$
+      .first()
+      .switchMap(app => this.appSpace$.pipe(
+        map(space => space.entity.organization_guid),
+        switchMap(orgGuid => {
+          return this.store.select(selectEntity(organisationSchemaKey, orgGuid));
+        })
+      ))
 
     this.isDeletingApp$ = this.appEntityService.isDeletingEntity$.shareReplay(1);
 

--- a/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.html
+++ b/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.html
@@ -1,4 +1,4 @@
-<app-page-header>
+<app-page-header [breadcrumbs]="breadcrumbs | async">
   <h1>{{ (applicationService.application$ | async)?.app.entity.name }} </h1>
   <div class="page-header-right">
     <a mat-icon-button *ngIf="(applicationService.application$ | async)?.appUrl != null

--- a/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.html
+++ b/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.html
@@ -1,4 +1,4 @@
-<app-page-header [breadcrumbs]="breadcrumbs | async">
+<app-page-header [breadcrumbs]="breadcrumbs$ | async">
   <h1>{{ (applicationService.application$ | async)?.app.entity.name }} </h1>
   <div class="page-header-right">
     <a mat-icon-button *ngIf="(applicationService.application$ | async)?.appUrl != null

--- a/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.ts
+++ b/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.ts
@@ -56,7 +56,6 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
     private confirmDialog: ConfirmationDialogService
   ) {
     const endpoints$ = store.select(endpointEntitiesSelector);
-    debugger;
     this.breadcrumbs$ = applicationService.waitForAppEntity$.pipe(
       withLatestFrom(
         endpoints$,
@@ -64,7 +63,6 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
         applicationService.appSpace$
       ),
       map(([app, endpoints, org, space]) => {
-        debugger;
         return this.getBreadcrumbs(
           app.entity.entity,
           endpoints[app.entity.entity.cfGuid],
@@ -103,7 +101,6 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
     org: APIResource<IOrganization>,
     space: APIResource<ISpace>
   ) {
-    debugger;
     return [
       {
         breadcrumbs: [{

--- a/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.ts
+++ b/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.ts
@@ -125,7 +125,7 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
           {
             value: space.entity.name,
             routerLink: `${baseOrgUrl}/spaces/${space.metadata.guid}`
-          },
+          }
         ]
       }
     ];

--- a/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.ts
+++ b/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
-import { take } from 'rxjs/operators';
+import { take, map, first } from 'rxjs/operators';
 import { Subscription } from 'rxjs/Rx';
 
 import { EntityService } from '../../../../core/entity-service';
@@ -14,6 +14,7 @@ import { AppState } from '../../../../store/app-state';
 import { ApplicationService } from '../../application.service';
 import { APIResource } from '../../../../store/types/api.types';
 import { ConfirmationDialogConfig } from '../../../../shared/components/confirmation-dialog.config';
+import { IHeaderBreadcrumb } from '../../../../shared/components/page-header/page-header.types';
 
 // Confirmation dialogs
 const appStopConfirmation = new ConfirmationDialogConfig(
@@ -60,6 +61,10 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
   appSub$: Subscription;
   entityServiceAppRefresh$: Subscription;
   autoRefreshString = 'auto-refresh';
+  public breadcrumbs: Observable<IHeaderBreadcrumb[]> = this.applicationService.app$.pipe(
+    map(app => this.getBreadcrumbs(app)),
+    first()
+  );
 
   autoRefreshing$ = this.entityService.updatingSection$.map(
     update => update[this.autoRefreshString] || { busy: false }
@@ -73,6 +78,30 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
     { link: 'variables', label: 'Variables' },
     { link: 'events', label: 'Events' }
   ];
+
+  private getBreadcrumbs(application) {
+    return [
+      {
+        breadcrumbs: [{
+          value: 'Applications',
+          routerLink: '/applications'
+        }]
+      },
+      {
+        key: 'space',
+        breadcrumbs: [
+          {
+            value: application.entity,
+            routerLink: '/applications'
+          },
+          {
+            value: 'Apps',
+            routerLink: '/applications'
+          }
+        ]
+      }
+    ];
+  }
 
   stopApplication() {
     this.confirmDialog.open(appStopConfirmation, () => {

--- a/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.ts
+++ b/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.ts
@@ -101,6 +101,8 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
     org: APIResource<IOrganization>,
     space: APIResource<ISpace>
   ) {
+    const baseCFUrl = `/cloud-foundry/${application.cfGuid}`;
+    const baseOrgUrl = `${baseCFUrl}/organizations/${org.metadata.guid}`;
     return [
       {
         breadcrumbs: [{
@@ -113,16 +115,16 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
         breadcrumbs: [
           {
             value: endpoint.name,
-            routerLink: `/cloud-foundry/${application.cfGuid}`
-          },
-          {
-            value: space.entity.name,
-            routerLink: '/applications'
+            routerLink: baseCFUrl
           },
           {
             value: org.entity.name,
-            routerLink: '/applications'
-          }
+            routerLink: baseOrgUrl
+          },
+          {
+            value: space.entity.name,
+            routerLink: `${baseOrgUrl}/spaces/${space.metadata.guid}`
+          },
         ]
       }
     ];

--- a/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.ts
+++ b/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.ts
@@ -68,8 +68,9 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
           endpoints[app.entity.entity.cfGuid],
           org,
           space
-        )
-      })
+        );
+      }),
+      first()
     );
   }
   public breadcrumbs$: Observable<IHeaderBreadcrumb[]>;

--- a/src/frontend/app/features/cloud-foundry/cf.helpers.ts
+++ b/src/frontend/app/features/cloud-foundry/cf.helpers.ts
@@ -119,7 +119,6 @@ function hasRole(user: CfUser, guid: string, roleType: string) {
 export const getRowUniqueId = (entity: APIResource) => entity.metadata ? entity.metadata.guid : null;
 
 export function getIdFromRoute(activatedRoute: ActivatedRoute, id: string) {
-
   if (activatedRoute.snapshot.params[id]) {
     return activatedRoute.snapshot.params[id];
   } else if (activatedRoute.parent) {

--- a/src/frontend/app/features/cloud-foundry/cloud-foundry.module.ts
+++ b/src/frontend/app/features/cloud-foundry/cloud-foundry.module.ts
@@ -65,6 +65,10 @@ import { CreateSpaceStepComponent } from './add-space/create-space-step/create-s
 import { CreateOrganizationStepComponent } from './add-organisation/create-organization-step/create-organization-step.component';
 import { EditOrganizationComponent } from './edit-organization/edit-organization.component';
 import { EditOrganizationStepComponent } from './edit-organization/edit-organization-step/edit-organization-step.component';
+import { CloudFoundryOrganisationService } from './services/cloud-foundry-organisation.service';
+import { ActiveRouteCfOrgSpace } from './cf-page.types';
+import { getActiveRouteCfOrgSpaceProvider } from './cf.helpers';
+import { CloudFoundryEndpointService } from './services/cloud-foundry-endpoint.service';
 
 @NgModule({
   imports: [CoreModule, SharedModule, CloudFoundryRoutingModule, RouterModule],
@@ -104,6 +108,12 @@ import { EditOrganizationStepComponent } from './edit-organization/edit-organiza
     CloudFoundryService,
     CFEndpointsListConfigService,
     EndpointsListConfigService,
+    {
+      provide: ActiveRouteCfOrgSpace,
+      useValue: {}
+    },
+    CloudFoundryOrganisationService,
+    CloudFoundryEndpointService
   ]
 })
 export class CloudFoundryModule { }

--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-base/cloud-foundry-organization-base.component.html
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-base/cloud-foundry-organization-base.component.html
@@ -1,17 +1,19 @@
-<app-page-header>
-  <h1> {{ (cfEndpointService.endpoint$ | async)?.entity.name }}</h1>
+<app-page-header [breadcrumbs]="breadcrumbs$ | async">
+  <h1> {{ name$ | async }}</h1>
   <div class="page-header-right">
-    <button mat-icon-button name="edit-org" *ngIf="(this.cfEndpointService.connected$ | async)" routerLink="/cloud-foundry/{{this.cfEndpointService.cfGuid}}/organizations/{{this.cfOrgService.orgGuid}}/edit-org">
+    <button mat-icon-button name="edit-org" *ngIf="(cfEndpointService.connected$ | async)" routerLink="/cloud-foundry/{{cfEndpointService.cfGuid}}/organizations/{{cfOrgService.orgGuid}}/edit-org">
         <mat-icon>mode_edit</mat-icon>
       </button>
-    <button mat-icon-button name="add-space" *ngIf="(this.cfEndpointService.connected$ | async)" routerLink="/cloud-foundry/{{this.cfEndpointService.cfGuid}}/organizations/{{this.cfOrgService.orgGuid}}/add-space">
+    <button mat-icon-button name="add-space" *ngIf="(cfEndpointService.connected$ | async)" routerLink="/cloud-foundry/{{cfEndpointService.cfGuid}}/organizations/{{cfOrgService.orgGuid}}/add-space">
         <mat-icon>add_box</mat-icon>
       </button>
-    <button mat-icon-button name="user-management" *ngIf="(this.cfEndpointService.connected$ | async)" routerLink="/cloud-foundry/{{this.cfEndpointService.cfGuid}}/manage-users">
+    <button mat-icon-button name="user-management" *ngIf="(cfEndpointService.connected$ | async)" routerLink="/cloud-foundry/{{cfEndpointService.cfGuid}}/manage-users">
         <mat-icon>people</mat-icon>
       </button>
   </div>
 </app-page-header>
 <app-page-subheader [tabs]="tabLinks">
 </app-page-subheader>
-<router-outlet></router-outlet>
+<app-loading-page [isLoading]="isFetching$" [text]="'Retrieving Organization'">
+  <router-outlet></router-outlet>
+</app-loading-page>

--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-base/cloud-foundry-organization-base.component.ts
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-base/cloud-foundry-organization-base.component.ts
@@ -45,10 +45,11 @@ export class CloudFoundryOrganizationBaseComponent implements OnInit {
   constructor(public cfEndpointService: CloudFoundryEndpointService, public cfOrgService: CloudFoundryOrganisationService) {
     this.isFetching$ = cfOrgService.org$.pipe(
       map(org => org.entityRequestInfo.fetching)
-    )
+    );
     this.name$ = cfOrgService.org$.pipe(
-      map(org => org.entity.entity.name)
-    )
+      map(org => org.entity.entity.name),
+      first()
+    );
     this.breadcrumbs$ = cfEndpointService.endpoint$.pipe(
       map(endpoint => ([
         {
@@ -61,7 +62,7 @@ export class CloudFoundryOrganizationBaseComponent implements OnInit {
         }
       ])),
       first()
-    )
+    );
   }
 
   ngOnInit() {

--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.html
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.html
@@ -1,5 +1,5 @@
-<app-page-header>
-  <h1> {{ (cfEndpointService.endpoint$ | async)?.entity.name }}</h1>
+<app-page-header [breadcrumbs]="breadcrumbs$ | async">
+  <h1> {{ name$ | async }}</h1>
   <div class="page-header-right">
     <button mat-icon-button name="rename" *ngIf="(cfEndpointService.connected$ | async)" routerLink="/cloud-foundry/{{cfEndpointService.cfGuid}}/organizations/{{cfSpaceService.orgGuid}}/spaces/{{cfSpaceService.spaceGuid}}/edit-space">
         <mat-icon>edit</mat-icon>
@@ -14,4 +14,6 @@
 </app-page-header>
 <app-page-subheader [tabs]="tabLinks">
 </app-page-subheader>
-<router-outlet></router-outlet>
+<app-loading-page [isLoading]="isFetching$" [text]="'Retrieving space'">
+  <router-outlet></router-outlet>
+</app-loading-page>

--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.ts
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.ts
@@ -11,6 +11,11 @@ import { CloudFoundryEndpointService } from '../../../../services/cloud-foundry-
 import { CloudFoundrySpaceService } from '../../../../services/cloud-foundry-space.service';
 import { RouterNav } from '../../../../../../store/actions/router.actions';
 import { getActiveRouteCfOrgSpaceProvider } from '../../../../cf.helpers';
+import { Observable } from 'rxjs/Observable';
+import { IHeaderBreadcrumb } from '../../../../../../shared/components/page-header/page-header.types';
+import { map, first } from 'rxjs/operators';
+import { CloudFoundryOrganisationService } from '../../../../services/cloud-foundry-organisation.service';
+import { combineLatest } from 'rxjs/observable/combineLatest';
 
 @Component({
   selector: 'app-cloud-foundry-space-base',
@@ -18,7 +23,8 @@ import { getActiveRouteCfOrgSpaceProvider } from '../../../../cf.helpers';
   styleUrls: ['./cloud-foundry-space-base.component.scss'],
   providers: [
     getActiveRouteCfOrgSpaceProvider,
-    CloudFoundrySpaceService
+    CloudFoundrySpaceService,
+    CloudFoundryOrganisationService
   ]
 })
 export class CloudFoundrySpaceBaseComponent implements OnInit {
@@ -46,12 +52,47 @@ export class CloudFoundrySpaceBaseComponent implements OnInit {
     }
   ];
 
+  public breadcrumbs$: Observable<IHeaderBreadcrumb[]>;
+
+  public name$: Observable<string>;
+
+  public isFetching$: Observable<boolean>;
+
   constructor(
-    private cfEndpointService: CloudFoundryEndpointService,
+    public cfEndpointService: CloudFoundryEndpointService,
     private cfSpaceService: CloudFoundrySpaceService,
     private cfOrgSpaceService: CfOrgSpaceDataService,
+    private cfOrgService: CloudFoundryOrganisationService,
     private store: Store<AppState>
-  ) { }
+  ) {
+    this.isFetching$ = cfSpaceService.space$.pipe(
+      map(space => space.entityRequestInfo.fetching)
+    )
+    this.name$ = cfSpaceService.space$.pipe(
+      map(space => space.entity.entity.name)
+    )
+    this.breadcrumbs$ = combineLatest(
+      cfEndpointService.endpoint$,
+      cfOrgService.org$
+    ).pipe(
+      map(([endpoint, org]) => ([
+        {
+          breadcrumbs: [
+            {
+              value: endpoint.entity.name,
+              routerLink: `/cloud-foundry/${endpoint.entity.guid}/summary`
+            },
+            {
+              value: org.entity.entity.name,
+              routerLink: `/cloud-foundry/${endpoint.entity.guid}/organizations/${org.entity.metadata.guid}`
+            }
+          ]
+        }
+      ])),
+      first()
+    )
+  }
+
 
   ngOnInit() { }
 

--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.ts
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.ts
@@ -72,6 +72,13 @@ export class CloudFoundrySpaceBaseComponent implements OnInit {
       map(space => space.entity.entity.name),
       first()
     );
+    this.setUpBreadcrumbs(cfEndpointService, cfOrgService);
+  }
+
+  private setUpBreadcrumbs(
+    cfEndpointService: CloudFoundryEndpointService,
+    cfOrgService: CloudFoundryOrganisationService
+  ) {
     this.breadcrumbs$ = combineLatest(
       cfEndpointService.endpoint$,
       cfOrgService.org$

--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.ts
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.ts
@@ -67,10 +67,11 @@ export class CloudFoundrySpaceBaseComponent implements OnInit {
   ) {
     this.isFetching$ = cfSpaceService.space$.pipe(
       map(space => space.entityRequestInfo.fetching)
-    )
+    );
     this.name$ = cfSpaceService.space$.pipe(
-      map(space => space.entity.entity.name)
-    )
+      map(space => space.entity.entity.name),
+      first()
+    );
     this.breadcrumbs$ = combineLatest(
       cfEndpointService.endpoint$,
       cfOrgService.org$
@@ -90,7 +91,7 @@ export class CloudFoundrySpaceBaseComponent implements OnInit {
         }
       ])),
       first()
-    )
+    );
   }
 
 

--- a/src/frontend/app/features/no-endpoints-non-admin/no-endpoints-non-admin.component.spec.ts
+++ b/src/frontend/app/features/no-endpoints-non-admin/no-endpoints-non-admin.component.spec.ts
@@ -6,6 +6,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NoEndpointsNonAdminComponent } from './no-endpoints-non-admin.component';
 import { createBasicStoreModule } from '../../test-framework/store-test-helper';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('NoEndpointsNonAdminComponent', () => {
   let component: NoEndpointsNonAdminComponent;
@@ -16,6 +17,7 @@ describe('NoEndpointsNonAdminComponent', () => {
       declarations: [NoEndpointsNonAdminComponent],
       imports: [
         CoreModule,
+        RouterTestingModule,
         SharedModule,
         createBasicStoreModule(),
       ]

--- a/src/frontend/app/features/service-catalogue/service-catalogue-page/service-catalogue-page.component.html
+++ b/src/frontend/app/features/service-catalogue/service-catalogue-page/service-catalogue-page.component.html
@@ -1,4 +1,4 @@
-<app-page-header [breadcrumbs]="breadcrumbs">
+<app-page-header>
   <h1>Service Catalogue</h1>
 </app-page-header>
 

--- a/src/frontend/app/features/service-catalogue/service-catalogue-page/service-catalogue-page.component.html
+++ b/src/frontend/app/features/service-catalogue/service-catalogue-page/service-catalogue-page.component.html
@@ -1,4 +1,4 @@
-<app-page-header>
+<app-page-header [breadcrumbs]="breadcrumbs">
   <h1>Service Catalogue</h1>
 </app-page-header>
 

--- a/src/frontend/app/features/service-catalogue/service-catalogue-page/service-catalogue-page.component.ts
+++ b/src/frontend/app/features/service-catalogue/service-catalogue-page/service-catalogue-page.component.ts
@@ -7,39 +7,4 @@ import { IHeaderBreadcrumb } from '../../../shared/components/page-header/page-h
   templateUrl: './service-catalogue-page.component.html',
   styleUrls: ['./service-catalogue-page.component.scss']
 })
-export class ServiceCataloguePageComponent implements OnInit {
-  breadcrumbs: IHeaderBreadcrumb[];
-  constructor() {
-    this.breadcrumbs = [
-      {
-        breadcrumbs: [
-          {
-            value: 'test',
-            routerLink: '/applications'
-          },
-          {
-            value: 'Apps',
-            routerLink: '/applications'
-          }
-        ]
-      },
-      {
-        key: 'test',
-        breadcrumbs: [
-          {
-            value: 'Param1',
-            routerLink: '/applications'
-          },
-          {
-            value: 'Param2',
-            routerLink: '/applications'
-          }
-        ]
-      }
-    ];
-  }
-
-  ngOnInit() {
-  }
-
-}
+export class ServiceCataloguePageComponent { }

--- a/src/frontend/app/features/service-catalogue/service-catalogue-page/service-catalogue-page.component.ts
+++ b/src/frontend/app/features/service-catalogue/service-catalogue-page/service-catalogue-page.component.ts
@@ -1,13 +1,30 @@
 import { Component, OnInit } from '@angular/core';
 
+import { IHeaderBreadcrumb } from '../../../shared/components/page-header/page-header.types';
+
 @Component({
   selector: 'app-service-catalogue-page',
   templateUrl: './service-catalogue-page.component.html',
   styleUrls: ['./service-catalogue-page.component.scss']
 })
 export class ServiceCataloguePageComponent implements OnInit {
-
-  constructor() { }
+  breadcrumbs: IHeaderBreadcrumb[];
+  constructor() {
+    this.breadcrumbs = [
+      {
+        breadcrumbs: [
+          {
+            value: 'test',
+            routerLink: '/applications'
+          },
+          {
+            value: 'Apps',
+            routerLink: '/applications'
+          }
+        ]
+      }
+    ]
+  }
 
   ngOnInit() {
   }

--- a/src/frontend/app/features/service-catalogue/service-catalogue-page/service-catalogue-page.component.ts
+++ b/src/frontend/app/features/service-catalogue/service-catalogue-page/service-catalogue-page.component.ts
@@ -22,8 +22,21 @@ export class ServiceCataloguePageComponent implements OnInit {
             routerLink: '/applications'
           }
         ]
+      },
+      {
+        key: 'test',
+        breadcrumbs: [
+          {
+            value: 'Param1',
+            routerLink: '/applications'
+          },
+          {
+            value: 'Param2',
+            routerLink: '/applications'
+          }
+        ]
       }
-    ]
+    ];
   }
 
   ngOnInit() {

--- a/src/frontend/app/shared/components/list/list-types/app/table-cell-app-name/table-cell-app-name.component.html
+++ b/src/frontend/app/shared/components/list/list-types/app/table-cell-app-name/table-cell-app-name.component.html
@@ -1,1 +1,1 @@
-<a [routerLink]="['/applications', row.entity.cfGuid , row.entity.guid]">{{row.entity.name}}</a>
+<a [routerLink]="['/applications', row.entity.cfGuid , row.entity.guid]" [queryParams]="{breadcrumbs: 'space'}">{{row.entity.name}}</a>

--- a/src/frontend/app/shared/components/list/list-types/app/table-cell-app-name/table-cell-app-name.component.html
+++ b/src/frontend/app/shared/components/list/list-types/app/table-cell-app-name/table-cell-app-name.component.html
@@ -1,1 +1,1 @@
-<a [routerLink]="['/applications', row.entity.cfGuid , row.entity.guid]" [queryParams]="{breadcrumbs: 'space'}">{{row.entity.name}}</a>
+<a [routerLink]="['/applications', row.entity.cfGuid , row.entity.guid]" [queryParams]="appLinkUrlParam">{{row.entity.name}}</a>

--- a/src/frontend/app/shared/components/list/list-types/app/table-cell-app-name/table-cell-app-name.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/table-cell-app-name/table-cell-app-name.component.ts
@@ -1,10 +1,15 @@
 /* tslint:disable:no-access-missing-member https://github.com/mgechev/codelyzer/issues/191*/
 import { Component, OnInit } from '@angular/core';
 import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { BREADCRUMB_URL_PARAM } from '../../../../page-header/page-header.types';
 
 @Component({
   selector: 'app-table-cell-app-name',
   templateUrl: './table-cell-app-name.component.html',
   styleUrls: ['./table-cell-app-name.component.scss']
 })
-export class TableCellAppNameComponent<T> extends TableCellCustom<T> { }
+export class TableCellAppNameComponent<T> extends TableCellCustom<T> {
+  public appLinkUrlParam = {
+    [BREADCRUMB_URL_PARAM]: 'space'
+  };
+}

--- a/src/frontend/app/shared/components/list/list-types/cf-space-apps/cf-space-apps-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-space-apps/cf-space-apps-list-config.service.ts
@@ -35,7 +35,8 @@ export class CfSpaceAppsListConfigService implements IListConfig<APIResource> {
       }
     },
     {
-      columnId: 'status', headerCell: () => 'Status',
+      columnId: 'status',
+      headerCell: () => 'Status',
       cellFlex: '2',
       cellConfig: {
         hideIcon: true,

--- a/src/frontend/app/shared/components/page-header/page-header.component.html
+++ b/src/frontend/app/shared/components/page-header/page-header.component.html
@@ -5,7 +5,16 @@
         <mat-icon class="page-header__nav-toggle">menu</mat-icon>
       </button>
     </div>
-    <ng-content></ng-content>
+    <div class="page-header__breadcrumbs" *ngIf="breadcrumbDefinitions">
+      <ng-container *ngFor="let breadcrumbDef of breadcrumbDefinitions">
+        <span class="page-header__breadcrumb page-header__breadcrumb-link" *ngIf="breadcrumbDef.routerLink" [routerLink]="breadcrumbDef.routerLink">{{ breadcrumbDef.value }}</span>
+        <span class="page-header__breadcrumb" *ngIf="!breadcrumbDef.routerLink">{{ breadcrumbDef.value }}</span>
+        <mat-icon class="page-header__breadcrumb-separator">chevron_right</mat-icon>
+      </ng-container>
+    </div>
+    <span>
+      <ng-content></ng-content>
+    </span>
     <div class="page-header__filler"></div>
     <ng-content select=".page-header-right"></ng-content>
     <button mat-icon-button [matMenuTriggerFor]="menu">

--- a/src/frontend/app/shared/components/page-header/page-header.component.html
+++ b/src/frontend/app/shared/components/page-header/page-header.component.html
@@ -12,9 +12,7 @@
         <mat-icon class="page-header__breadcrumb-separator">chevron_right</mat-icon>
       </ng-container>
     </div>
-    <span>
-      <ng-content></ng-content>
-    </span>
+    <ng-content></ng-content>
     <div class="page-header__filler"></div>
     <ng-content select=".page-header-right"></ng-content>
     <button mat-icon-button [matMenuTriggerFor]="menu">

--- a/src/frontend/app/shared/components/page-header/page-header.component.scss
+++ b/src/frontend/app/shared/components/page-header/page-header.component.scss
@@ -21,6 +21,7 @@
     opacity: $breadcrumb-opacity;
   }
   &__breadcrumb-separator {
+    font-size: 26px;
     margin: 0 $breadcrumb-padding;
   }
   &__breadcrumbs {

--- a/src/frontend/app/shared/components/page-header/page-header.component.scss
+++ b/src/frontend/app/shared/components/page-header/page-header.component.scss
@@ -1,5 +1,6 @@
 .page-header {
   $breadcrumb-opacity: 0.7;
+  $breadcrumb-hover-opacity: 1;
   $breadcrumb-padding: 3px;
   left: 0;
   position: absolute;
@@ -22,6 +23,7 @@
   }
   &__breadcrumb-separator {
     font-size: 26px;
+    user-select: none;
     margin: 0 $breadcrumb-padding;
   }
   &__breadcrumbs {
@@ -31,6 +33,9 @@
   }
   &__breadcrumb-link {
     cursor: pointer;
+    &:hover {
+      opacity: $breadcrumb-hover-opacity;
+    }
   }
 }
 

--- a/src/frontend/app/shared/components/page-header/page-header.component.scss
+++ b/src/frontend/app/shared/components/page-header/page-header.component.scss
@@ -1,5 +1,5 @@
 .page-header {
-  $breadcrumb-opacity: 0.7;
+  $breadcrumb-opacity: .7;
   $breadcrumb-hover-opacity: 1;
   $breadcrumb-padding: 3px;
   left: 0;
@@ -23,8 +23,8 @@
   }
   &__breadcrumb-separator {
     font-size: 26px;
-    user-select: none;
     margin: 0 $breadcrumb-padding;
+    user-select: none;
   }
   &__breadcrumbs {
     align-items: center;

--- a/src/frontend/app/shared/components/page-header/page-header.component.scss
+++ b/src/frontend/app/shared/components/page-header/page-header.component.scss
@@ -1,8 +1,10 @@
 .page-header {
-  position: absolute;
-  top: 0;
+  $breadcrumb-opacity: 0.7;
+  $breadcrumb-padding: 3px;
   left: 0;
+  position: absolute;
   right: 0;
+  top: 0;
   transform: translate3d(0, 0, 0);
   &__nav-toggle-wrapper {
     margin-right: 20px;
@@ -13,6 +15,21 @@
   }
   &__filler {
     flex: 1 1 auto;
+  }
+  &__breadcrumb,
+  &__breadcrumb-separator {
+    opacity: $breadcrumb-opacity;
+  }
+  &__breadcrumb-separator {
+    margin: 0 $breadcrumb-padding;
+  }
+  &__breadcrumbs {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+  }
+  &__breadcrumb-link {
+    cursor: pointer;
   }
 }
 

--- a/src/frontend/app/shared/components/page-header/page-header.component.spec.ts
+++ b/src/frontend/app/shared/components/page-header/page-header.component.spec.ts
@@ -4,16 +4,30 @@ import { StoreModule } from '@ngrx/store';
 import { MDAppModule } from '../../../core/md.module';
 import { appReducers } from '../../../store/reducers.module';
 import { PageHeaderComponent } from './page-header.component';
+import { CoreModule } from '../../../core/core.module';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
 
-describe('PageHeaderComponent', () => {
+fdescribe('PageHeaderComponent', () => {
   let component: PageHeaderComponent;
   let fixture: ComponentFixture<PageHeaderComponent>;
-
+  const URL_KEY = 'key';
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [PageHeaderComponent],
+      providers: [{
+        provide: ActivatedRoute,
+        useValue: {
+          snapshot: {
+            queryParams: { breadcrumbs: URL_KEY }
+          }
+        }
+      }],
       imports: [
         MDAppModule,
+        CoreModule,
+        RouterTestingModule,
         StoreModule.forRoot(
           appReducers
         )
@@ -30,5 +44,66 @@ describe('PageHeaderComponent', () => {
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should have 3 breadcrumbs', () => {
+    component.breadcrumbs = [
+      {
+        breadcrumbs: [
+          {
+            value: 'test'
+          },
+          {
+            value: 'test2'
+          },
+          {
+            value: 'test3'
+          }
+        ]
+      },
+      {
+        key: 'fake',
+        breadcrumbs: [
+          {
+            value: 'keyed'
+          }
+        ]
+      }
+    ];
+    fixture.detectChanges();
+    const breadcrumbs = fixture.elementRef.nativeElement.getElementsByClassName('page-header__breadcrumb');
+    expect(breadcrumbs.length).toEqual(3);
+  });
+
+  it('should have 2 breadcrumb', () => {
+    component.breadcrumbs = [
+      {
+        breadcrumbs: [
+          {
+            value: 'test'
+          },
+          {
+            value: 'test2'
+          },
+          {
+            value: 'test3'
+          }
+        ]
+      },
+      {
+        key: URL_KEY,
+        breadcrumbs: [
+          {
+            value: 'keyed'
+          },
+          {
+            value: 'keyed123'
+          }
+        ]
+      }
+    ];
+    fixture.detectChanges();
+    const breadcrumbs = fixture.elementRef.nativeElement.getElementsByClassName('page-header__breadcrumb');
+    expect(breadcrumbs.length).toEqual(2);
   });
 });

--- a/src/frontend/app/shared/components/page-header/page-header.component.spec.ts
+++ b/src/frontend/app/shared/components/page-header/page-header.component.spec.ts
@@ -9,7 +9,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 
-fdescribe('PageHeaderComponent', () => {
+describe('PageHeaderComponent', () => {
   let component: PageHeaderComponent;
   let fixture: ComponentFixture<PageHeaderComponent>;
   const URL_KEY = 'key';

--- a/src/frontend/app/shared/components/page-header/page-header.component.ts
+++ b/src/frontend/app/shared/components/page-header/page-header.component.ts
@@ -4,7 +4,7 @@ import { Store } from '@ngrx/store';
 import { ToggleSideNav } from './../../../store/actions/dashboard-actions';
 import { AppState } from './../../../store/app-state';
 import { Logout } from '../../../store/actions/auth.actions';
-import { IHeaderBreadcrumb, IHeaderBreadcrumbLink } from './page-header.types';
+import { IHeaderBreadcrumb, IHeaderBreadcrumbLink, BREADCRUMB_URL_PARAM } from './page-header.types';
 import { ActivatedRoute } from '@angular/router';
 
 @Component({
@@ -12,7 +12,7 @@ import { ActivatedRoute } from '@angular/router';
   templateUrl: './page-header.component.html',
   styleUrls: ['./page-header.component.scss']
 })
-export class PageHeaderComponent implements OnInit {
+export class PageHeaderComponent {
   public breadcrumbDefinitions: IHeaderBreadcrumbLink[] = null;
   private breadcrumbKey: string;
 
@@ -39,22 +39,16 @@ export class PageHeaderComponent implements OnInit {
     }) || breadcrumbs[0];
   }
 
-  constructor(private store: Store<AppState>, private route: ActivatedRoute) {
-    this.breadcrumbKey = route.snapshot.queryParams['breadcrumbKey'] || null;
-  }
-
-
-
-  ngOnInit() {
-
-  }
-
   toggleSidenav() {
     this.store.dispatch(new ToggleSideNav());
   }
 
   logout() {
     this.store.dispatch(new Logout());
+  }
+
+  constructor(private store: Store<AppState>, private route: ActivatedRoute) {
+    this.breadcrumbKey = route.snapshot.queryParams[BREADCRUMB_URL_PARAM] || null;
   }
 
 }

--- a/src/frontend/app/shared/components/page-header/page-header.component.ts
+++ b/src/frontend/app/shared/components/page-header/page-header.component.ts
@@ -4,6 +4,8 @@ import { Store } from '@ngrx/store';
 import { ToggleSideNav } from './../../../store/actions/dashboard-actions';
 import { AppState } from './../../../store/app-state';
 import { Logout } from '../../../store/actions/auth.actions';
+import { IHeaderBreadcrumb, IHeaderBreadcrumbLink } from './page-header.types';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-page-header',
@@ -11,10 +13,37 @@ import { Logout } from '../../../store/actions/auth.actions';
   styleUrls: ['./page-header.component.scss']
 })
 export class PageHeaderComponent implements OnInit {
+  public breadcrumbDefinitions: IHeaderBreadcrumbLink[] = null;
+  private breadcrumbKey: string;
 
   @Input('hideSideNavButton') hideSideNavButton = false;
 
-  constructor(private store: Store<AppState>) { }
+  @Input('breadcrumbs')
+  set breadcrumbs(breadcrumbs: IHeaderBreadcrumb[]) {
+    this.breadcrumbDefinitions = this.getBreadcrumb(breadcrumbs);
+  }
+
+  private getBreadcrumb(breadcrumbs: IHeaderBreadcrumb[]) {
+    if (!breadcrumbs || !breadcrumbs.length) {
+      return [];
+    }
+    return this.getBreadcrumbFromKey(breadcrumbs).breadcrumbs;
+  }
+
+  private getBreadcrumbFromKey(breadcrumbs: IHeaderBreadcrumb[]) {
+    if (breadcrumbs.length === 1 || !this.breadcrumbKey) {
+      return breadcrumbs[0];
+    }
+    return breadcrumbs.find(breadcrumb => {
+      return breadcrumb.key === this.breadcrumbKey;
+    }) || breadcrumbs[0];
+  }
+
+  constructor(private store: Store<AppState>, private route: ActivatedRoute) {
+    this.breadcrumbKey = route.snapshot.queryParams['breadcrumbKey'] || null;
+  }
+
+
 
   ngOnInit() {
 

--- a/src/frontend/app/shared/components/page-header/page-header.types.ts
+++ b/src/frontend/app/shared/components/page-header/page-header.types.ts
@@ -1,6 +1,6 @@
 export interface IHeaderBreadcrumbLink {
   value: string;
-  routerLink: string;
+  routerLink?: string;
 }
 
 export interface IHeaderBreadcrumb {

--- a/src/frontend/app/shared/components/page-header/page-header.types.ts
+++ b/src/frontend/app/shared/components/page-header/page-header.types.ts
@@ -1,0 +1,9 @@
+export interface IHeaderBreadcrumbLink {
+  value: string;
+  routerLink: string;
+}
+
+export interface IHeaderBreadcrumb {
+  key?: string;
+  breadcrumbs: IHeaderBreadcrumbLink[];
+}

--- a/src/frontend/app/shared/components/page-header/page-header.types.ts
+++ b/src/frontend/app/shared/components/page-header/page-header.types.ts
@@ -7,3 +7,5 @@ export interface IHeaderBreadcrumb {
   key?: string;
   breadcrumbs: IHeaderBreadcrumbLink[];
 }
+
+export const BREADCRUMB_URL_PARAM = 'breadcrumbs';

--- a/src/frontend/app/shared/data-services/cf-user.service.ts
+++ b/src/frontend/app/shared/data-services/cf-user.service.ts
@@ -20,6 +20,7 @@ import { getPaginationObservables } from '../../store/reducers/pagination-reduce
 import { APIResource } from '../../store/types/api.types';
 import { CfUser, UserRoleInOrg, UserSchema, UserRoleInSpace, IUserPermissionInOrg } from '../../store/types/user.types';
 import { PaginationMonitorFactory } from '../monitors/pagination-monitor.factory';
+import { IOrganization, ISpace } from '../../core/cf-api.types';
 @Injectable()
 export class CfUserService {
   public allUsersAction: GetAllUsers;
@@ -50,7 +51,8 @@ export class CfUserService {
     )
 
   getRolesFromUser(user: CfUser, type: 'organizations' | 'spaces' = 'organizations'): IUserPermissionInOrg[] {
-    return user[type].map(org => {
+    const role = user[type] as APIResource<IOrganization | ISpace>[];
+    return role.map(org => {
       const orgGuid = org.metadata.guid;
       return {
         orgName: org.entity.name as string,

--- a/src/frontend/app/store/actions/space.actions.ts
+++ b/src/frontend/app/store/actions/space.actions.ts
@@ -22,7 +22,7 @@ export class GetSpace extends CFStartAction implements ICFAction {
   constructor(public guid: string, public endpointGuid: string, private withInlineDepth: number) {
     super();
     this.options = new RequestOptions();
-    this.options.url = `space/${guid}`;
+    this.options.url = `spaces/${guid}`;
     this.options.method = 'get';
     this.options.params = new URLSearchParams();
     if (withInlineDepth !== 0) {

--- a/src/frontend/app/store/selectors/endpoint.selectors.ts
+++ b/src/frontend/app/store/selectors/endpoint.selectors.ts
@@ -27,4 +27,4 @@ export const endpointsRegisteredEntitiesSelector = createSelector(
 // Single endpoint request information
 export const endpointsEntityRequestSelector = (guid) => selectRequestInfo(endpointStoreNames.type, guid);
 // Single endpoint request data
-export const endpointsEntityRequestDataSelector = (guid) => selectEntity(endpointStoreNames.type, guid);
+export const endpointsEntityRequestDataSelector = (guid) => selectEntity<EndpointModel>(endpointStoreNames.type, guid);

--- a/src/frontend/app/store/types/entity.types.ts
+++ b/src/frontend/app/store/types/entity.types.ts
@@ -8,10 +8,9 @@ import {
   AppSummarySchema
 } from './app-metadata.types';
 import { SystemInfo } from './system.types';
-import { IRoute, IFeatureFlag } from '../../core/cf-api.types';
+import { IRoute, IFeatureFlag, IApp } from '../../core/cf-api.types';
 
 export interface IRequestDataInternal<T> extends IRequestTypeState {
-  application: IRequestEntityTypeState<T>;
   stack: IRequestEntityTypeState<T>;
   space: IRequestEntityTypeState<T>;
   organization: IRequestEntityTypeState<T>;
@@ -26,13 +25,13 @@ export interface IRequestDataInternal<T> extends IRequestTypeState {
   service: IRequestEntityTypeState<T>;
   serviceBinding: IRequestEntityTypeState<T>;
   securityGroup: IRequestEntityTypeState<T>;
-
 }
 
 export interface IRequestDataState extends IRequestDataInternal<APIResource> {
   endpoint: IRequestEntityTypeState<EndpointModel>;
   system: IRequestEntityTypeState<SystemInfo>;
   featureFlag: IRequestEntityTypeState<IFeatureFlag>;
+  application: IRequestEntityTypeState<APIResource<IApp>>;
 }
 
 export interface IRequestState extends IRequestDataInternal<RequestInfoState> {

--- a/src/frontend/app/store/types/entity.types.ts
+++ b/src/frontend/app/store/types/entity.types.ts
@@ -1,43 +1,54 @@
+import { IApp, IDomain, IFeatureFlag, IOrganization, IRoute, ISecurityGroup, ISpace, IStack } from '../../core/cf-api.types';
 import { IRequestEntityTypeState, IRequestTypeState } from '../app-state';
-import { endpointStoreNames, EndpointModel } from './endpoint.types';
 import { RequestInfoState } from '../reducers/api-request-reducer/types';
 import { APIResource } from './api.types';
-import {
-  AppEnvVarSchema,
-  AppStatSchema,
-  AppSummarySchema
-} from './app-metadata.types';
+import { AppEnvVarSchema, AppStatSchema, AppSummarySchema } from './app-metadata.types';
+import { EndpointModel } from './endpoint.types';
+import { GitBranch, GithubCommit } from './github.types';
+import { CfService, CfServiceBinding, CfServiceInstance, CfServicePlan } from './service.types';
 import { SystemInfo } from './system.types';
-import { IRoute, IFeatureFlag, IApp } from '../../core/cf-api.types';
+import { CfUser } from './user.types';
 
-export interface IRequestDataInternal<T> extends IRequestTypeState {
-  stack: IRequestEntityTypeState<T>;
-  space: IRequestEntityTypeState<T>;
-  organization: IRequestEntityTypeState<T>;
-  route: IRequestEntityTypeState<T>;
-  event: IRequestEntityTypeState<T>;
-  githubBranches: IRequestEntityTypeState<T>;
-  githubCommits: IRequestEntityTypeState<T>;
-  domain: IRequestEntityTypeState<T>;
-  user: IRequestEntityTypeState<T>;
-  serviceInstance: IRequestEntityTypeState<T>;
-  servicePlan: IRequestEntityTypeState<T>;
-  service: IRequestEntityTypeState<T>;
-  serviceBinding: IRequestEntityTypeState<T>;
-  securityGroup: IRequestEntityTypeState<T>;
-}
-
-export interface IRequestDataState extends IRequestDataInternal<APIResource> {
+export interface IRequestDataState extends IRequestTypeState {
   endpoint: IRequestEntityTypeState<EndpointModel>;
   system: IRequestEntityTypeState<SystemInfo>;
   featureFlag: IRequestEntityTypeState<IFeatureFlag>;
   application: IRequestEntityTypeState<APIResource<IApp>>;
+  stack: IRequestEntityTypeState<APIResource<IStack>>;
+  space: IRequestEntityTypeState<APIResource<ISpace>>;
+  organization: IRequestEntityTypeState<APIResource<IOrganization>>;
+  route: IRequestEntityTypeState<APIResource<IRoute>>;
+  event: IRequestEntityTypeState<APIResource>;
+  githubBranches: IRequestEntityTypeState<APIResource<GitBranch>>;
+  githubCommits: IRequestEntityTypeState<APIResource<GithubCommit>>;
+  domain: IRequestEntityTypeState<APIResource<IDomain>>;
+  user: IRequestEntityTypeState<APIResource<CfUser>>;
+  serviceInstance: IRequestEntityTypeState<APIResource<CfServiceInstance>>;
+  servicePlan: IRequestEntityTypeState<APIResource<CfServicePlan>>;
+  service: IRequestEntityTypeState<APIResource<CfService>>;
+  serviceBinding: IRequestEntityTypeState<APIResource<CfServiceBinding>>;
+  securityGroup: IRequestEntityTypeState<APIResource<ISecurityGroup>>;
 }
 
-export interface IRequestState extends IRequestDataInternal<RequestInfoState> {
+export interface IRequestState extends IRequestTypeState {
+  application: IRequestEntityTypeState<RequestInfoState>;
   endpoint: IRequestEntityTypeState<RequestInfoState>;
   system: IRequestEntityTypeState<RequestInfoState>;
   featureFlag: IRequestEntityTypeState<RequestInfoState>;
+  stack: IRequestEntityTypeState<RequestInfoState>;
+  space: IRequestEntityTypeState<RequestInfoState>;
+  organization: IRequestEntityTypeState<RequestInfoState>;
+  route: IRequestEntityTypeState<RequestInfoState>;
+  event: IRequestEntityTypeState<RequestInfoState>;
+  githubBranches: IRequestEntityTypeState<RequestInfoState>;
+  githubCommits: IRequestEntityTypeState<RequestInfoState>;
+  domain: IRequestEntityTypeState<RequestInfoState>;
+  user: IRequestEntityTypeState<RequestInfoState>;
+  serviceInstance: IRequestEntityTypeState<RequestInfoState>;
+  servicePlan: IRequestEntityTypeState<RequestInfoState>;
+  service: IRequestEntityTypeState<RequestInfoState>;
+  serviceBinding: IRequestEntityTypeState<RequestInfoState>;
+  securityGroup: IRequestEntityTypeState<RequestInfoState>;
 }
 
 

--- a/src/frontend/app/store/types/user.types.ts
+++ b/src/frontend/app/store/types/user.types.ts
@@ -1,23 +1,33 @@
 import { APIResource } from './api.types';
 import { schema } from 'normalizr';
 import { getAPIResourceGuid } from '../selectors/api.selectors';
+import { ISpace, IOrganization } from '../../core/cf-api.types';
 
 export const UserSchema = new schema.Entity('user', {}, {
   idAttribute: getAPIResourceGuid
 });
 
 export interface CfUser {
-  organizations: APIResource<any>[];
-  managed_organizations: APIResource<any>[];
-  billing_managed_organizations: APIResource<any>[];
-  audited_organizations: APIResource<any>[];
-
-  spaces: APIResource<any>[];
-  managed_spaces: APIResource<any>;
-  audited_spaces: APIResource<any>;
+  organizations?: APIResource<IOrganization>[];
+  managed_organizations: APIResource<IOrganization>[];
+  billing_managed_organizations: APIResource<IOrganization>[];
+  audited_organizations: APIResource<IOrganization>[];
+  admin: boolean;
+  spaces?: APIResource<ISpace>[];
+  managed_spaces?: APIResource<ISpace>[];
+  audited_spaces?: APIResource<ISpace>[];
   cfGuid?: string;
   guid: string;
-  username: string;
+  username?: string;
+  active: boolean;
+  spaces_url: string;
+  organizations_url: string;
+  managed_organizations_url: string;
+  billing_managed_organizations_url: string;
+  audited_organizations_url: string;
+  managed_spaces_url: string;
+  audited_spaces_url: string;
+  default_space_guid: string;
 }
 
 export interface UserRoleInOrg {


### PR DESCRIPTION
Added breadcumbs to the header bar of some pages.

These breadcrumbs can change based on the context of the current page, for example:

The application summary can have two different breadcrumbs
* `Applications > APPLICATION_NAME` - If we've navigated to the application from the application wall page.
* `ENDPOINT_NAME > ORG_NAME > SPACE_NAME > APPLICATION_NAME` - if we have navigated from the space page.

We allow the breadcrumbs to be context aware like this to try and keep the navigation continuity  throughout the app.