### PR TITLE
Fixes for a few small UX issues

### DIFF
--- a/src/frontend/app/features/applications/ssh-application/ssh-application.component.html
+++ b/src/frontend/app/features/applications/ssh-application/ssh-application.component.html
@@ -2,13 +2,13 @@
   <h1>Application SSH ({{ (applicationService.app$ | async)?.entity?.entity.name }} #{{ instanceId }})</h1>
   <div class="page-header-right">
     <span>
-      <button mat-icon-button name="stop" *ngIf="sshViewer.isConnected" (click)="sshViewer.disconnect()" [disabled]="sshViewer.attemptingConnection">
+      <button mat-icon-button matTooltip="Disconnect" name="stop" *ngIf="sshViewer.isConnected" (click)="sshViewer.disconnect()" [disabled]="sshViewer.attemptingConnection">
         <mat-icon>stop</mat-icon>
       </button>
-      <button mat-icon-button name="start" *ngIf="!sshViewer.isConnected" (click)="sshViewer.reconnect()" [disabled]="sshViewer.attemptingConnection">
+      <button mat-icon-button matTooltip="Connect" name="start" *ngIf="!sshViewer.isConnected" (click)="sshViewer.reconnect()" [disabled]="sshViewer.attemptingConnection">
         <mat-icon>play_arrow</mat-icon>
       </button>
-      <button mat-icon-button [routerLink]="appInstanceLink">
+      <button mat-icon-button matTooltip="Back to App" [routerLink]="appInstanceLink">
         <mat-icon>close</mat-icon>
       </button>
     </span>

--- a/src/frontend/app/shared/components/dialog-confirm/dialog-confirm.component.scss
+++ b/src/frontend/app/shared/components/dialog-confirm/dialog-confirm.component.scss
@@ -1,6 +1,7 @@
 .confirm-dialog {
   &__actions {
     justify-content: flex-end;
+    margin-top: 24px;
   }
   &__header {
     display: flex;

--- a/src/frontend/app/shared/components/list/list.component.scss
+++ b/src/frontend/app/shared/components/list/list.component.scss
@@ -65,6 +65,10 @@
         }
       }
     }
+    &__right {
+      flex: 1;
+      justify-content: flex-end;
+    }
     &__left {
       flex: 1;
       &--text {

--- a/src/frontend/app/shared/components/ssh-viewer/ssh-viewer.component.theme.scss
+++ b/src/frontend/app/shared/components/ssh-viewer/ssh-viewer.component.theme.scss
@@ -9,7 +9,7 @@
 
   .ssh-viewer {
 
-    .ssh-terminal {
+    .terminal {
       background-color: $ssh-background;
       border: 2px solid $ssh-background;
     }


### PR DESCRIPTION
This PR fixes:

- App Wall - the panel at the top now wraps better on smaller screens - the right-hand set of controls will stay aligned to the right when it splits, rather than shifting to the left as it currently does.
- Added 24px margin above actions in confirmation dialog, as per Material Design spec - see: https://material.io/guidelines/components/dialogs.html#dialogs-specs
- Fixed black border on SSH terminal
- Added tooltips to the SSH actions