### PR TITLE
Fix three list bugs

### DIFF
--- a/src/frontend/app/shared/components/list/data-sources-controllers/list-data-source.ts
+++ b/src/frontend/app/shared/components/list/data-sources-controllers/list-data-source.ts
@@ -275,20 +275,17 @@ export abstract class ListDataSource<T, A = T> extends DataSource<T> implements 
         if (entities && !entities.length) {
           return [];
         }
-        const entitiesPreFilter = entities.length;
+
         if (dataFunctions && dataFunctions.length) {
           entities = dataFunctions.reduce((value, fn) => {
             return fn(value, paginationEntity);
           }, entities);
         }
-        const entitiesPostFilter = entities.length;
 
         const pages = this.splitClientPages(entities, paginationEntity.clientPagination.pageSize);
-        if (
-          entitiesPreFilter !== entitiesPostFilter &&
-          (paginationEntity.totalResults !== entities.length ||
-            paginationEntity.clientPagination.totalResults !== entities.length)
-        ) {
+        // Note - ensure we don't also include the entities count pre/post reduce (fails for local pagination - specifically when a filter
+        // resets to include all entities)
+        if (paginationEntity.totalResults !== entities.length || paginationEntity.clientPagination.totalResults !== entities.length) {
           this.store.dispatch(new SetResultCount(this.entityKey, this.paginationKey, entities.length));
         }
 

--- a/src/frontend/app/shared/components/list/list.component.html
+++ b/src/frontend/app/shared/components/list/list.component.html
@@ -27,18 +27,18 @@
           </mat-form-field>
         </div>
         <!-- Sort Button & Drop down -->
-        <div class="sort" [hidden]="(view$ | async) === 'table' || sortColumns.length < 1 || (isAddingOrSelecting$ | async) || (!(dataSource.isLoadingPage$ | async) && !(hasRows$ | async))">
+        <div class="sort" [hidden]="(view$ | async) === 'table' || sortColumns.length < 1 || (isAddingOrSelecting$ | async) || (!(dataSource.isLoadingPage$ | async) && !(hasRowsOrIsFiltering$ | async))">
           <mat-form-field>
-            <mat-select matInput #headerSortField shouldPlaceholderFloat="false" [disabled]="(dataSource?.isLoadingPage$ | async)" (change)="updateListSort($event.value, headerSortDirection)">
+            <mat-select matInput #headerSortField shouldPlaceholderFloat="false" [disabled]="(disableActions$ | async)" (change)="updateListSort($event.value, headerSortDirection)">
               <mat-option *ngFor="let column of sortColumns" [value]="column.columnId">
                 {{column.headerCell()}}
               </mat-option>
             </mat-select>
           </mat-form-field>
-          <button mat-icon-button (click)="updateListSort(headerSortField.value, 'desc')" [disabled]="(dataSource.isLoadingPage$ | async)" *ngIf="headerSortDirection==='asc'">
+          <button mat-icon-button (click)="updateListSort(headerSortField.value, 'desc')" [disabled]="(disableActions$ | async)" *ngIf="headerSortDirection==='asc'">
             <mat-icon>sort</mat-icon>
           </button>
-          <button mat-icon-button (click)="updateListSort(headerSortField.value, 'asc')" [disabled]="(dataSource.isLoadingPage$ | async)" *ngIf="headerSortDirection==='desc'">
+          <button mat-icon-button (click)="updateListSort(headerSortField.value, 'asc')" [disabled]="(disableActions$ | async)" *ngIf="headerSortDirection==='desc'">
             <mat-icon style="transform: rotate(180deg);">sort</mat-icon>
           </button>
         </div>
@@ -76,12 +76,12 @@
           </button>
         </div>
         <!-- Select table or cards view button -->
-        <div *ngIf="config.viewType === 'both' && !(isAddingOrSelecting$ | async) && ((dataSource.isLoadingPage$ | async) || (hasRows$ | async))">
+        <div *ngIf="config.viewType === 'both' && !(isAddingOrSelecting$ | async) && ((dataSource.isLoadingPage$ | async) || (hasRowsOrIsFiltering$ | async))">
           <button mat-icon-button [disabled]="(dataSource.isLoadingPage$ | async)" (click)="updateListView('cards');" *ngIf="(view$ | async)==='table'">
             <mat-icon>grid_on</mat-icon>
           </button>
           <button mat-icon-button [disabled]="(dataSource.isLoadingPage$ | async)" (click)="updateListView('table');" *ngIf="(view$ | async)==='cards'">
-            <mat-icon>list</mat-icon>
+          <mat-icon>list</mat-icon>
           </button>
         </div>
       </div>

--- a/src/frontend/app/shared/components/list/list.component.ts
+++ b/src/frontend/app/shared/components/list/list.component.ts
@@ -70,6 +70,10 @@ export class ListComponent<T> implements OnInit, OnDestroy, AfterViewInit {
 
   isAddingOrSelecting$: Observable<boolean>;
   hasRows$: Observable<boolean>;
+  noRowsHaveFilter$: Observable<boolean>;
+  disableActions$: Observable<boolean>;
+  hasRowsOrIsFiltering$: Observable<boolean>;
+  isFiltering$: Observable<boolean>;
 
   // Observable which allows you to determine if the paginator control should be hidden
   hidePaginator$: Observable<boolean>;
@@ -200,6 +204,34 @@ export class ListComponent<T> implements OnInit, OnDestroy, AfterViewInit {
       this.filterString = filter.string;
       this.multiFilters = filter.items;
     });
+
+    this.isFiltering$ = this.paginationController.filter$.pipe(
+      map((filter: ListFilter) => {
+        const isFilteringByString = filter.string ? !!filter.string.length : false;
+        const isFilteringByItems = Object.keys(filter.items).map(key => {
+          return !!filter.items[key];
+        }).length > 0;
+        return isFilteringByString || isFilteringByItems;
+      })
+    );
+
+    this.noRowsHaveFilter$ = combineLatest(this.hasRows$, this.isFiltering$).pipe(
+      map(([hasRows, isFiltering]) => {
+        return !hasRows && isFiltering;
+      })
+    );
+
+    this.hasRowsOrIsFiltering$ = combineLatest(this.hasRows$, this.isFiltering$).pipe(
+      map(([hasRows, isFiltering]) => {
+        return hasRows || isFiltering;
+      })
+    );
+
+    this.disableActions$ = combineLatest(this.dataSource.isLoadingPage$, this.noRowsHaveFilter$).pipe(
+      map(([isLoading, noRowsHaveFilter]) => {
+        return isLoading || noRowsHaveFilter;
+      })
+    );
 
     this.uberSub = Observable.combineLatest(
       paginationStoreToWidget,


### PR DESCRIPTION
- Selecting 'all' cf/org/space should now correctly reset the list
- Filtering to zero entries and then more than zero should now correctly show paginator again
- Filtering to zero entries should now result in less top bar widget wiggle (see app wall before/after)