### PR TITLE
Ensure we add guid/cfGuid to items in an entity's arrays

### DIFF
--- a/src/frontend/app/store/types/api.types.ts
+++ b/src/frontend/app/store/types/api.types.ts
@@ -17,6 +17,9 @@ export interface APIResource<T = any> {
   metadata: APIResourceMetadata;
   entity: T;
 }
+export function instanceOfAPIResource(object: any): boolean {
+  return object && typeof object === 'object' && 'metadata' in object && 'entity' in object;
+}
 
 export interface APIResourceMetadata {
   created_at: string;


### PR DESCRIPTION
Bug was ..
- start fresh on cf summary page
- click on an app from the 'recent apps' list
- app summary page is reached but with no content

We now ensure that any objects within an entity gets stamped with a guid and cfGuid. Previously we failed to run through entity parameters that were arrays.