### PR TITLE
Service catalogue fixes

### DIFF
--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.ts
@@ -14,8 +14,6 @@ interface Tag {
 })
 export class CfServiceCardComponent extends CardCell<APIResource<IService>> implements OnInit {
 
-  static columns = 2;
-
   @Input('row') row: APIResource<IService>;
   extraInfo: IServiceExtra;
   tags: AppChip<Tag>[] = [];

--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-services-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-services-list-config.service.ts
@@ -15,6 +15,7 @@ import { createListFilterConfig } from '../../list.helper';
 import { CfServiceCardComponent } from './cf-service-card/cf-service-card.component';
 import { CfServicesDataSource } from './cf-services-data-source';
 import { ITableColumn } from '../../list-table/table.types';
+import { EndpointModel } from '../../../../../store/types/endpoint.types';
 
 @Injectable()
 export class CfServicesListConfigService implements IListConfig<APIResource> {
@@ -67,7 +68,10 @@ export class CfServicesListConfigService implements IListConfig<APIResource> {
       list$: this.store
         .select(endpointsRegisteredEntitiesSelector)
         .first()
-        .map(endpoints => Object.values(endpoints)),
+        .map(endpoints => {
+          return Object.values(endpoints)
+            .filter((endpoint: EndpointModel) => endpoint.connectionStatus === 'connected' && endpoint.cnsi_type === 'cf');
+        }),
       loading$: Observable.of(false),
       select: new BehaviorSubject(undefined)
     };


### PR DESCRIPTION
Show 2 columns instead of 1 + only show connected cf's in filter. 
Note - Could not reproduce filter failure seen in merge branch