### PR TITLE
Fix CF User Service

### DIFF
--- a/src/frontend/app/shared/data-services/cf-user.service.ts
+++ b/src/frontend/app/shared/data-services/cf-user.service.ts
@@ -37,7 +37,10 @@ export class CfUserService {
     public activeRouteCfOrgSpace: ActiveRouteCfOrgSpace
   ) {
     // See issue #1741
-    this.allUsersAction = new GetAllUsers(createEntityRelationPaginationKey(endpointSchemaKey, activeRouteCfOrgSpace.cfGuid));
+    this.allUsersAction = new GetAllUsers(
+      createEntityRelationPaginationKey(endpointSchemaKey, activeRouteCfOrgSpace.cfGuid),
+      activeRouteCfOrgSpace.cfGuid
+    );
   }
 
   getUsers = (endpointGuid: string): Observable<APIResource<CfUser>[]> =>

--- a/src/frontend/app/store/actions/users.actions.ts
+++ b/src/frontend/app/store/actions/users.actions.ts
@@ -21,6 +21,7 @@ export const REMOVE_PERMISSION_FAILED = '[Users]  Remove Permission failed';
 export class GetAllUsers extends CFStartAction implements PaginatedAction, EntityInlineParentAction {
   constructor(
     public paginationKey: string,
+    public endpointGuid: string,
     public includeRelations: string[] = [
       createEntityRelationKey(cfUserSchemaKey, organisationSchemaKey),
       createEntityRelationKey(cfUserSchemaKey, 'audited_organizations'),


### PR DESCRIPTION
When an SAP CF is connected, without targeting a specific endpoint we block the user observables since the request to fetch users from SAP fails.