### PR TITLE
Ensure we retain the result of missing inline data that was fetched during an api call

### DIFF
--- a/src/frontend/app/shared/components/cards/card-app-usage/card-app-usage.component.spec.ts
+++ b/src/frontend/app/shared/components/cards/card-app-usage/card-app-usage.component.spec.ts
@@ -1,22 +1,23 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { CardAppUsageComponent } from './card-app-usage.component';
-import { CardStatusComponent } from '../card-status/card-status.component';
-import { ApplicationStateComponent } from '../../application-state/application-state.component';
-import { ApplicationStateIconComponent } from '../../application-state/application-state-icon/application-state-icon.component';
-import { ApplicationStateIconPipe } from '../../application-state/application-state-icon/application-state-icon.pipe';
-import { CoreModule } from '../../../../core/core.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { createBasicStoreModule } from '../../../../test-framework/store-test-helper';
-import { ApplicationService } from '../../../../features/applications/application.service';
-import { ApplicationServiceMock } from '../../../../test-framework/application-service-helper';
-import { ApplicationStateService } from '../../application-state/application-state.service';
-import { CardAppStatusComponent } from '../card-app-status/card-app-status.component';
-import { TableCellAppStatusComponent } from '../../list/list-types/app/table-cell-app-status/table-cell-app-status.component';
-import { PercentagePipe } from '../../../pipes/percentage.pipe';
+
+import { CoreModule } from '../../../../core/core.module';
 import { UtilsService } from '../../../../core/utils.service';
 import { ApplicationMonitorService } from '../../../../features/applications/application-monitor.service';
+import { ApplicationService } from '../../../../features/applications/application.service';
+import { ApplicationServiceMock } from '../../../../test-framework/application-service-helper';
+import { createBasicStoreModule } from '../../../../test-framework/store-test-helper';
+import { PercentagePipe } from '../../../pipes/percentage.pipe';
+import {
+  ApplicationStateIconComponent,
+} from '../../application-state/application-state-icon/application-state-icon.component';
+import { ApplicationStateIconPipe } from '../../application-state/application-state-icon/application-state-icon.pipe';
+import { ApplicationStateComponent } from '../../application-state/application-state.component';
+import { ApplicationStateService } from '../../application-state/application-state.service';
 import { TableCellStatusDirective } from '../../list/list-table/table-cell-status.directive';
+import { CardAppStatusComponent } from '../card-app-status/card-app-status.component';
+import { CardStatusComponent } from '../card-status/card-status.component';
+import { CardAppUsageComponent } from './card-app-usage.component';
 
 describe('CardAppUsageComponent', () => {
   let component: CardAppUsageComponent;

--- a/src/frontend/app/store/helpers/reducer.helper.ts
+++ b/src/frontend/app/store/helpers/reducer.helper.ts
@@ -38,10 +38,14 @@ export const deepMergeState = (state, newState) => {
 };
 
 export function mergeEntity(baseEntity, newEntity) {
-  if (baseEntity && baseEntity.entity && baseEntity.metadata) {
+  if (baseEntity && baseEntity.entity) {
     return {
       entity: merge(baseEntity.entity, newEntity.entity),
-      metadata: merge(baseEntity.metadata, newEntity.metadata)
+      // Always apply the metadata regardless of whether it exists in the baseEntity or not
+      // (for cases where we fetch missing inline data of an entity before the entity exists, for example fetch orgs and their spaces..
+      // .. one org has over 50 spaces.. we fetch that list of spaces and apply it to a new org entity without metadata BEFORE we apply the
+      // main org and mark it as fetched)
+      metadata: merge(baseEntity.metadata || {}, newEntity.metadata)
     };
   } else {
     return merge(baseEntity, newEntity);

--- a/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer.helper.ts
+++ b/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer.helper.ts
@@ -154,7 +154,7 @@ function getObservables<T = any>(
     )
       .pipe(
         filter(([ent, pagination]) => {
-          return !!pagination && (isLocal && pagination.currentPage !== 1) || isPageReady(pagination);
+          return !!pagination && isPageReady(pagination);
         }),
         shareReplay(1),
         tap(([ent, pagination]) => {
@@ -190,7 +190,7 @@ function getPaginationCompareString(paginationEntity: PaginationEntityState) {
 }
 
 export function isPageReady(pagination: PaginationEntityState) {
-  return !!pagination && !!pagination.ids[pagination.currentPage];
+  return !!pagination && !!pagination.ids[pagination.currentPage] && !isFetchingPage(pagination);
 }
 
 export function isFetchingPage(pagination: PaginationEntityState): boolean {


### PR DESCRIPTION
* To reproduce have an org with 50+ spaces (so console will fetch an org which will not contain inline spaces)
* Visit the list orgs page directly
* We would..
  - Make the `fetch all orgs` call
  - Validate each org for the required spaces
  - Discover one of the orgs was missing it's spaces
  - Go out and fetch those spaces and save them in the store to an empty org entity
  - Store the result of the `fetch all orgs` call ... overwriting the existing org with spaces with the response from the original call without spaces
- This occurred because the original org did not contain a metadata property

- Also ensure we don't return a pagination page if it's busy (i.e. fetching inline params)