### PR TITLE
Fix bread-crumb in the app-wall table view

### DIFF
--- a/src/frontend/app/shared/components/list/list-types/app/table-cell-app-name/table-cell-app-name.component.html
+++ b/src/frontend/app/shared/components/list/list-types/app/table-cell-app-name/table-cell-app-name.component.html
@@ -1,1 +1,1 @@
-<a [routerLink]="['/applications', row.entity.cfGuid , row.entity.guid]" [queryParams]="appLinkUrlParam">{{row.entity.name}}</a>
+<a [routerLink]="['/applications', row.entity.cfGuid , row.entity.guid]" [queryParams]="appLinkUrlParam$ | async">{{row.entity.name}}</a>

--- a/src/frontend/app/shared/components/list/list-types/app/table-cell-app-name/table-cell-app-name.component.spec.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/table-cell-app-name/table-cell-app-name.component.spec.ts
@@ -3,6 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TableCellAppNameComponent } from './table-cell-app-name.component';
 import { CoreModule } from '../../../../../../core/core.module';
 import { RouterTestingModule } from '@angular/router/testing';
+import { createBasicStoreModule } from '../../../../../../test-framework/store-test-helper';
 
 describe('TableCellAppNameComponent', () => {
   let component: TableCellAppNameComponent<any>;
@@ -13,7 +14,8 @@ describe('TableCellAppNameComponent', () => {
       declarations: [TableCellAppNameComponent],
       imports: [
         CoreModule,
-        RouterTestingModule
+        RouterTestingModule,
+        createBasicStoreModule()
       ]
     })
       .compileComponents();

--- a/src/frontend/app/shared/components/list/list-types/app/table-cell-app-name/table-cell-app-name.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/table-cell-app-name/table-cell-app-name.component.ts
@@ -1,15 +1,38 @@
-/* tslint:disable:no-access-missing-member https://github.com/mgechev/codelyzer/issues/191*/
 import { Component, OnInit } from '@angular/core';
 import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
 import { BREADCRUMB_URL_PARAM } from '../../../../page-header/page-header.types';
+import { ActivatedRoute } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { AppState } from '../../../../../../store/app-state';
+import { getCurrentRoutingState, RoutingHistory, RoutingEvent } from '../../../../../../store/types/routing.type';
+import { Observable } from 'rxjs/Observable';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-table-cell-app-name',
   templateUrl: './table-cell-app-name.component.html',
   styleUrls: ['./table-cell-app-name.component.scss']
 })
-export class TableCellAppNameComponent<T> extends TableCellCustom<T> {
-  public appLinkUrlParam = {
-    [BREADCRUMB_URL_PARAM]: 'space'
-  };
+export class TableCellAppNameComponent<T> extends TableCellCustom<T> implements OnInit {
+  public appLinkUrlParam$: Observable<any>;
+
+  constructor(private store: Store<AppState>) {
+    super();
+  }
+
+  ngOnInit(): void {
+
+    this.appLinkUrlParam$ = this.store.select(getCurrentRoutingState).pipe(
+      map((state: RoutingEvent) => {
+        if (state.url.indexOf('cloud-foundry') !== -1) {
+          // We're in the Cloud Foundry section, change the breadcrumb
+          return {
+            [BREADCRUMB_URL_PARAM]: 'space'
+          };
+        }
+        // Default breadcrumb is apps/appName
+        return {};
+      })
+    );
+  }
 }

--- a/src/frontend/app/store/types/routing.type.ts
+++ b/src/frontend/app/store/types/routing.type.ts
@@ -28,3 +28,6 @@ export const defaultRoutingState: RoutingHistory = {
 export function getPreviousRoutingState(state: AppState) {
   return state.routing.previousState;
 }
+export function getCurrentRoutingState(state: AppState) {
+  return state.routing.currentState;
+}

--- a/src/frontend/app/test-framework/store-test-helper.ts
+++ b/src/frontend/app/test-framework/store-test-helper.ts
@@ -21582,7 +21582,26 @@ const testInitialStoreState: AppState = {
   actionHistory: [],
   lists: {},
   routing: {
-    currentState: null
+    previousState: {
+      id: 4,
+      url: '/service-catalog',
+      urlAfterRedirects: '/service-catalog',
+      state: {
+        url: '/service-catalog',
+        params: {},
+        queryParams: {}
+      }
+    },
+    currentState: {
+      id: 5,
+      url: '/applications',
+      urlAfterRedirects: '/applications',
+      state: {
+        url: '/applications',
+        params: {},
+        queryParams: {}
+      }
+    }
   }
 };
 /* tslint:enable */


### PR DESCRIPTION
Issue was the same cell component was being used for both the apps table in the `spaces` section and the application wall. 
The cell component now determines in which section it is (by checking the current URL) and adds the appropriate query params for the bread crumb