### PR TITLE
Fixed layout when we have an empty list

### DIFF
--- a/src/frontend/app/shared/components/list/list.component.scss
+++ b/src/frontend/app/shared/components/list/list.component.scss
@@ -1,7 +1,6 @@
 .list-component {
   display: flex;
   flex-direction: column;
-  height: 100%;
   position: relative;
   mat-progress-bar {
     position: absolute;


### PR DESCRIPTION
The "there are no entries" element is shown half way down the page. Removing height 100% to fix this. @richard-cox can you confirm this isn't going to mess with any other layout.