### PR TITLE
Fix exception thrown when polling on app summary

### DIFF
--- a/src/frontend/app/shared/components/list/list-types/cf-security-groups/cf-security-groups-card/cf-security-groups-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-security-groups/cf-security-groups-card/cf-security-groups-card.component.ts
@@ -30,9 +30,9 @@ export class CfSecurityGroupsCardComponent extends CardCell<APIResource> impleme
   ngOnInit() {
     this.row.entity.rules.forEach(t => {
       this.tags.push({
-        value: `${t.protocol} ${this.getRuleString(t)}`,
+        value: `${t.entity.protocol} ${this.getRuleString(t.entity)}`,
         key: t,
-        color: this.typeColors[t.protocol]
+        color: this.typeColors[t.entity.protocol]
       });
     });
 

--- a/src/frontend/app/store/effects/api.effects.ts
+++ b/src/frontend/app/store/effects/api.effects.ts
@@ -111,7 +111,7 @@ export class APIEffect {
         )];
       }),
     ).catch(errObservable => {
-      this.logger.warn(`API request process failed`, errObservable.error);
+      this.logger.warn(`API request process failed`, errObservable.error || errObservable);
       return [
         new APISuccessOrFailedAction(actionClone.actions[2], actionClone),
         new WrapperRequestActionFailed(
@@ -140,9 +140,9 @@ export class APIEffect {
     Object.keys(result.entity).forEach(resourceKey => {
       const nestedResource = result.entity[resourceKey];
       if (instanceOfAPIResource(nestedResource)) {
-        resource.entity[resourceKey] = this.completeResourceEntity(nestedResource, cfGuid, nestedResource.metadata.guid);
+        result.entity[resourceKey] = this.completeResourceEntity(nestedResource, cfGuid, nestedResource.metadata.guid);
       } else if (Array.isArray(nestedResource)) {
-        resource.entity[resourceKey] = nestedResource.map(nested => {
+        result.entity[resourceKey] = nestedResource.map(nested => {
           return nested && typeof nested === 'object'
             ? this.completeResourceEntity(nested, cfGuid, nested.metadata ? nested.metadata.guid : guid + '-' + resourceKey)
             : nested;


### PR DESCRIPTION
- We were setting a property on the original non-massaged resource
- Now we set the property correctly on the new `resource` with it's possibly new `entity`
- Also provide better feedback in logging
