### PR TITLE
App Instance Fixes

### DIFF
--- a/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.ts
+++ b/src/frontend/app/features/applications/application/application-tabs-base/application-tabs-base.component.ts
@@ -11,7 +11,7 @@ import { ConfirmationDialogConfig } from '../../../../shared/components/confirma
 import { ConfirmationDialogService } from '../../../../shared/components/confirmation-dialog.service';
 import { IHeaderBreadcrumb } from '../../../../shared/components/page-header/page-header.types';
 import { ISubHeaderTabs } from '../../../../shared/components/page-subheader/page-subheader.types';
-import { GetAppStatsAction, GetAppSummaryAction } from '../../../../store/actions/app-metadata.actions';
+import { GetAppStatsAction, GetAppSummaryAction, AppMetadataTypes } from '../../../../store/actions/app-metadata.actions';
 import { DeleteApplication } from '../../../../store/actions/application.actions';
 import { ResetPagination } from '../../../../store/actions/pagination.actions';
 import { RouterNav } from '../../../../store/actions/router.actions';
@@ -178,7 +178,7 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
       first(),
       tap(appData => {
         this.confirmDialog.open(confirmConfig, () => {
-          this.applicationService.updateApplication({ state: requiredAppState }, [], appData.app.entity);
+          this.applicationService.updateApplication({ state: requiredAppState }, [AppMetadataTypes.STATS], appData.app.entity);
           this.pollEntityService(updateKey, requiredAppState).delay(1).subscribe(() => { }, () => { }, onSuccess);
         });
       })

--- a/src/frontend/app/shared/components/cards/card-app-instances/card-app-instances.component.ts
+++ b/src/frontend/app/shared/components/cards/card-app-instances/card-app-instances.component.ts
@@ -53,12 +53,14 @@ export class CardAppInstancesComponent implements OnInit, OnDestroy {
   private runningInstances$: Observable<number>;
 
   private isRunning = false;
+  private app: any;
 
   ngOnInit() {
     this.sub = this.applicationService.application$.subscribe(app => {
       if (app.app.entity) {
         this.currentCount = app.app.entity.instances;
         this.isRunning = app.app.entity.state === 'STARTED';
+        this.app = app.app.entity;
       }
     });
   }
@@ -92,7 +94,7 @@ export class CardAppInstancesComponent implements OnInit, OnDestroy {
 
   // Set instance count. Ask for confirmation if setting count to 0
   private setInstanceCount(value: number) {
-    const doUpdate = () => this.applicationService.updateApplication({ instances: value }, [AppMetadataTypes.STATS]);
+    const doUpdate = () => this.applicationService.updateApplication({ instances: value }, [AppMetadataTypes.STATS], this.app);
     if (value === 0) {
       this.confirmDialog.open(appInstanceScaleToZeroConfirmation, doUpdate);
     } else {

--- a/src/frontend/app/shared/components/cards/card-app-usage/card-app-usage.component.ts
+++ b/src/frontend/app/shared/components/cards/card-app-usage/card-app-usage.component.ts
@@ -20,11 +20,14 @@ export class CardAppUsageComponent implements OnInit {
 
   ngOnInit() {
     this.appData$ = Observable.combineLatest(
-      this.appMonitor.appMonitor$.startWith(null),
-      this.appService.application$.map(data => data.app.entity.state === 'STARTED'), (monitor, isRunning) => ({
-        monitor: monitor, isRunning: isRunning, status: !isRunning ? 'tentative' : monitor.status.usage
-      })
+      this.appMonitor.appMonitor$,
+      this.appService.application$.map(data => data.app.entity.state === 'STARTED'),
     ).pipe(
+      map(([monitor, isRunning]) => ({
+        monitor: monitor,
+        isRunning: isRunning,
+        status: !isRunning ? 'tentative' : monitor.status.usage
+      })),
       share()
     );
     this.status$ = this.appData$.pipe(

--- a/src/frontend/app/shared/components/list/data-sources-controllers/local-list-controller.ts
+++ b/src/frontend/app/shared/components/list/data-sources-controllers/local-list-controller.ts
@@ -54,6 +54,7 @@ export class LocalListController<T = any> {
       cleanPage$
     ).pipe(
       map(([paginationEntity, entities]) => {
+        this.pageSplitCache = null;
         if (!entities || !entities.length) {
           return [];
         }
@@ -62,7 +63,6 @@ export class LocalListController<T = any> {
             return fn(value, paginationEntity);
           }, entities);
         }
-        this.pageSplitCache = null;
         return entities;
       })
     );

--- a/src/frontend/app/shared/components/list/list.component.html
+++ b/src/frontend/app/shared/components/list/list.component.html
@@ -1,7 +1,7 @@
 <div class="list-component" [ngClass]="{'list-component__table': (view$ | async) === 'table', 'list-component__cards': (view$ | async) === 'cards' }">
   <mat-progress-bar color="primary" *ngIf="!(hasControls$ | async)" [hidden]="!(showProgressBar$ | async)" [mode]="'query'"></mat-progress-bar>
   <div class="list-component__header" [hidden]="!(hasControls$ | async)">
-    <mat-progress-bar color="primary" [hidden]="!(dataSource.isLoadingPage$ | async)" [mode]="'query'"></mat-progress-bar>
+    <mat-progress-bar color="primary" [hidden]="!(showProgressBar$ | async)" [mode]="'query'"></mat-progress-bar>
     <mat-card [ngClass]="{'list-component__header--selected': (dataSource.isSelecting$ | async), 'mat-header-row': (view$ | async) === 'table'}" class="list-component__header-card">
       <div class="list-component__header__left">
         <div class="list-component__header__left--text" *ngIf="!(isAddingOrSelecting$ | async) && config.text?.title">{{ config.text?.title }}</div>

--- a/src/frontend/app/shared/components/list/list.component.html
+++ b/src/frontend/app/shared/components/list/list.component.html
@@ -1,5 +1,5 @@
 <div class="list-component" [ngClass]="{'list-component__table': (view$ | async) === 'table', 'list-component__cards': (view$ | async) === 'cards' }">
-  <mat-progress-bar color="primary" *ngIf="!(hasControls$ | async)" [hidden]="!(dataSource.isLoadingPage$ | async)" [mode]="'query'"></mat-progress-bar>
+  <mat-progress-bar color="primary" *ngIf="!(hasControls$ | async)" [hidden]="!(showProgressBar$ | async)" [mode]="'query'"></mat-progress-bar>
   <div class="list-component__header" [hidden]="!(hasControls$ | async)">
     <mat-progress-bar color="primary" [hidden]="!(dataSource.isLoadingPage$ | async)" [mode]="'query'"></mat-progress-bar>
     <mat-card [ngClass]="{'list-component__header--selected': (dataSource.isSelecting$ | async), 'mat-header-row': (view$ | async) === 'table'}" class="list-component__header-card">
@@ -90,9 +90,8 @@
   </div>
   <div class="list-component__body">
     <div class="list-component__body-inner" [hidden]="!(hasRows$ | async)" [@list]="(pageState$ | async)">
-      <div *ngIf="dataSource.isLoadingPage$ | async" class="list-component__blocker"></div>
-      <app-cards *ngIf="(view$ | async) === 'cards'" #cards [dataSource]="dataSource" [component]="config.cardComponent" [hidden]="!(dataSource.isLoadingPage$ | async) && !(hasRows$ | async)"></app-cards>
-      <app-table *ngIf="(view$ | async) === 'table'" #table [listConfig]="config" [paginationController]="paginationController" [columns]="columns" [text]="config.text" [enableFilter]="config.enableTextFilter" [fixedRowHeight]="config.tableFixedRowHeight" [hidden]="!(dataSource.isLoadingPage$ | async) && !(hasRows$ | async)">
+      <app-cards *ngIf="(view$ | async) === 'cards'" #cards [dataSource]="dataSource" [component]="config.cardComponent" [hidden]="!(hasRows$ | async)"></app-cards>
+      <app-table *ngIf="(view$ | async) === 'table'" #table [listConfig]="config" [paginationController]="paginationController" [columns]="columns" [text]="config.text" [enableFilter]="config.enableTextFilter" [fixedRowHeight]="config.tableFixedRowHeight" [hidden]="!(hasRows$ | async)">
       </app-table>
     </div>
     <mat-card class="list-component__paginator" [hidden]="(hidePaginator$ | async)">
@@ -107,7 +106,7 @@
       </mat-card-content>
     </mat-card>
   </ng-template>
-  <div [hidden]="(dataSource.isLoadingPage$ | async) || (hasRows$ | async)" class="list-component__no-entries">
+  <div [hidden]="(showProgressBar$ | async) || (hasRows$ | async)" class="list-component__no-entries">
     <ng-container *ngIf="(noRowsNotFiltering$ | async)">
       <ng-container *ngTemplateOutlet="noEntries ? noEntries : defaultNoEntries">
       </ng-container>

--- a/src/frontend/app/shared/components/list/list.component.scss
+++ b/src/frontend/app/shared/components/list/list.component.scss
@@ -30,14 +30,6 @@
       border-top-right-radius: 0;
     }
   }
-  &__blocker {
-    bottom: 0;
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-    z-index: 999;
-  }
   &__body-inner {
     position: relative;
   }

--- a/src/frontend/app/shared/components/list/list.component.ts
+++ b/src/frontend/app/shared/components/list/list.component.ts
@@ -100,6 +100,7 @@ export class ListComponent<T> implements OnInit, OnDestroy, AfterViewInit {
   hasRowsOrIsFiltering$: Observable<boolean>;
   isFiltering$: Observable<boolean>;
   noRowsNotFiltering$: Observable<boolean>;
+  showProgressBar$: Observable<boolean>;
 
   // Observable which allows you to determine if the paginator control should be hidden
   hidePaginator$: Observable<boolean>;
@@ -342,6 +343,18 @@ export class ListComponent<T> implements OnInit, OnDestroy, AfterViewInit {
           return newVal;
         })
       );
+
+    let blockProgressBar = false;
+    this.showProgressBar$ = this.dataSource.isLoadingPage$.pipe(
+      startWith(false),
+      pairwise(),
+      map(([oldIsLoading, newIsLoading]) => {
+        if (oldIsLoading && !newIsLoading) {
+          blockProgressBar = true;
+        }
+        return newIsLoading && !blockProgressBar;
+      })
+    );
   }
 
   ngAfterViewInit() {

--- a/src/frontend/app/shared/monitors/pagination-monitor.ts
+++ b/src/frontend/app/shared/monitors/pagination-monitor.ts
@@ -135,7 +135,8 @@ export class PaginationMonitor<T = any> {
       map(pagination => {
         const currentPageRequest = this.getCurrentPageRequestInfo(pagination);
         return currentPageRequest.busy;
-      })
+      }),
+      distinctUntilChanged()
     );
   }
   // ### Initialization methods end.

--- a/src/frontend/app/store/reducers/app-stats-request.reducer.ts
+++ b/src/frontend/app/store/reducers/app-stats-request.reducer.ts
@@ -12,11 +12,15 @@ export function appStatsReducer(state: IRequestEntityTypeState<RequestInfoState>
   }
 }
 
-function createAppStat(appStat) {
-  return {
-    ...appStat,
+function deleteAppStat(newState, key) {
+  const state = newState[key];
+  if (!state) {
+    return;
+  }
+  newState[key] = {
+    ...state,
     deleting: {
-      ...appStat.deleting,
+      ...state.deleting,
       deleted: true,
     }
   };
@@ -31,17 +35,12 @@ function markAppStatsAsDeleted(state: IRequestEntityTypeState<RequestInfoState>,
     return state;
   }
   const newState = { ...state };
-  const baseState = newState[action.guid];
-  if (baseState) {
-    newState[action.guid] = createAppStat(baseState);
-  }
+  // Delete root stat
+  deleteAppStat(newState, action.guid);
+  // Delete each instance stat
   const instances = action.existingApplication.instances || 0;
   for (let i = 0; i < instances; i++) {
-    const appStat = newState[action.guid + '-' + i];
-    if (!appStat) {
-      continue;
-    }
-    newState[action.guid + '-' + i] = createAppStat(appStat);
+    deleteAppStat(newState, action.guid + '-' + i);
   }
   return newState;
 }


### PR DESCRIPTION
- Make a request to update stats on app start/stop
- Mark all stale stats as deleted (when app has zero instance or was stopped)
- Clear the pageSplitCache when there are no entities
- Only show the list progres bar when the list if first shown
- Don't hide the app cards/table when loading (causes blip)

Solves #1962 and #1909