### PR TITLE
Org/Space delete/create/edit fixes

### DIFF
--- a/src/frontend/app/core/button-blur-on-click.directive.spec.ts
+++ b/src/frontend/app/core/button-blur-on-click.directive.spec.ts
@@ -13,7 +13,7 @@ class TestButtonComponent {
 class MockElementRef { }
 class MockRenderer { }
 
-fdescribe('ButtonBlurOnClickDirective', () => {
+describe('ButtonBlurOnClickDirective', () => {
 
   let component: TestButtonComponent;
   let fixture: ComponentFixture<TestButtonComponent>;

--- a/src/frontend/app/features/cloud-foundry/add-organization/create-organization-step/create-organization-step.component.html
+++ b/src/frontend/app/features/cloud-foundry/add-organization/create-organization-step/create-organization-step.component.html
@@ -2,8 +2,8 @@
   <div>Specify the name of the new organization</div>
   <form [formGroup]="addOrg" class="stepper-form">
     <mat-form-field>
-      <input matInput formControlName="orgName" [(ngModel)]="orgName" placeholder="Organization Name" required>
-      <mat-error *ngIf="!validate()">
+      <input matInput formControlName="orgName" placeholder="Organization Name" required>
+      <mat-error *ngIf="orgName.hasError('nameTaken')">
         An organization with this name already exists. Please enter a different one.
       </mat-error>
     </mat-form-field>

--- a/src/frontend/app/features/cloud-foundry/add-organization/create-organization-step/create-organization-step.component.ts
+++ b/src/frontend/app/features/cloud-foundry/add-organization/create-organization-step/create-organization-step.component.ts
@@ -32,7 +32,8 @@ export class CreateOrganizationStepComponent implements OnInit, OnDestroy {
   orgs$: Observable<APIResource<IOrganization>[]>;
   cfUrl: string;
   addOrg: FormGroup;
-  orgName: string;
+
+  get orgName(): any { return this.addOrg ? this.addOrg.get('orgName') : { value: '' }; }
 
   constructor(
     private store: Store<AppState>,
@@ -68,19 +69,11 @@ export class CreateOrganizationStepComponent implements OnInit, OnDestroy {
   }
 
   nameTakenValidator = (): ValidatorFn => {
-    return (formField: AbstractControl): { [key: string]: any } => {
-      const nameValid = this.validate(formField.value);
-      return !nameValid ? { 'nameTaken': { value: formField.value } } : null;
-    };
+    return (formField: AbstractControl): { [key: string]: any } =>
+      !this.validate(formField.value) ? { 'nameTaken': { value: formField.value } } : null;
   }
 
-  validate = (value: string = null) => {
-    const currValue = this.addOrg && this.addOrg.value['orgName'];
-    if (this.allOrgs) {
-      return this.allOrgs.indexOf(value ? value : this.orgName) === -1;
-    }
-    return true;
-  }
+  validate = (value: string = null) => this.allOrgs ? this.allOrgs.indexOf(value || this.orgName.value) === -1 : true;
 
   submit = () => {
     const orgName = this.addOrg.value['orgName'];
@@ -107,7 +100,7 @@ export class CreateOrganizationStepComponent implements OnInit, OnDestroy {
     'Failed to create organization! Please select a different name and try again!',
     'Dismiss'
   )
-  ngOnDestroy(): void {
+  ngOnDestroy() {
     this.orgSubscription.unsubscribe();
     if (this.submitSubscription) {
       this.submitSubscription.unsubscribe();

--- a/src/frontend/app/features/cloud-foundry/add-space/create-space-step/create-space-step.component.html
+++ b/src/frontend/app/features/cloud-foundry/add-space/create-space-step/create-space-step.component.html
@@ -3,7 +3,7 @@
   <form [formGroup]="createSpaceForm" class="stepper-form">
     <mat-form-field>
       <input matInput formControlName="spaceName" placeholder="Space Name" required>
-      <mat-error *ngIf="!validate()">
+      <mat-error *ngIf="spaceName.hasError('spaceNameTaken')">
         A space with this name already exists. Please enter a different one.
       </mat-error>
     </mat-form-field>

--- a/src/frontend/app/features/cloud-foundry/add-space/create-space-step/create-space-step.component.ts
+++ b/src/frontend/app/features/cloud-foundry/add-space/create-space-step/create-space-step.component.ts
@@ -23,6 +23,7 @@ export class CreateSpaceStepComponent extends AddEditSpaceStepBase implements On
 
   cfUrl: string;
   createSpaceForm: FormGroup;
+  get spaceName(): any { return this.createSpaceForm ? this.createSpaceForm.get('spaceName') : { value: '' }; }
 
   constructor(
     store: Store<AppState>,
@@ -40,19 +41,12 @@ export class CreateSpaceStepComponent extends AddEditSpaceStepBase implements On
     });
   }
 
-  validate = (spaceName: string = null) => {
-    const currValue = spaceName ? spaceName : this.createSpaceForm && this.createSpaceForm.value['spaceName'];
-    if (this.allSpacesInOrg) {
-      return this.allSpacesInOrg.indexOf(currValue) === -1;
-    }
-    return true;
-  }
+  validate = (spaceName: string = null) =>
+    this.allSpacesInOrg ? this.allSpacesInOrg.indexOf(spaceName || this.spaceName.value) === -1 : true
 
   spaceNameTakenValidator = (): ValidatorFn => {
-    return (formField: AbstractControl): { [key: string]: any } => {
-      const nameInvalid = this.validate();
-      return nameInvalid ? { 'spaceNameTaken': { value: formField.value } } : null;
-    };
+    return (formField: AbstractControl): { [key: string]: any } =>
+      !this.validate(formField.value) ? { 'spaceNameTaken': { value: formField.value } } : null;
   }
 
   submit = () => {
@@ -71,7 +65,7 @@ export class CreateSpaceStepComponent extends AddEditSpaceStepBase implements On
     return Observable.of({ success: true });
   }
 
-  ngOnDestroy(): void {
+  ngOnDestroy() {
     this.destroy();
   }
 }

--- a/src/frontend/app/store/actions/organization.actions.ts
+++ b/src/frontend/app/store/actions/organization.actions.ts
@@ -67,7 +67,7 @@ export class GetAllOrganizationSpaces extends CFStartAction implements Paginated
   flattenPagination = true;
   initialParams = {
     'results-per-page': 100,
-    'order-direction': 'asc',
+    'order-direction': 'desc',
     'order-direction-field': 'name'
   };
   parentGuid: string;
@@ -118,6 +118,7 @@ export class DeleteOrganization extends CFStartAction implements ICFAction {
   entity = [entityFactory(organizationSchemaKey)];
   entityKey = organizationSchemaKey;
   options: RequestOptions;
+  removeEntityOnDelete = true;
 }
 
 export class CreateOrganization extends CFStartAction implements ICFAction {

--- a/src/frontend/app/store/actions/space.actions.ts
+++ b/src/frontend/app/store/actions/space.actions.ts
@@ -162,6 +162,7 @@ export class DeleteSpace extends BaseSpaceAction {
     this.options.params.append('async', 'false');
   }
   actions = [DELETE_SPACE, DELETE_SPACE_SUCCESS, DELETE_SPACE_FAILED];
+  removeEntityOnDelete = true;
 }
 
 export class CreateSpace extends BaseSpaceAction {

--- a/src/frontend/app/store/reducers/organization-space.reducer.ts
+++ b/src/frontend/app/store/reducers/organization-space.reducer.ts
@@ -17,10 +17,16 @@ function deleteOrgSpaces(state: APIResource, orgGuid: string) {
   if (!orgGuid) {
     return state;
   }
-  const oldEntities = Object.values(state);
+
+  const orgGuids = Object.keys(state);
+  if (orgGuids.indexOf(orgGuid) === -1) {
+    return state;
+  }
+
   const entities = {};
-  oldEntities.forEach(org => {
-    if (org.metadata.guid === orgGuid) {
+  orgGuids.forEach(currentGuid => {
+    const org = state[currentGuid];
+    if (currentGuid === orgGuid) {
       const newOrg = {
         ...org,
         entity: {
@@ -28,9 +34,9 @@ function deleteOrgSpaces(state: APIResource, orgGuid: string) {
           spaces: null
         }
       };
-      entities[org.metadata.guid] = newOrg;
+      entities[currentGuid] = newOrg;
     } else {
-      entities[org.metadata.guid] = org;
+      entities[currentGuid] = org;
     }
   });
   return entities;

--- a/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-clear-pagination-of-entity.ts
+++ b/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-clear-pagination-of-entity.ts
@@ -19,18 +19,20 @@ export function paginationClearOfEntity(state: PaginationState, action) {
         const index = page.indexOf(guid);
         if (index >= 0) {
           // Recreate the pagination section with new values
-          const newEntityPaginationState = {
+          const newEntityPagState = {
             ...entityPaginationState,
             ids: { ...entityPaginationState.ids },
             clientPagination: {
               ...entityPaginationState.clientPagination
             }
           };
-          newEntityPaginationState.ids[pageKey] = [...newEntityPaginationState.ids[pageKey]];
-          newEntityPaginationState.ids[pageKey].splice(index, 1);
-          newEntityPaginationState.totalResults--;
-          newEntityPaginationState.clientPagination.totalResults--;
-          newEntityState[key] = newEntityPaginationState;
+          newEntityPagState.ids[pageKey] = [...newEntityPagState.ids[pageKey]];
+          newEntityPagState.ids[pageKey].splice(index, 1);
+          newEntityPagState.totalResults--;
+          const clientPag = newEntityPagState.clientPagination;
+          clientPag.totalResults--;
+          clientPag.currentPage = 1;
+          newEntityState[key] = newEntityPagState;
         }
       });
     });

--- a/src/frontend/app/store/types/request.types.ts
+++ b/src/frontend/app/store/types/request.types.ts
@@ -38,8 +38,11 @@ export interface IRequestAction extends RequestAction {
   // For single entity requests
   guid?: string;
   entityLocation?: RequestEntityLocation;
-  // For delete requests we clear the pagination sections (include all pages) of all list matching the same entity type. In some cases,
-  // like local lists, we want to immediately remove that entry instead of clearing the table and refetching all data. This flag allows that
+  /**
+   * For delete requests we clear the pagination sections (include all pages) of all list matching the same entity type. In some cases,
+   * like local lists, we want to immediately remove that entry instead of clearing the table and refetching all data. This flag allows that
+   *
+   */
   removeEntityOnDelete?: boolean;
 }
 


### PR DESCRIPTION
- Deletion of more than one org/space should now show in it's list
  - Switched delete of org/space to only clear the entity rather than all of type (removeEntityOnDelete)
  - The original issue of not dispatching the list action after the pagination is reset still exists
  - The follow on issue of multiple subscribers passing the same code still exists
- Fixed an issue where clearing an entity after delete would leave the list borked if the entity was alone on the last page
- Fixed an issue where a partially populated entity could fail the removal of it's org due to missing a guid
- Fixed default sort order of org spaces
- Tidied up add/edit org + space (field should no longer show invalid on submit)
