### PR TITLE
Ensure we're more null safe to catch case where entities of a certain type are missing

### DIFF
--- a/src/frontend/app/store/helpers/entity-relations.ts
+++ b/src/frontend/app/store/helpers/entity-relations.ts
@@ -327,8 +327,11 @@ function validationLoop(config: ValidateLoopConfig): ValidateEntityResult[] {
           const guids = childEntitiesAsGuids(childEntitiesAsArray);
 
           childEntities = [];
-          const allEntitiesOfType = allEntities ? allEntities[childRelation.entityKey] : {};
-          const newEntitiesOfType = newEntities ? newEntities[childRelation.entityKey] : {};
+          let allEntitiesOfType = allEntities ? allEntities[childRelation.entityKey] : {};
+          let newEntitiesOfType = newEntities ? newEntities[childRelation.entityKey] : {};
+          allEntitiesOfType = allEntities || {};
+          newEntitiesOfType = newEntities || {};
+
           for (let i = 0; i < guids.length; i++) {
             const guid = guids[i];
             const foundEntity = newEntitiesOfType[guid] || allEntitiesOfType[guid];


### PR DESCRIPTION
If entities in a response are missing we check the existing/new store to see if we have them already. Ensure that if the existing/new store exists but the entities section of the missing entity doesn't... we don't barf.