### PR TITLE
Reset Helm repository

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,6 +2,86 @@ apiVersion: v1
 entries:
   console:
   - apiVersion: v1
+    created: 2018-03-06T10:50:26.932728235Z
+    description: A Helm chart for deploying Stratos UI Console
+    digest: 12e246b9dc3a41b0f22a0c1738864f4d7b29cef21419ffe6d1d6128df94b4900
+    name: console
+    urls:
+    - https://github.com/SUSE/stratos-ui/releases/download/1.0.2/console-helm-chart-1.0.2.tgz
+    version: 1.0.2
+  - apiVersion: v1
+    created: 2018-01-09T11:48:55.233833731Z
+    description: A Helm chart for deploying Stratos UI Console
+    digest: 378df78adeebfad7d81b63a9f01afbb830c35cf948e3b662349e1d20a0972955
+    name: console
+    urls:
+    - https://github.com/SUSE/stratos-ui/releases/download/1.0.0/console-helm-chart-1.0.0.tgz
+    version: 1.0.0
+  - apiVersion: v1
+    created: 2017-12-08T13:21:38.611521378Z
+    description: A Helm chart for deploying Stratos UI Console
+    digest: 8e8994171cf7ba37c4b37564c8efa07f1fd66dda347900b592ebfaae5407bf3d
+    name: console
+    urls:
+    - https://github.com/SUSE/stratos-ui/releases/download/0.9.9/console-helm-chart-0.9.9.tgz
+    version: 0.9.9
+  - apiVersion: v1
+    created: 2017-11-23T16:31:10.781104928Z
+    description: A Helm chart for deploying Stratos UI Console
+    digest: 97bdf40f53053815016e223d49082ba16984b9b5a0a5a2d237ef45bb42183ad8
+    name: console
+    urls:
+    - https://github.com/SUSE/stratos-ui/releases/download/0.9.8/console-helm-chart-0.9.8.tgz
+    version: 0.9.8
+  - apiVersion: v1
+    created: 2017-11-09T11:58:41.085073375Z
+    description: A Helm chart for deploying Stratos UI Console
+    digest: 1a297cebb9bf8d34fe4d679203082fb89894d9b90583988fb0a1349a27dde920
+    name: console
+    urls:
+    - https://github.com/SUSE/stratos-ui/releases/download/0.9.7/console-helm-chart-0.9.7.tgz
+    version: 0.9.7
+  - apiVersion: v1
+    created: 2017-11-01T11:57:35.330202636Z
+    description: A Helm chart for deploying Stratos UI Console
+    digest: 08611ec5de41a71567a033c4975752f31ca895b26316592a75d6dc93c2968e5f
+    name: console
+    urls:
+    - https://github.com/SUSE/stratos-ui/releases/download/0.9.6/console-helm-chart-0.9.6.tgz
+    version: 0.9.6
+  - apiVersion: v1
+    created: 2017-09-21T14:17:00.259268006+01:00
+    description: A Helm chart for deploying Console
+    digest: c0aa7067eebd02cbf775f1adde1948ff679f3753f5d6bb7403798260ad8278d7
+    name: console
+    urls:
+    - https://github.com/suse/stratos-ui/releases/download/0.9.5/console-helm-chart-0.9.5.tgz
+    version: 0.9.5
+  - apiVersion: v1
+    created: 2017-08-21T16:05:19.606723792Z
+    description: A Helm chart for deploying Console
+    digest: 488b5011edcc0b22a28f4e70e576351cc6b9f0f34198fb366cc53cddc197c9d1
+    name: console
+    urls:
+    - https://github.com/suse/stratos-ui/releases/download/0.9.2/console-helm-chart-0.9.2.tgz
+    version: 0.9.2
+  - apiVersion: v1
+    created: 2017-08-01T10:54:22.706325757Z
+    description: A Helm chart for deploying Console
+    digest: 5c7c2769771d7648647ed33a9e7c326c95cf550cb165aa3144dc8f8062dc66bb
+    name: console
+    urls:
+    - https://github.com/suse/stratos-ui/releases/download/0.9.1/console-helm-chart-0.9.1.tgz
+    version: 0.9.1
+  - apiVersion: v1
+    created: 2017-07-27T13:08:56.409964314Z
+    description: A Helm chart for deploying Console
+    digest: e05d4dd12d3e518ce8d123480196008815988dc59fa3653ad4593042e92cc36b
+    name: console
+    urls:
+    - https://github.com/suse/stratos-ui/releases/download/0.9.0/console-helm-chart-0.9.0.tgz
+    version: 0.9.0
+  - apiVersion: v1
     created: 2018-04-06T15:16:08.588491124Z
     description: A Helm chart for deploying Stratos UI Console
     digest: 667358f35a2f8d9dc8024dbaf93a07026947f7f7d9449f9a79a846c8c68266a7


### PR DESCRIPTION
Due to a bug in the Dev releases pipeline, the helm repository was reset. This reverts the change