### PR TITLE
List ux tweaks

### DIFF
--- a/src/frontend/app/shared/components/list/list-cards/card/card.component.ts
+++ b/src/frontend/app/shared/components/list/list-cards/card/card.component.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 
 import { IListDataSource } from '../../data-sources-controllers/list-data-source-types';
-import { TableCellCustom } from '../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../list.types';
 import {
   AppServiceBindingCardComponent,
 } from '../../list-types/app-sevice-bindings/app-service-binding-card/app-service-binding-card.component';

--- a/src/frontend/app/shared/components/list/list-cards/cards.component.html
+++ b/src/frontend/app/shared/components/list/list-cards/cards.component.html
@@ -1,4 +1,4 @@
-<div class="cards" [ngClass]="{'cards--large': size === cardSize.LARGE }">
+<div class="cards {{'cards__columns-' + component.columns}}">
   <app-card *ngFor="let item of dataSource.page$ | async; trackBy: dataSource.trackBy" [item]="item" [component]="component" [dataSource]="dataSource"></app-card>
   <app-card class="row-filler"></app-card>
 </div>

--- a/src/frontend/app/shared/components/list/list-cards/cards.component.spec.ts
+++ b/src/frontend/app/shared/components/list/list-cards/cards.component.spec.ts
@@ -5,6 +5,7 @@ import { EntityInfo } from '../../../../store/types/api.types';
 import { SharedModule } from '../../../shared.module';
 import { IListDataSource } from '../data-sources-controllers/list-data-source-types';
 import { CardsComponent } from './cards.component';
+import { CardCell } from '../list.types';
 
 describe('CardsComponent', () => {
   let component: CardsComponent<EntityInfo>;
@@ -23,6 +24,7 @@ describe('CardsComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CardsComponent);
     component = fixture.componentInstance;
+    component.component = {} as CardCell<any>;
     component.dataSource = {} as IListDataSource<EntityInfo>;
     fixture.detectChanges();
   });

--- a/src/frontend/app/shared/components/list/list-cards/cards.component.ts
+++ b/src/frontend/app/shared/components/list/list-cards/cards.component.ts
@@ -1,24 +1,14 @@
-import { CfAppEventsDataSource } from '../list-types/app-event/cf-app-events-data-source';
-import { Component, Input, OnInit, Type, ViewContainerRef, ComponentFactoryResolver, ViewChild } from '@angular/core';
-import { IListDataSource } from '../data-sources-controllers/list-data-source-types';
-import { TableCellCustom, CardSize } from '../list-table/table-cell/table-cell-custom';
+import { Component, Input } from '@angular/core';
 
+import { IListDataSource } from '../data-sources-controllers/list-data-source-types';
+import { TableCellCustom } from '../list.types';
 
 @Component({
   selector: 'app-cards',
   templateUrl: './cards.component.html',
   styleUrls: ['./cards.component.scss']
 })
-export class CardsComponent<T> implements OnInit {
-
+export class CardsComponent<T> {
   @Input('dataSource') dataSource: IListDataSource<T>;
   @Input('component') component: TableCellCustom<T>;
-
-  private size: CardSize;
-
-  private cardSize = CardSize;
-
-  ngOnInit() {
-    this.size = this.component ? this.component.size : null;
-  }
 }

--- a/src/frontend/app/shared/components/list/list-cards/cards.components.theme.scss
+++ b/src/frontend/app/shared/components/list/list-cards/cards.components.theme.scss
@@ -1,15 +1,32 @@
 @import '../../../../../sass/mixins';
 .cards {
+  $space: 15px;
+  $space-row: $space + 10px;
   app-card {
-    $space: 15px;
-    $space-row: $space + 10px;
     margin-bottom: $space;
     width: 100%;
-    @include breakpoint(desktop) {
-      width: calc(25% - #{$space-row});
+  }
+  &__columns-2 {
+    app-card {
+      @include breakpoint(tablet) {
+        width: calc(50% - #{$space-row});
+      } //
+      // We should bring the below back in once we sort out the spacing.
+      // .. currently row is flex with space between
+      // .. this means on a row with 4 spaces and 2 cards the second card is spaced incorrectly
+      // .. need to remove this `space-between` and dynamically add padding to the last card as per v1
+      // @include breakpoint(desktop) {
+      //   width: calc(25% - #{$space-row});
+      // }
     }
-    @include breakpoint(tablet) {
-      width: calc(33% - #{$space-row});
+  }
+  &__columns-3 {
+    app-card {
+      @include breakpoint(tablet) {
+        width: calc(33% - #{$space-row});
+      } // @include breakpoint(desktop) {
+      //   width: calc(25% - #{$space-row});
+      // }
     }
   }
 }

--- a/src/frontend/app/shared/components/list/list-cards/custom-cards/endpoint-card/endpoint-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-cards/custom-cards/endpoint-card/endpoint-card.component.ts
@@ -3,7 +3,7 @@ import { ReplaySubject } from 'rxjs/ReplaySubject';
 
 import { EndpointModel } from '../../../../../../store/types/endpoint.types';
 import { CardStatus } from '../../../../application-state/application-state.service';
-import { TableCellCustom, CardSize } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom, CardCell } from '../../../list.types';
 import { getFullEndpointApiUrl } from '../../../../../../features/endpoints/endpoint-helpers';
 
 @Component({
@@ -11,9 +11,10 @@ import { getFullEndpointApiUrl } from '../../../../../../features/endpoints/endp
   templateUrl: './endpoint-card.component.html',
   styleUrls: ['./endpoint-card.component.scss']
 })
-export class EndpointCardComponent extends TableCellCustom<EndpointModel> implements OnInit, OnChanges {
+export class EndpointCardComponent extends CardCell<EndpointModel> implements OnInit, OnChanges {
 
-  public size = CardSize.LARGE;
+  static columns = 2;
+
   private status$ = new ReplaySubject<CardStatus>();
 
   @Input('row')

--- a/src/frontend/app/shared/components/list/list-table/app-table-cell-default/app-table-cell-default.component.ts
+++ b/src/frontend/app/shared/components/list/list-table/app-table-cell-default/app-table-cell-default.component.ts
@@ -1,7 +1,7 @@
 import { objectHelper } from './../../../../../core/helper-classes/object.helpers';
 import { ICellDefinition } from './../table.types';
 import { Component, OnChanges, SimpleChanges, SimpleChange } from '@angular/core';
-import { TableCellCustom } from '../table-cell/table-cell-custom';
+import { TableCellCustom } from '../../list.types';
 
 @Component({
   moduleId: module.id,

--- a/src/frontend/app/shared/components/list/list-table/table-cell-actions/table-cell-actions.component.ts
+++ b/src/frontend/app/shared/components/list/list-table/table-cell-actions/table-cell-actions.component.ts
@@ -7,7 +7,7 @@ import { map } from 'rxjs/operators';
 import { AppState } from '../../../../../store/app-state';
 import { RowState } from '../../data-sources-controllers/list-data-source-types';
 import { IListAction, ListConfig } from '../../list.component.types';
-import { TableCellCustom } from '../table-cell/table-cell-custom';
+import { TableCellCustom } from '../../list.types';
 
 @Component({
   selector: 'app-table-cell-actions',

--- a/src/frontend/app/shared/components/list/list-table/table-cell-edit/table-cell-edit.component.ts
+++ b/src/frontend/app/shared/components/list/list-table/table-cell-edit/table-cell-edit.component.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-access-missing-member https://github.com/mgechev/codelyzer/issues/191*/
 import { Component, OnInit } from '@angular/core';
-import { TableCellCustom } from '../table-cell/table-cell-custom';
+import { TableCellCustom } from '../../list.types';
 
 @Component({
   selector: 'app-table-cell-edit',

--- a/src/frontend/app/shared/components/list/list-table/table-cell-select/table-cell-select.component.ts
+++ b/src/frontend/app/shared/components/list/list-table/table-cell-select/table-cell-select.component.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-access-missing-member https://github.com/mgechev/codelyzer/issues/191*/
 import { Component, OnInit } from '@angular/core';
-import { TableCellCustom } from '../table-cell/table-cell-custom';
+import { TableCellCustom } from '../../list.types';
 
 @Component({
   selector: 'app-table-cell-select',

--- a/src/frontend/app/shared/components/list/list-table/table-cell/table-cell.component.ts
+++ b/src/frontend/app/shared/components/list/list-table/table-cell/table-cell.component.ts
@@ -73,8 +73,8 @@ import { TableCellEditComponent } from '../table-cell-edit/table-cell-edit.compo
 import { TableCellSelectComponent } from '../table-cell-select/table-cell-select.component';
 import { TableHeaderSelectComponent } from '../table-header-select/table-header-select.component';
 import { ICellDefinition } from '../table.types';
-import { TableCellCustom } from './table-cell-custom';
 import { CfSpacePermissionCellComponent } from '../../list-types/cf-users/cf-space-permission-cell/cf-space-permission-cell.component';
+import { TableCellCustom } from '../../list.types';
 
 export const listTableCells = [
   TableCellDefaultComponent,

--- a/src/frontend/app/shared/components/list/list-table/table-header-select/table-header-select.component.ts
+++ b/src/frontend/app/shared/components/list/list-table/table-header-select/table-header-select.component.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-access-missing-member https://github.com/mgechev/codelyzer/issues/191*/
 import { Component, OnInit } from '@angular/core';
-import { TableCellCustom } from '../table-cell/table-cell-custom';
+import { TableCellCustom } from '../../list.types';
 
 @Component({
   selector: 'app-table-header-select',

--- a/src/frontend/app/shared/components/list/list-table/table.types.ts
+++ b/src/frontend/app/shared/components/list/list-table/table.types.ts
@@ -1,9 +1,9 @@
 import { DataFunction, DataFunctionDefinition } from '../data-sources-controllers/list-data-source';
+import { TableCellDefaultComponent } from './app-table-cell-default/app-table-cell-default.component';
 import { TableCellStatusDirective } from './table-cell-status.directive';
 import { listTableCells, TableCellComponent } from './table-cell/table-cell.component';
 import { TableRowComponent } from './table-row/table-row.component';
 import { TableComponent } from './table.component';
-import { TableCellDefaultComponent } from './app-table-cell-default/app-table-cell-default.component';
 
 export interface ICellDefinition<T> {
   // Dot separated path to get the value from the row

--- a/src/frontend/app/shared/components/list/list-types/app-event/table-cell-event-action/table-cell-event-action.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-event/table-cell-event-action/table-cell-event-action.component.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-access-missing-member https://github.com/mgechev/codelyzer/issues/191*/
 import { Component, OnInit } from '@angular/core';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-table-cell-event-action',

--- a/src/frontend/app/shared/components/list/list-types/app-event/table-cell-event-detail/table-cell-event-detail.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-event/table-cell-event-detail/table-cell-event-detail.component.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-access-missing-member https://github.com/mgechev/codelyzer/issues/191*/
 import { Component, OnInit } from '@angular/core';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-table-cell-event-detail',

--- a/src/frontend/app/shared/components/list/list-types/app-event/table-cell-event-timestamp/table-cell-event-timestamp.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-event/table-cell-event-timestamp/table-cell-event-timestamp.component.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-access-missing-member https://github.com/mgechev/codelyzer/issues/191*/
 import { Component, OnInit } from '@angular/core';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-table-cell-event-timestamp',

--- a/src/frontend/app/shared/components/list/list-types/app-event/table-cell-event-type/table-cell-event-type.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-event/table-cell-event-type/table-cell-event-type.component.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-access-missing-member https://github.com/mgechev/codelyzer/issues/191*/
 import { Component, OnInit } from '@angular/core';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-table-cell-event-type',

--- a/src/frontend/app/shared/components/list/list-types/app-instance/cf-app-instances-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-instance/cf-app-instances-config.service.ts
@@ -101,7 +101,7 @@ export class CfAppInstancesConfigService implements IListConfig<ListAppInstance>
   viewType = ListViewTypes.TABLE_ONLY;
   text = {
     title: null,
-    noEntries: 'There are no applications'
+    noEntries: 'There are no application instances'
   };
 
   private listActionTerminate: IListAction<any> = {

--- a/src/frontend/app/shared/components/list/list-types/app-instance/table-cell-usage/table-cell-usage.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-instance/table-cell-usage/table-cell-usage.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-table-cell-usage',

--- a/src/frontend/app/shared/components/list/list-types/app-route/table-cell-app-route/table-cell-app-route.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-route/table-cell-app-route/table-cell-app-route.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 
 import { ApplicationService } from '../../../../../../features/applications/application.service';
 import { getMappedApps } from '../../../../../../features/applications/routes/routes.helper';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-table-cell-app-route',

--- a/src/frontend/app/shared/components/list/list-types/app-route/table-cell-radio/table-cell-radio.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-route/table-cell-radio/table-cell-radio.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 
 import { ApplicationService } from '../../../../../../features/applications/application.service';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-table-cell-radio',

--- a/src/frontend/app/shared/components/list/list-types/app-route/table-cell-route/table-cell-route.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-route/table-cell-route/table-cell-route.component.ts
@@ -7,7 +7,7 @@ import { getRoute, isTCPRoute } from '../../../../../../features/applications/ro
 import { AppState } from '../../../../../../store/app-state';
 import { selectEntity } from '../../../../../../store/selectors/api.selectors';
 import { EntityInfo } from '../../../../../../store/types/api.types';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-table-cell-route',

--- a/src/frontend/app/shared/components/list/list-types/app-route/table-cell-tcproute/table-cell-tcproute.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-route/table-cell-tcproute/table-cell-tcproute.component.ts
@@ -1,4 +1,4 @@
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 import { Component, OnInit, Input } from '@angular/core';
 import { isTCPRoute } from '../../../../../../features/applications/routes/routes.helper';
 

--- a/src/frontend/app/shared/components/list/list-types/app-sevice-bindings/app-service-binding-card/app-service-binding-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-sevice-bindings/app-service-binding-card/app-service-binding-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
@@ -19,21 +19,20 @@ import { ConfirmationDialogConfig } from '../../../../confirmation-dialog.config
 import { ConfirmationDialogService } from '../../../../confirmation-dialog.service';
 import { EnvVarViewComponent } from '../../../../env-var-view/env-var-view.component';
 import { MetaCardMenuItem } from '../../../list-cards/meta-card/meta-card-base/meta-card.component';
-import { TableCellCustom } from '../../../list.types';
+import { CardCell } from '../../../list.types';
 
 @Component({
   selector: 'app-app-service-binding-card',
   templateUrl: './app-service-binding-card.component.html',
   styleUrls: ['./app-service-binding-card.component.scss']
 })
-export class AppServiceBindingCardComponent extends TableCellCustom<APIResource<IServiceBinding>> implements OnInit {
+export class AppServiceBindingCardComponent extends CardCell<APIResource<IServiceBinding>> implements OnInit {
 
   envVarUrl: string;
   cardMenu: MetaCardMenuItem[];
   service$: Observable<EntityInfo<APIResource<IService>>>;
   serviceInstance$: Observable<EntityInfo<APIResource<IServiceInstance>>>;
   tags$: Observable<AppChip<IServiceInstance>[]>;
-  @Input('row') row: APIResource<IServiceBinding>;
 
   constructor(
     private store: Store<AppState>,

--- a/src/frontend/app/shared/components/list/list-types/app-sevice-bindings/app-service-binding-card/app-service-binding-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-sevice-bindings/app-service-binding-card/app-service-binding-card.component.ts
@@ -19,7 +19,7 @@ import { ConfirmationDialogConfig } from '../../../../confirmation-dialog.config
 import { ConfirmationDialogService } from '../../../../confirmation-dialog.service';
 import { EnvVarViewComponent } from '../../../../env-var-view/env-var-view.component';
 import { MetaCardMenuItem } from '../../../list-cards/meta-card/meta-card-base/meta-card.component';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-app-service-binding-card',

--- a/src/frontend/app/shared/components/list/list-types/app-variables/table-cell-edit-variable/table-cell-edit-variable.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-variables/table-cell-edit-variable/table-cell-edit-variable.component.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-access-missing-member https://github.com/mgechev/codelyzer/issues/191*/
 import { Component, OnInit } from '@angular/core';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-table-cell-edit-variable',

--- a/src/frontend/app/shared/components/list/list-types/app/card/card-app.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/card/card-app.component.ts
@@ -11,15 +11,14 @@ import {
   ApplicationStateService,
   CardStatus,
 } from '../../../../application-state/application-state.service';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom, CardCell } from '../../../list.types';
 
 @Component({
   selector: 'app-card-app',
   templateUrl: './card-app.component.html',
   styleUrls: ['./card-app.component.scss']
 })
-export class CardAppComponent extends TableCellCustom<APIResource> implements OnInit {
-
+export class CardAppComponent extends CardCell<APIResource> implements OnInit {
 
   @Input('row') row;
   applicationState$: Observable<ApplicationStateData>;
@@ -31,7 +30,6 @@ export class CardAppComponent extends TableCellCustom<APIResource> implements On
     private appStateService: ApplicationStateService
   ) {
     super();
-
   }
   ngOnInit() {
     const initState = this.appStateService.get(this.row.entity, null);

--- a/src/frontend/app/shared/components/list/list-types/app/table-cell-app-instances/table-cell-app-instances.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/table-cell-app-instances/table-cell-app-instances.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-table-cell-app-instances',

--- a/src/frontend/app/shared/components/list/list-types/app/table-cell-app-name/table-cell-app-name.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/table-cell-app-name/table-cell-app-name.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 import { BREADCRUMB_URL_PARAM } from '../../../../page-header/page-header.types';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';

--- a/src/frontend/app/shared/components/list/list-types/app/table-cell-app-status/table-cell-app-status.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/table-cell-app-status/table-cell-app-status.component.ts
@@ -7,7 +7,7 @@ import { ApplicationService } from '../../../../../../features/applications/appl
 import { AppState } from '../../../../../../store/app-state';
 import { PaginationMonitorFactory } from '../../../../../monitors/pagination-monitor.factory';
 import { ApplicationStateData, ApplicationStateService } from '../../../../application-state/application-state.service';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-table-cell-app-status',

--- a/src/frontend/app/shared/components/list/list-types/cf-buildpacks/cf-buildpack-card/cf-buildpack-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-buildpacks/cf-buildpack-card/cf-buildpack-card.component.ts
@@ -1,18 +1,12 @@
-import { Component, OnInit, Input } from '@angular/core';
-import { APIResource } from '../../../../../../store/types/api.types';
+import { Component } from '@angular/core';
+
 import { IBuildpack } from '../../../../../../core/cf-api.types';
+import { APIResource } from '../../../../../../store/types/api.types';
+import { CardCell } from '../../../list.types';
 
 @Component({
   selector: 'app-cf-buildpack-card',
   templateUrl: './cf-buildpack-card.component.html',
   styleUrls: ['./cf-buildpack-card.component.scss']
 })
-export class CfBuildpackCardComponent implements OnInit {
-
-  @Input('row') row: APIResource<IBuildpack>;
-  constructor() { }
-
-  ngOnInit() {
-  }
-
-}
+export class CfBuildpackCardComponent extends CardCell<APIResource<IBuildpack>> { }

--- a/src/frontend/app/shared/components/list/list-types/cf-orgs/cf-org-card/cf-org-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-orgs/cf-org-card/cf-org-card.component.ts
@@ -17,7 +17,7 @@ import { EndpointUser } from '../../../../../../store/types/endpoint.types';
 import { CfOrgSpaceDataService } from '../../../../../data-services/cf-org-space-service.service';
 import { CfUserService } from '../../../../../data-services/cf-user.service';
 import { MetaCardMenuItem } from '../../../list-cards/meta-card/meta-card-base/meta-card.component';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-cf-org-card',

--- a/src/frontend/app/shared/components/list/list-types/cf-orgs/cf-org-card/cf-org-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-orgs/cf-org-card/cf-org-card.component.ts
@@ -1,7 +1,7 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
-import { map, switchMap, tap, first } from 'rxjs/operators';
+import { map, switchMap, tap } from 'rxjs/operators';
 import { Subscription } from 'rxjs/Subscription';
 
 import { IApp, IOrganization } from '../../../../../../core/cf-api.types';
@@ -17,15 +17,14 @@ import { EndpointUser } from '../../../../../../store/types/endpoint.types';
 import { CfOrgSpaceDataService } from '../../../../../data-services/cf-org-space-service.service';
 import { CfUserService } from '../../../../../data-services/cf-user.service';
 import { MetaCardMenuItem } from '../../../list-cards/meta-card/meta-card-base/meta-card.component';
-import { TableCellCustom } from '../../../list.types';
+import { CardCell } from '../../../list.types';
 
 @Component({
   selector: 'app-cf-org-card',
   templateUrl: './cf-org-card.component.html',
   styleUrls: ['./cf-org-card.component.scss']
 })
-export class CfOrgCardComponent extends TableCellCustom<APIResource<IOrganization>>
-  implements OnInit, OnDestroy {
+export class CfOrgCardComponent extends CardCell<APIResource<IOrganization>> implements OnInit, OnDestroy {
   cardMenu: MetaCardMenuItem[];
   orgGuid: string;
   normalisedMemoryUsage: number;
@@ -38,8 +37,6 @@ export class CfOrgCardComponent extends TableCellCustom<APIResource<IOrganizatio
   appCount: number;
   userRolesInOrg: string;
   currentUser$: Observable<EndpointUser>;
-
-  @Input('row') row: APIResource<IOrganization>;
 
   constructor(
     private cfUserService: CfUserService,

--- a/src/frontend/app/shared/components/list/list-types/cf-security-groups/cf-security-groups-card/cf-security-groups-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-security-groups/cf-security-groups-card/cf-security-groups-card.component.ts
@@ -3,7 +3,7 @@ import { APIResource } from '../../../../../../store/types/api.types';
 import { ISecurityGroup, ISpace, IRule, IRuleType } from '../../../../../../core/cf-api.types';
 import { CloudFoundryEndpointService } from '../../../../../../features/cloud-foundry/services/cloud-foundry-endpoint.service';
 import { AppChip } from '../../../../chips/chips.component';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-cf-security-groups-card',

--- a/src/frontend/app/shared/components/list/list-types/cf-security-groups/cf-security-groups-card/cf-security-groups-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-security-groups/cf-security-groups-card/cf-security-groups-card.component.ts
@@ -1,16 +1,19 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+
+import { IRule, IRuleType, ISpace } from '../../../../../../core/cf-api.types';
+import {
+  CloudFoundryEndpointService,
+} from '../../../../../../features/cloud-foundry/services/cloud-foundry-endpoint.service';
 import { APIResource } from '../../../../../../store/types/api.types';
-import { ISecurityGroup, ISpace, IRule, IRuleType } from '../../../../../../core/cf-api.types';
-import { CloudFoundryEndpointService } from '../../../../../../features/cloud-foundry/services/cloud-foundry-endpoint.service';
 import { AppChip } from '../../../../chips/chips.component';
-import { TableCellCustom } from '../../../list.types';
+import { CardCell } from '../../../list.types';
 
 @Component({
   selector: 'app-cf-security-groups-card',
   templateUrl: './cf-security-groups-card.component.html',
   styleUrls: ['./cf-security-groups-card.component.scss']
 })
-export class CfSecurityGroupsCardComponent extends TableCellCustom<APIResource> implements OnInit {
+export class CfSecurityGroupsCardComponent extends CardCell<APIResource> implements OnInit {
 
   tags: AppChip<IRule>[] = [];
   private typeColors = {
@@ -18,7 +21,6 @@ export class CfSecurityGroupsCardComponent extends TableCellCustom<APIResource> 
     all: 'all-class',
     udp: 'udp-class'
   };
-  @Input('row') row: APIResource<ISecurityGroup>;
   constructor(
     private cfEndpointService: CloudFoundryEndpointService
   ) {

--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, Input } from '@angular/core';
 import { IService, IServiceExtra } from '../../../../../../core/cf-api-svc.types';
 import { APIResource } from '../../../../../../store/types/api.types';
 import { AppChip } from '../../../../chips/chips.component';
+import { CardCell } from '../../../list.types';
 interface Tag {
   value: string;
   key: APIResource<IService>;
@@ -11,13 +12,15 @@ interface Tag {
   templateUrl: './cf-service-card.component.html',
   styleUrls: ['./cf-service-card.component.scss']
 })
-export class CfServiceCardComponent implements OnInit {
+export class CfServiceCardComponent extends CardCell<APIResource<IService>> implements OnInit {
+
+  static columns = 2;
 
   @Input('row') row: APIResource<IService>;
   extraInfo: IServiceExtra;
   tags: AppChip<Tag>[] = [];
   constructor() {
-
+    super();
   }
 
   ngOnInit() {
@@ -36,7 +39,6 @@ export class CfServiceCardComponent implements OnInit {
     }
     return this.row.entity.label;
   }
-
 
 
   hasDocumentationUrl() {

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-instance-apps-attached/table-cell-service-instance-apps-attached.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-instance-apps-attached/table-cell-service-instance-apps-attached.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 import { StringLiteral } from 'typescript';
 import { selectEntity } from '../../../../../../store/selectors/api.selectors';
 import { ActivatedRoute } from '@angular/router';

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-instance-tags/table-cell-service-instance-tags.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-instance-tags/table-cell-service-instance-tags.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 import { APIResource } from '../../../../../../store/types/api.types';
 import { CfServiceInstance } from '../../../../../../store/types/service.types';
 import { AppChip } from '../../../../chips/chips.component';

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-name/table-cell-service-name.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-name/table-cell-service-name.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { APIResource } from '../../../../../../store/types/api.types';
 import { CfServiceInstance, CfService } from '../../../../../../store/types/service.types';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 import { Store } from '@ngrx/store';
 import { AppState } from '../../../../../../store/app-state';
 import { selectEntity } from '../../../../../../store/selectors/api.selectors';

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-plan/table-cell-service-plan.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-plan/table-cell-service-plan.component.ts
@@ -7,7 +7,7 @@ import { AppState } from '../../../../../../store/app-state';
 import { selectEntity } from '../../../../../../store/selectors/api.selectors';
 import { APIResource } from '../../../../../../store/types/api.types';
 import { CfServicePlan } from '../../../../../../store/types/service.types';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-table-cell-service-plan',

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces/cf-space-card/cf-space-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces/cf-space-card/cf-space-card.component.ts
@@ -20,15 +20,14 @@ import { EndpointUser } from '../../../../../../store/types/endpoint.types';
 import { CfOrgSpaceDataService } from '../../../../../data-services/cf-org-space-service.service';
 import { CfUserService } from '../../../../../data-services/cf-user.service';
 import { MetaCardMenuItem } from '../../../list-cards/meta-card/meta-card-base/meta-card.component';
-import { TableCellCustom } from '../../../list.types';
+import { CardCell } from '../../../list.types';
 
 @Component({
   selector: 'app-cf-space-card',
   templateUrl: './cf-space-card.component.html',
   styleUrls: ['./cf-space-card.component.scss']
 })
-export class CfSpaceCardComponent extends TableCellCustom<APIResource<ISpace>>
-  implements OnInit, OnDestroy {
+export class CfSpaceCardComponent extends CardCell<APIResource<ISpace>> implements OnInit, OnDestroy {
   cardMenu: MetaCardMenuItem[];
   spaceGuid: string;
   serviceInstancesCount: number;
@@ -45,8 +44,6 @@ export class CfSpaceCardComponent extends TableCellCustom<APIResource<ISpace>>
   appCount: number;
   userRolesInOrg: string;
   currentUser$: Observable<EndpointUser>;
-
-  @Input('row') row: APIResource<ISpace>;
 
   constructor(
     private cfUserService: CfUserService,

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces/cf-space-card/cf-space-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces/cf-space-card/cf-space-card.component.ts
@@ -20,7 +20,7 @@ import { EndpointUser } from '../../../../../../store/types/endpoint.types';
 import { CfOrgSpaceDataService } from '../../../../../data-services/cf-org-space-service.service';
 import { CfUserService } from '../../../../../data-services/cf-user.service';
 import { MetaCardMenuItem } from '../../../list-cards/meta-card/meta-card-base/meta-card.component';
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 @Component({
   selector: 'app-cf-space-card',

--- a/src/frontend/app/shared/components/list/list-types/cf-stacks/cf-stacks-card/cf-stacks-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-stacks/cf-stacks-card/cf-stacks-card.component.ts
@@ -1,18 +1,11 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component } from '@angular/core';
+
 import { APIResource } from '../../../../../../store/types/api.types';
-import { IStack } from '../../../../../../core/cf-api.types';
+import { CardCell } from '../../../list.types';
 
 @Component({
   selector: 'app-cf-stacks-card',
   templateUrl: './cf-stacks-card.component.html',
   styleUrls: ['./cf-stacks-card.component.scss']
 })
-export class CfStacksCardComponent implements OnInit {
-
-  @Input('row') row: APIResource<IStack>;
-  constructor() { }
-
-  ngOnInit() {
-  }
-
-}
+export class CfStacksCardComponent extends CardCell<APIResource> { }

--- a/src/frontend/app/shared/components/list/list-types/endpoint/table-cell-endpoint-status/table-cell-endpoint-status.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/endpoint/table-cell-endpoint-status/table-cell-endpoint-status.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import { TableCellCustom } from '../../../list-table/table-cell/table-cell-custom';
+import { TableCellCustom } from '../../../list.types';
 
 /* tslint:disable:no-access-missing-member https://github.com/mgechev/codelyzer/issues/191*/
 @Component({

--- a/src/frontend/app/shared/components/list/list.component.html
+++ b/src/frontend/app/shared/components/list/list.component.html
@@ -88,7 +88,7 @@
     </mat-card>
   </div>
   <div class="list-component__body">
-    <div class="list-component__body-inner">
+    <div class="list-component__body-inner" [hidden]="!(hasRows$ | async)">
       <div *ngIf="dataSource.isLoadingPage$ | async" class="list-component__blocker"></div>
       <app-cards *ngIf="(view$ | async) === 'cards'" #cards [dataSource]="dataSource" [component]="config.cardComponent" [hidden]="!(dataSource.isLoadingPage$ | async) && !(hasRows$ | async)"></app-cards>
       <app-table *ngIf="(view$ | async) === 'table'" #table [listConfig]="config" [paginationController]="paginationController" [columns]="columns" [text]="config.text" [enableFilter]="config.enableTextFilter" [fixedRowHeight]="config.tableFixedRowHeight" [hidden]="!(dataSource.isLoadingPage$ | async) && !(hasRows$ | async)">
@@ -98,24 +98,23 @@
       <mat-paginator #paginator [pageSizeOptions]="paginator.pageSizeOptions" [pageSize]="paginator.pageSizeOptions[0]">
       </mat-paginator>
     </mat-card>
+  </div>
+  <ng-template #defaultNoEntries>
+    <mat-card class="list-component__default-no-entries">
+      <mat-card-content>
+        <div class="no-rows">{{config.text?.noEntries || 'There are no entries.'}}</div>
+      </mat-card-content>
+    </mat-card>
+  </ng-template>
 
-    <ng-template #defaultNoEntries>
-      <mat-card class="list-component__empty">
-        <mat-card-content>
-          <div class="no-rows">{{config.text?.noEntries || 'There are no entries.'}}</div>
-        </mat-card-content>
-      </mat-card>
-    </ng-template>
-
-    <div [hidden]="(dataSource.isLoadingPage$ | async) || (hasRows$ | async)">
-      <ng-container *ngIf="(noRowsNotFiltering$ | async)">
-        <ng-container *ngTemplateOutlet="noEntries ? noEntries : defaultNoEntries">
-        </ng-container>
+  <div [hidden]="(dataSource.isLoadingPage$ | async) || (hasRows$ | async)" class="list-component__no-entries">
+    <ng-container *ngIf="(noRowsNotFiltering$ | async)">
+      <ng-container *ngTemplateOutlet="noEntries ? noEntries : defaultNoEntries">
       </ng-container>
-      <ng-container *ngIf="(noRowsHaveFilter$ | async)">
-        <ng-container *ngTemplateOutlet="noEntriesForCurrentFilter ? noEntriesForCurrentFilter : defaultNoEntries">
-        </ng-container>
+    </ng-container>
+    <ng-container *ngIf="(noRowsHaveFilter$ | async)">
+      <ng-container *ngTemplateOutlet="noEntriesForCurrentFilter ? noEntriesForCurrentFilter : defaultNoEntries">
       </ng-container>
-    </div>
+    </ng-container>
   </div>
 </div>

--- a/src/frontend/app/shared/components/list/list.component.scss
+++ b/src/frontend/app/shared/components/list/list.component.scss
@@ -1,4 +1,7 @@
 .list-component {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   *,
   .sort,
   .filter,
@@ -94,6 +97,18 @@
     padding: 4px;
     mat-paginator-container {
       padding: 0;
+    }
+  }
+  &__no-entries {
+    align-items: center;
+    display: flex;
+    flex: 1;
+    justify-content: center;
+  }
+  &__default-no-entries {
+    width: 100%;
+    mat-card-content {
+      padding-left: 10px;
     }
   }
 }

--- a/src/frontend/app/shared/components/list/list.types.ts
+++ b/src/frontend/app/shared/components/list/list.types.ts
@@ -1,14 +1,13 @@
+import { IListDataSource, RowState } from './data-sources-controllers/list-data-source-types';
 import { Observable } from 'rxjs/Observable';
 
-import { IListDataSource, RowState } from '../../data-sources-controllers/list-data-source-types';
-
-export enum CardSize {
-  LARGE = 'large'
-}
 export abstract class TableCellCustom<T> {
   dataSource: IListDataSource<T>;
   row: T;
   config: any;
   rowState: Observable<RowState>;
-  size?: CardSize;
+}
+
+export abstract class CardCell<T> extends TableCellCustom<T> {
+  static columns = 3;
 }


### PR DESCRIPTION
- Custom number of card columns in card list view
    - card can define number of columns
    - removed unused cards--large
    - all card lists are still 3 columns except top level cf and service
- Centre align custom 'no x' messages