### PR TITLE
Stepper style tweaks

### DIFF
--- a/src/frontend/app/shared/components/stepper/stepper-form/stepper-form.component.scss
+++ b/src/frontend/app/shared/components/stepper/stepper-form/stepper-form.component.scss
@@ -1,6 +1,6 @@
 .steppers-form {
   display: flex;
-  width: 60%;
   flex-direction: column;
   height: 100%;
+  width: 60%;
 }

--- a/src/frontend/app/shared/components/stepper/steppers/steppers.component.html
+++ b/src/frontend/app/shared/components/stepper/steppers/steppers.component.html
@@ -1,7 +1,7 @@
 <div class="steppers__wrapper">
-  <div class="steppers" *ngIf="this.steps && this.steps.length">
+  <div class="steppers" *ngIf="steps && steps.length">
     <div class="steppers__inner">
-      <div class="steppers__headers">
+      <div class="steppers__headers" *ngIf="steps.length > 1">
         <div *ngFor="let step of steps; let i = index" (click)="setActive(i)" [ngClass]="{'steppers__header--active': step.active || step.complete}" class="steppers__header">
           <div class="steppers__header-inner" *ngIf="steps.length !== 1">
             <div class="steppers__header-icon">

--- a/src/frontend/app/shared/components/stepper/steppers/steppers.component.scss
+++ b/src/frontend/app/shared/components/stepper/steppers/steppers.component.scss
@@ -40,8 +40,10 @@
         content: none;
       }
     }
-    &--active .steppers__header-text {
-      font-weight: 600;
+    &--active {
+      .steppers__header-text {
+        font-weight: 600;
+      }
     }
     &-complete {
       font-size: 20px;
@@ -68,7 +70,7 @@
   &__contents {
     flex: 1;
     height: 100%;
-    margin: 30px 80px;
+    margin: 24px 48px;
   }
   &__wrapper {
     display: flex;
@@ -88,7 +90,7 @@
     display: flex;
     flex-direction: column;
     margin-top: 10px;
-    max-width: 60%;
+    max-width: 450px;
     mat-form-field {
       padding-top: 10px;
       width: 100%;


### PR DESCRIPTION
Couldn't reproduce issue we saw in the walk through (tiny input field width in stepper forms), however did tweak a few things.
- Fixed some scss linting
- Hide stepper header if there's only one step
- Improved visuals of form field widths
  - Reduce the margin so it looks better on smaller widths
  - Use px max-width for form instead of % so it looks better when shrunk
