### PR TITLE
Fix for cf/org/space filters in production mode

### DIFF
--- a/src/frontend/app/shared/components/list/list.component.ts
+++ b/src/frontend/app/shared/components/list/list.component.ts
@@ -240,7 +240,7 @@ export class ListComponent<T> implements OnInit, OnDestroy, AfterViewInit {
 
     const filterStoreToWidget = this.paginationController.filter$.do((filter: ListFilter) => {
       this.filterString = filter.string;
-      this.multiFilters = filter.items;
+      this.multiFilters = { ...filter.items };
     });
 
     // Multi filters (e.g. cf/org/space)


### PR DESCRIPTION
- Change of store state occurred outside of normal flow
- Resulted in code thinking the store already had the change, so no action was dispatched
- storeFreeze might have missed this due to the change occurring in html
- Includes fix for #2001
