### PR TITLE
Fixed issue where app entity's space value failed to denormalise

### DIFF
--- a/src/frontend/app/core/entity-service.ts
+++ b/src/frontend/app/core/entity-service.ts
@@ -85,7 +85,7 @@ export class EntityService<T = any> {
           false
         ));
       })
-    );
+      );
 
     this.waitForEntity$ = this.entityObs$.pipe(
       filter((ent) => {
@@ -149,28 +149,28 @@ export class EntityService<T = any> {
   poll(interval = 10000, updateKey = this.refreshKey) {
     return Observable.interval(interval)
       .pipe(
-        tag('poll'),
-        withLatestFrom(
-          this.entityMonitor.entity$,
-          this.entityMonitor.entityRequest$
-        ),
-        map(([poll, resource, requestState]) => ({
-          resource,
-          updatingSection: composeFn(
-            getUpdateSectionById(updateKey),
-            getEntityUpdateSections,
-            () => requestState
-          )
-        })),
-        tap(({ resource, updatingSection }) => {
-          if (!updatingSection || !updatingSection.busy) {
-            this.actionDispatch(updateKey);
-          }
-        }),
-        filter(({ resource, updatingSection }) => {
-          return !!updatingSection;
-        }),
-        share(),
+      tag('poll'),
+      withLatestFrom(
+        this.entityMonitor.entity$,
+        this.entityMonitor.entityRequest$
+      ),
+      map(([poll, resource, requestState]) => ({
+        resource,
+        updatingSection: composeFn(
+          getUpdateSectionById(updateKey),
+          getEntityUpdateSections,
+          () => requestState
+        )
+      })),
+      tap(({ resource, updatingSection }) => {
+        if (!updatingSection || !updatingSection.busy) {
+          this.actionDispatch(updateKey);
+        }
+      }),
+      filter(({ resource, updatingSection }) => {
+        return !!updatingSection;
+      }),
+      share(),
     );
   }
 

--- a/src/frontend/app/features/applications/application.service.ts
+++ b/src/frontend/app/features/applications/application.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
-import { filter, map, mergeMap, switchMap } from 'rxjs/operators';
+import { filter, map, switchMap } from 'rxjs/operators';
 
+import { IApp, IOrganization, ISpace } from '../../core/cf-api.types';
 import { EntityService } from '../../core/entity-service';
 import { EntityServiceFactory } from '../../core/entity-service-factory.service';
 import {
@@ -28,9 +29,9 @@ import {
   entityFactory,
   organizationSchemaKey,
   routeSchemaKey,
+  serviceBindingSchemaKey,
   spaceSchemaKey,
   stackSchemaKey,
-  serviceBindingSchemaKey,
 } from '../../store/helpers/entity-factory';
 import { createEntityRelationKey } from '../../store/helpers/entity-relations.types';
 import { ActionState, rootUpdatingKey } from '../../store/reducers/api-request-reducer/types';
@@ -49,8 +50,6 @@ import {
   EnvVarStratosProject,
 } from './application/application-tabs-base/tabs/build-tab/application-env-vars.service';
 import { getRoute, isTCPRoute } from './routes/routes.helper';
-import { IApp, IOrganization, ISpace } from '../../core/cf-api.types';
-import { IServiceBinding } from '../../core/cf-api-svc.types';
 
 export function createGetApplicationAction(guid: string, endpointGuid: string) {
   return new GetApplication(

--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-base/cloud-foundry-organization-base.component.ts
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-base/cloud-foundry-organization-base.component.ts
@@ -2,12 +2,12 @@ import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { first, map } from 'rxjs/operators';
 
+import { environment } from '../../../../../../environments/environment';
 import { IHeaderBreadcrumb } from '../../../../../shared/components/page-header/page-header.types';
 import { ISubHeaderTabs } from '../../../../../shared/components/page-subheader/page-subheader.types';
+import { getActiveRouteCfOrgSpaceProvider } from '../../../cf.helpers';
 import { CloudFoundryEndpointService } from '../../../services/cloud-foundry-endpoint.service';
 import { CloudFoundryOrganizationService } from '../../../services/cloud-foundry-organization.service';
-import { getActiveRouteCfOrgSpaceProvider } from '../../../cf.helpers';
-import { environment } from '../../../../../../environments/environment';
 
 @Component({
   selector: 'app-cloud-foundry-organization-base',
@@ -49,6 +49,7 @@ export class CloudFoundryOrganizationBaseComponent implements OnInit {
     this.isFetching$ = cfOrgService.org$.pipe(
       map(org => org.entityRequestInfo.fetching)
     );
+
     this.name$ = cfOrgService.org$.pipe(
       map(org => org.entity.entity.name),
       first()

--- a/src/frontend/app/shared/components/cards/card-app-usage/card-app-usage.component.spec.ts
+++ b/src/frontend/app/shared/components/cards/card-app-usage/card-app-usage.component.spec.ts
@@ -1,22 +1,23 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { CardAppUsageComponent } from './card-app-usage.component';
-import { CardStatusComponent } from '../card-status/card-status.component';
-import { ApplicationStateComponent } from '../../application-state/application-state.component';
-import { ApplicationStateIconComponent } from '../../application-state/application-state-icon/application-state-icon.component';
-import { ApplicationStateIconPipe } from '../../application-state/application-state-icon/application-state-icon.pipe';
-import { CoreModule } from '../../../../core/core.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { createBasicStoreModule } from '../../../../test-framework/store-test-helper';
-import { ApplicationService } from '../../../../features/applications/application.service';
-import { ApplicationServiceMock } from '../../../../test-framework/application-service-helper';
-import { ApplicationStateService } from '../../application-state/application-state.service';
-import { CardAppStatusComponent } from '../card-app-status/card-app-status.component';
-import { TableCellAppStatusComponent } from '../../list/list-types/app/table-cell-app-status/table-cell-app-status.component';
-import { PercentagePipe } from '../../../pipes/percentage.pipe';
+
+import { CoreModule } from '../../../../core/core.module';
 import { UtilsService } from '../../../../core/utils.service';
 import { ApplicationMonitorService } from '../../../../features/applications/application-monitor.service';
+import { ApplicationService } from '../../../../features/applications/application.service';
+import { ApplicationServiceMock } from '../../../../test-framework/application-service-helper';
+import { createBasicStoreModule } from '../../../../test-framework/store-test-helper';
+import { PercentagePipe } from '../../../pipes/percentage.pipe';
+import {
+  ApplicationStateIconComponent,
+} from '../../application-state/application-state-icon/application-state-icon.component';
+import { ApplicationStateIconPipe } from '../../application-state/application-state-icon/application-state-icon.pipe';
+import { ApplicationStateComponent } from '../../application-state/application-state.component';
+import { ApplicationStateService } from '../../application-state/application-state.service';
 import { TableCellStatusDirective } from '../../list/list-table/table-cell-status.directive';
+import { CardAppStatusComponent } from '../card-app-status/card-app-status.component';
+import { CardStatusComponent } from '../card-status/card-status.component';
+import { CardAppUsageComponent } from './card-app-usage.component';
 
 describe('CardAppUsageComponent', () => {
   let component: CardAppUsageComponent;

--- a/src/frontend/app/shared/components/list/list-types/app/cf-apps-data-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/cf-apps-data-source.ts
@@ -1,15 +1,20 @@
 import { Store } from '@ngrx/store';
 import { schema } from 'normalizr';
 
+import { getRowMetadata } from '../../../../../features/cloud-foundry/cf.helpers';
 import { GetAllApplications } from '../../../../../store/actions/application.actions';
 import { AppState } from '../../../../../store/app-state';
-import { applicationSchemaKey, entityFactory, spaceSchemaKey, routeSchemaKey } from '../../../../../store/helpers/entity-factory';
+import {
+  applicationSchemaKey,
+  entityFactory,
+  routeSchemaKey,
+  spaceSchemaKey,
+} from '../../../../../store/helpers/entity-factory';
+import { createEntityRelationKey } from '../../../../../store/helpers/entity-relations.types';
 import { APIResource } from '../../../../../store/types/api.types';
 import { PaginationEntityState } from '../../../../../store/types/pagination.types';
 import { ListDataSource } from '../../data-sources-controllers/list-data-source';
 import { IListConfig } from '../../list.component.types';
-import { createEntityRelationKey } from '../../../../../store/helpers/entity-relations.types';
-import { getRowMetadata } from '../../../../../features/cloud-foundry/cf.helpers';
 
 export class CfAppsDataSource extends ListDataSource<APIResource> {
 

--- a/src/frontend/app/shared/monitors/pagination-monitor.ts
+++ b/src/frontend/app/shared/monitors/pagination-monitor.ts
@@ -118,7 +118,7 @@ export class PaginationMonitor<T = any> {
         return page.length ? denormalize(page, [schema], allEntities).filter(ent => !!ent) : [];
       }),
       shareReplay(1)
-    );
+      );
   }
 
   private createErrorObservable(pagination$: Observable<PaginationEntityState>) {

--- a/src/frontend/app/store/actions/application.actions.ts
+++ b/src/frontend/app/store/actions/application.actions.ts
@@ -71,7 +71,7 @@ export class GetAllApplications extends CFStartAction implements PaginatedAction
     'order-direction': 'asc',
     'order-direction-field': GetAllApplications.sortField,
     page: 1,
-    'results-per-page': 50,
+    'results-per-page': 100,
   };
   flattenPagination = true;
 }

--- a/src/frontend/app/store/helpers/entity-factory.ts
+++ b/src/frontend/app/store/helpers/entity-factory.ts
@@ -213,9 +213,11 @@ const ApplicationEntitySchema = new EntitySchema(
     entity: {
       stack: StackSchema,
       space: new EntitySchema(spaceSchemaKey, {
-        ...coreSpaceSchemaParams,
-        routes: [RouteNoAppsSchema],
-        organization: OrganizationsWithoutSpaces,
+        entity: {
+          ...coreSpaceSchemaParams,
+          routes: [RouteNoAppsSchema],
+          organization: OrganizationsWithoutSpaces,
+        }
       }, { idAttribute: getAPIResourceGuid }),
       routes: [RouteNoAppsSchema],
       service_bindings: [ServiceBindingsSchema]

--- a/src/frontend/app/store/helpers/entity-factory.ts
+++ b/src/frontend/app/store/helpers/entity-factory.ts
@@ -98,25 +98,21 @@ entityCache[domainSchemaKey] = DomainSchema;
 const ServiceSchema = new EntitySchema(serviceSchemaKey, {}, { idAttribute: getAPIResourceGuid });
 entityCache[serviceSchemaKey] = ServiceSchema;
 
-const ApplicationWithoutRelationsSchema = new EntitySchema(applicationSchemaKey, {}, { idAttribute: getAPIResourceGuid });
+const SpaceQuotaSchema = new EntitySchema(spaceQuotaSchemaKey, {}, { idAttribute: getAPIResourceGuid });
+entityCache[spaceQuotaSchemaKey] = SpaceQuotaSchema;
+
 const ServiceBindingsSchema = new EntitySchema(serviceBindingSchemaKey, {
   entity: {
-    app: ApplicationWithoutRelationsSchema
+    app: new EntitySchema(applicationSchemaKey, {}, { idAttribute: getAPIResourceGuid })
   }
-}, {
-    idAttribute: getAPIResourceGuid
-  }
-);
+}, { idAttribute: getAPIResourceGuid });
 entityCache[serviceBindingSchemaKey] = ServiceBindingsSchema;
 
 const ServicePlanSchema = new EntitySchema(servicePlanSchemaKey, {
   entity: {
     service: ServiceSchema
   }
-}, {
-    idAttribute: getAPIResourceGuid
-  }
-);
+}, { idAttribute: getAPIResourceGuid });
 entityCache[servicePlanSchemaKey] = ServicePlanSchema;
 
 const ServiceInstancesSchema = new EntitySchema(serviceInstancesSchemaKey, {
@@ -125,24 +121,31 @@ const ServiceInstancesSchema = new EntitySchema(serviceInstancesSchemaKey, {
     service_plan: ServicePlanSchema,
     service_bindings: [ServiceBindingsSchema]
   }
-}, {
-    idAttribute: getAPIResourceGuid,
-  }
-);
+}, { idAttribute: getAPIResourceGuid });
 entityCache[serviceInstancesSchemaKey] = ServiceInstancesSchema;
 
 const BuildpackSchema = new EntitySchema(buildpackSchemaKey, {}, { idAttribute: getAPIResourceGuid });
 entityCache[buildpackSchemaKey] = BuildpackSchema;
 
-const RouteSchema = new EntitySchema(routeSchemaKey, {
+const coreRouteSchemaParams = {
   entity: {
-    apps: [ApplicationWithoutRelationsSchema],
     domain: DomainSchema
   }
-}, {
-    idAttribute: getAPIResourceGuid
-  });
+};
+const RouteSchema = new EntitySchema(routeSchemaKey, {
+  entity: {
+    ...coreRouteSchemaParams,
+    apps: [new EntitySchema(applicationSchemaKey, {}, { idAttribute: getAPIResourceGuid })],
+  }
+}, { idAttribute: getAPIResourceGuid });
 entityCache[routeSchemaKey] = RouteSchema;
+const RouteNoAppsSchema = new EntitySchema(routeSchemaKey, {
+  entity: {
+    ...coreRouteSchemaParams,
+  }
+}, { idAttribute: getAPIResourceGuid });
+entityCache[routeSchemaKey] = RouteSchema;
+
 
 const QuotaDefinitionSchema = new EntitySchema(quotaDefinitionSchemaKey, {}, { idAttribute: getAPIResourceGuid });
 entityCache[quotaDefinitionSchemaKey] = QuotaDefinitionSchema;
@@ -152,30 +155,22 @@ const ApplicationWithoutSpaceEntitySchema = new EntitySchema(
   {
     entity: {
       stack: StackSchema,
-      routes: [RouteSchema],
+      routes: [RouteNoAppsSchema],
       service_bindings: [ServiceBindingsSchema]
     }
-  },
-  {
-    idAttribute: getAPIResourceGuid
-  },
+  }, { idAttribute: getAPIResourceGuid },
 );
-entityCache[applicationSchemaKey] = ApplicationWithoutSpaceEntitySchema;
-
-const SpaceQuotaSchema = new EntitySchema(spaceQuotaSchemaKey, {}, { idAttribute: getAPIResourceGuid });
-entityCache[spaceQuotaSchemaKey] = SpaceQuotaSchema;
 
 const coreSpaceSchemaParams = {
-  apps: [ApplicationWithoutSpaceEntitySchema],
   routes: [RouteSchema],
   domains: [DomainSchema],
   space_quota_definition: SpaceQuotaSchema,
   service_instances: [ServiceInstancesSchema],
 };
-
 const SpaceSchema = new EntitySchema(spaceSchemaKey, {
   entity: {
-    ...coreSpaceSchemaParams
+    ...coreSpaceSchemaParams,
+    apps: [ApplicationWithoutSpaceEntitySchema],
   }
 }, {
     idAttribute: getAPIResourceGuid
@@ -185,32 +180,31 @@ entityCache[spaceSchemaKey] = SpaceSchema;
 const PrivateDomainsSchema = new EntitySchema(privateDomainsSchemaKey, {}, { idAttribute: getAPIResourceGuid });
 entityCache[privateDomainsSchemaKey] = PrivateDomainsSchema;
 
+const coreOrgSchemaParams = {
+  domains: [DomainSchema],
+  quota_definition: QuotaDefinitionSchema,
+  private_domains: [PrivateDomainsSchema]
+};
+const OrganizationsWithoutSpaces = new EntitySchema(organizationSchemaKey, {
+  entity: {
+    ...coreOrgSchemaParams,
+  }
+}, { idAttribute: getAPIResourceGuid });
 const OrganizationSchema = new EntitySchema(organizationSchemaKey, {
   entity: {
-    domains: [DomainSchema],
+    ...coreOrgSchemaParams,
     spaces: [SpaceSchema],
-    quota_definition: QuotaDefinitionSchema,
-    private_domains: [PrivateDomainsSchema]
   }
-}, {
-    idAttribute: getAPIResourceGuid
-  });
+}, { idAttribute: getAPIResourceGuid });
 entityCache[organizationSchemaKey] = OrganizationSchema;
 
 const SpaceWithOrgsEntitySchema = new EntitySchema(spaceSchemaKey, {
   entity: {
     ...coreSpaceSchemaParams,
     apps: [ApplicationWithoutSpaceEntitySchema],
-    routes: [RouteSchema],
-    organization: OrganizationSchema,
-    domains: [DomainSchema],
-    space_quota_definition: SpaceQuotaSchema,
-    service_instances: [ServiceInstancesSchema]
+    organization: OrganizationsWithoutSpaces,
   }
-}, {
-    idAttribute: getAPIResourceGuid
-  },
-  spaceWithOrgKey);
+}, { idAttribute: getAPIResourceGuid }, spaceWithOrgKey);
 entityCache[spaceWithOrgKey] = SpaceWithOrgsEntitySchema;
 
 const ApplicationEntitySchema = new EntitySchema(
@@ -218,15 +212,15 @@ const ApplicationEntitySchema = new EntitySchema(
   {
     entity: {
       stack: StackSchema,
-      space: SpaceWithOrgsEntitySchema,
-      routes: [RouteSchema],
+      space: new EntitySchema(spaceSchemaKey, {
+        ...coreSpaceSchemaParams,
+        routes: [RouteNoAppsSchema],
+        organization: OrganizationsWithoutSpaces,
+      }, { idAttribute: getAPIResourceGuid }),
+      routes: [RouteNoAppsSchema],
       service_bindings: [ServiceBindingsSchema]
     }
-  },
-  {
-    idAttribute: getAPIResourceGuid
-  }
-);
+  }, { idAttribute: getAPIResourceGuid });
 entityCache[applicationSchemaKey] = ApplicationEntitySchema;
 
 const EndpointSchema = new EntitySchema(endpointSchemaKey, {}, { idAttribute: 'guid' });
@@ -236,9 +230,7 @@ const SecurityGroupSchema = new EntitySchema(securityGroupSchemaKey, {
   entity: {
     spaces: [SpaceSchema]
   }
-}, {
-    idAttribute: getAPIResourceGuid
-  });
+}, { idAttribute: getAPIResourceGuid });
 entityCache[securityGroupSchemaKey] = SecurityGroupSchema;
 
 const FeatureFlagSchema = new EntitySchema(featureFlagSchemaKey, {}, { idAttribute: getAPIResourceGuid });
@@ -250,12 +242,8 @@ const OrganizationAuditedSchema = new EntitySchema(
   organizationSchemaKey, {}, { idAttribute: getAPIResourceGuid }, 'audited_organizations');
 const OrganizationManagedSchema = new EntitySchema(
   organizationSchemaKey, {}, { idAttribute: getAPIResourceGuid }, 'managed_organizations');
-const OrganizationBillingSchema = new EntitySchema(
-  organizationSchemaKey, {
-  }, {
-    idAttribute: getAPIResourceGuid
-  },
-  'billing_managed_organizations');
+const OrganizationBillingSchema = new EntitySchema(organizationSchemaKey, {},
+  { idAttribute: getAPIResourceGuid }, 'billing_managed_organizations');
 const SpaceUserSchema = new EntitySchema(spaceSchemaKey, {}, { idAttribute: getAPIResourceGuid }, 'users_spaces');
 const SpaceManagedSchema = new EntitySchema(spaceSchemaKey, {}, { idAttribute: getAPIResourceGuid }, 'managed_spaces');
 const SpaceAuditedSchema = new EntitySchema(spaceSchemaKey, {}, { idAttribute: getAPIResourceGuid }, 'audited_spaces');

--- a/src/frontend/app/store/helpers/reducer.helper.ts
+++ b/src/frontend/app/store/helpers/reducer.helper.ts
@@ -38,10 +38,14 @@ export const deepMergeState = (state, newState) => {
 };
 
 export function mergeEntity(baseEntity, newEntity) {
-  if (baseEntity && baseEntity.entity && baseEntity.metadata) {
+  if (baseEntity && baseEntity.entity) {
     return {
       entity: merge(baseEntity.entity, newEntity.entity),
-      metadata: merge(baseEntity.metadata, newEntity.metadata)
+      // Always apply the metadata regardless of whether it exists in the baseEntity or not
+      // (for cases where we fetch missing inline data of an entity before the entity exists, for example fetch orgs and their spaces..
+      // .. one org has over 50 spaces.. we fetch that list of spaces and apply it to a new org entity without metadata BEFORE we apply the
+      // main org and mark it as fetched)
+      metadata: merge(baseEntity.metadata || {}, newEntity.metadata)
     };
   } else {
     return merge(baseEntity, newEntity);

--- a/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer.helper.ts
+++ b/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer.helper.ts
@@ -154,7 +154,7 @@ function getObservables<T = any>(
     )
       .pipe(
         filter(([ent, pagination]) => {
-          return !!pagination && (isLocal && pagination.currentPage !== 1) || isPageReady(pagination);
+          return !!pagination && isPageReady(pagination);
         }),
         shareReplay(1),
         tap(([ent, pagination]) => {
@@ -190,7 +190,7 @@ function getPaginationCompareString(paginationEntity: PaginationEntityState) {
 }
 
 export function isPageReady(pagination: PaginationEntityState) {
-  return !!pagination && !!pagination.ids[pagination.currentPage];
+  return !!pagination && !!pagination.ids[pagination.currentPage] && !isFetchingPage(pagination);
 }
 
 export function isFetchingPage(pagination: PaginationEntityState): boolean {


### PR DESCRIPTION
Depends on #1827

- visit space apps page (from afresh or before hitting app wall)
- space entity would be fetched and contain a list of apps
- visit app wall
- all apps are fetched, stored and denormalised
- for those apps in the space previously fetched there was a circular reference with 
  - app --> space --> apps
- only became an issue when filtering by orgs (app's space entity was a guid instead of obj)