### PR TITLE
Use custom Echo logger to hide query params

### DIFF
--- a/deploy/tools/restart_proxy.sh
+++ b/deploy/tools/restart_proxy.sh
@@ -23,19 +23,9 @@ docker-compose -f docker-compose.development.yml stop nginx
 docker-compose -f docker-compose.development.yml stop proxy
 docker-compose -f docker-compose.development.yml rm -f proxy
 
-./build_portal_proxy.sh
-ret=$?
-cd ../
-docker build . -f deploy/Dockerfile.bk.dev -t deploy_proxy
-cd ${DEPLOYDIR}
-ls
+docker-compose -f docker-compose.development.yml build proxy
 
-if [ ${ret} -eq 0 ]; then
-    # nginx also restarts the proxy
-    docker-compose -f docker-compose.development.yml up -d nginx
-else
-    echo -e "\033[0;31mOoops Build failed! Not restarting portal-proxy container until you fix the build!\033[0m"
-fi
+docker-compose -f docker-compose.development.yml up -d nginx
 
 popd
 

--- a/src/backend/app-core/main.go
+++ b/src/backend/app-core/main.go
@@ -442,7 +442,12 @@ func start(config interfaces.PortalConfig, p *portalProxy, addSetupMiddleware *s
 	if !isUpgrade {
 		e.Use(sessionCleanupMiddleware)
 	}
-	e.Use(middleware.Logger())
+	customLoggerConfig := middleware.LoggerConfig{
+		Format: `Request: [${time_rfc3339}] Remote-IP:"${remote_ip}" ` +
+			`Method:"${method}" Path:"${path}" Status:${status} Latency:${latency_human} ` +
+			`Bytes-In:${bytes_in} Bytes-Out:${bytes_out}` + "\n",
+	}
+	e.Use(middleware.LoggerWithConfig(customLoggerConfig))
 	e.Use(middleware.Recover())
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins:     config.AllowedOrigins,


### PR DESCRIPTION
Echo requests are now logged as:

```
INFO[Tue Apr 10 10:16:19 UTC 2018] Decrypting Auth Token                        
INFO[Tue Apr 10 10:16:19 UTC 2018] Decrypting Refresh Token                     
INFO[Tue Apr 10 10:16:19 UTC 2018] List                                         
INFO[Tue Apr 10 10:16:19 UTC 2018] NewPgsqlTokenRepository                      
INFO[Tue Apr 10 10:16:19 UTC 2018] findCNSIToken                                
INFO[Tue Apr 10 10:16:19 UTC 2018] Decrypting Auth Token                        
INFO[Tue Apr 10 10:16:19 UTC 2018] Decrypting Refresh Token                     
INFO[Tue Apr 10 10:16:19 UTC 2018] Find                                         
Request: [2018-04-10T10:16:19Z] Remote-IP:"172.18.0.1" Method:"GET" Path:"/v1/auth/session/verify" Status:200 Latency:5.567736ms Bytes-In:0 Bytes-Out:750
INFO[Tue Apr 10 10:16:19 UTC 2018] NewPostgresGooseDBVersionRepository   
```


Unfortunately the timestamp format isn't consistent between Logrus and Echo Logger Middleware since the latter only supports the RFC 3339 format (Echo v3 supports more).

+ Also updates the restart-proxy script