### PR TITLE
Small ux fixes

### DIFF
--- a/src/frontend/app/features/applications/application.service.ts
+++ b/src/frontend/app/features/applications/application.service.ts
@@ -134,6 +134,7 @@ export class ApplicationService {
   applicationStratProject$: Observable<EnvVarStratosProject>;
   applicationState$: Observable<ApplicationStateData>;
   applicationUrl$: Observable<string>;
+  applicationRunning$: Observable<boolean>;
 
   /**
    * Fetch the current state of the app (given it's instances) as an object ready
@@ -246,6 +247,10 @@ export class ApplicationService {
     this.applicationStratProject$ = this.appEnvVars.entities$.map(applicationEnvVars => {
       return this.appEnvVarsService.FetchStratosProject(applicationEnvVars[0].entity);
     }).publishReplay(1).refCount();
+
+    this.applicationRunning$ = this.application$.pipe(
+      map(app => app ? app.app.entity.state === 'STARTED' : false)
+    );
 
   }
 

--- a/src/frontend/app/features/applications/create-application/create-application-step2/create-application-step2.component.html
+++ b/src/frontend/app/features/applications/create-application/create-application-step2/create-application-step2.component.html
@@ -6,7 +6,7 @@
       <mat-error *ngIf="form.controls.appName?.hasError('appNameTaken')">
         This name has been taken, please try another.
       </mat-error>
-      <div class="inline-icon inline-icon__form">
+      <div *ngIf="!form.controls.appName?.hasError('required')" class="inline-icon inline-icon__form">
         <app-stateful-icon [state]="appNameChecking.status"></app-stateful-icon>
       </div>
     </mat-form-field>

--- a/src/frontend/app/features/applications/create-application/create-application-step3/create-application-step3.component.html
+++ b/src/frontend/app/features/applications/create-application/create-application-step3/create-application-step3.component.html
@@ -1,13 +1,13 @@
 <b>Create a route</b>
 <form novalidate #form="ngForm" class="stepper-form">
   <mat-form-field>
-    <mat-select placeholder="Domain" ngModel name="domain">
-      <mat-option *ngFor="let domain of (domains | async)" [value]="domain">
+    <mat-select placeholder="Domain" ngModel name="domain" [(ngModel)]="selectedDomainGuid">
+      <mat-option *ngFor="let domain of (domains$ | async)" [value]="domain.entity.guid">
         <span>{{ domain.entity.name }}</span>
       </mat-option>
     </mat-select>
   </mat-form-field>
   <mat-form-field>
-    <input [disabled]="!form.controls['domain']?.value" [(ngModel)]="hostName" matInput placeholder="Host" name="hostName">
+    <input required [disabled]="!form.controls['domain']?.value" [(ngModel)]="hostName" matInput placeholder="Host" name="hostName">
   </mat-form-field>
 </form>

--- a/src/frontend/app/features/applications/create-application/create-application-step3/create-application-step3.component.html
+++ b/src/frontend/app/features/applications/create-application/create-application-step3/create-application-step3.component.html
@@ -1,7 +1,7 @@
 <b>Create a route</b>
 <form novalidate #form="ngForm" class="stepper-form">
   <mat-form-field>
-    <mat-select placeholder="Domain" ngModel name="domain" [(ngModel)]="selectedDomainGuid">
+    <mat-select placeholder="Domain" name="domain" [(ngModel)]="selectedDomainGuid">
       <mat-option *ngFor="let domain of (domains$ | async)" [value]="domain.entity.guid">
         <span>{{ domain.entity.name }}</span>
       </mat-option>

--- a/src/frontend/app/features/applications/create-application/create-application.component.html
+++ b/src/frontend/app/features/applications/create-application/create-application.component.html
@@ -8,7 +8,7 @@
   <app-step title="Name" [valid]="step2.validate | async" [onNext]="step2.onNext" [onEnter]="step2.onEnter">
     <app-create-application-step2 #step2></app-create-application-step2>
   </app-step>
-  <app-step [title]="'Create Route'" [onNext]="step3.onNext">
+  <app-step [title]="'Create Route'" [valid]="step3.validate()" [onNext]="step3.onNext">
     <app-create-application-step3 #step3></app-create-application-step3>
   </app-step>
 </app-steppers>

--- a/src/frontend/app/features/applications/ssh-application/ssh-application.component.html
+++ b/src/frontend/app/features/applications/ssh-application/ssh-application.component.html
@@ -1,5 +1,5 @@
-<app-page-header>
-  <h1>Application SSH ({{ (applicationService.app$ | async)?.entity?.entity.name }} #{{ instanceId }})</h1>
+<app-page-header [breadcrumbs]="breadcrumbs$ | async">
+  <h1>SSH ({{ (applicationService.app$ | async)?.entity?.entity.name }} #{{ instanceId }})</h1>
   <div class="page-header-right">
     <span>
       <button mat-icon-button matTooltip="Disconnect" name="stop" *ngIf="sshViewer.isConnected" (click)="sshViewer.disconnect()" [disabled]="sshViewer.attemptingConnection">

--- a/src/frontend/app/features/applications/ssh-application/ssh-application.component.html
+++ b/src/frontend/app/features/applications/ssh-application/ssh-application.component.html
@@ -1,5 +1,5 @@
 <app-page-header [breadcrumbs]="breadcrumbs$ | async">
-  <h1>SSH ({{ (applicationService.app$ | async)?.entity?.entity.name }} #{{ instanceId }})</h1>
+  <h1>SSH (#{{ instanceId }})</h1>
   <div class="page-header-right">
     <span>
       <button mat-icon-button matTooltip="Disconnect" name="stop" *ngIf="sshViewer.isConnected" (click)="sshViewer.disconnect()" [disabled]="sshViewer.attemptingConnection">

--- a/src/frontend/app/features/applications/ssh-application/ssh-application.component.ts
+++ b/src/frontend/app/features/applications/ssh-application/ssh-application.component.ts
@@ -49,7 +49,7 @@ export class SshApplicationComponent implements OnInit {
       {
         breadcrumbs: [
           { value: 'Applications', routerLink: '/applications' },
-          { value: application.name, routerLink: `/applications/${application.cfGuid}/${application.cfGuid}/instances` }
+          { value: application.name, routerLink: `/applications/${application.cfGuid}/${application.guid}/instances` }
         ]
       },
     ];

--- a/src/frontend/app/features/applications/ssh-application/ssh-application.component.ts
+++ b/src/frontend/app/features/applications/ssh-application/ssh-application.component.ts
@@ -4,8 +4,11 @@ import { Store } from '@ngrx/store';
 import { QueueingSubject } from 'queueing-subject';
 import websocketConnect from 'rxjs-websockets';
 import { Observable } from 'rxjs/Observable';
+import { first, map } from 'rxjs/operators';
 import { Subscription } from 'rxjs/Rx';
 
+import { IApp } from '../../../core/cf-api.types';
+import { IHeaderBreadcrumb } from '../../../shared/components/page-header/page-header.types';
 import { SshViewerComponent } from '../../../shared/components/ssh-viewer/ssh-viewer.component';
 import { AppState } from '../../../store/app-state';
 import { ApplicationService } from '../application.service';
@@ -35,7 +38,22 @@ export class SshApplicationComponent implements OnInit {
 
   public instanceId: string;
 
+  public breadcrumbs$: Observable<IHeaderBreadcrumb[]>;
+
   @ViewChild('sshViewer') sshViewer: SshViewerComponent;
+
+  private getBreadcrumbs(
+    application: IApp,
+  ) {
+    return [
+      {
+        breadcrumbs: [
+          { value: 'Applications', routerLink: '/applications' },
+          { value: application.name, routerLink: `/applications/${application.cfGuid}/${application.cfGuid}/instances` }
+        ]
+      },
+    ];
+  }
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -77,6 +95,11 @@ export class SshApplicationComponent implements OnInit {
         });
 
       this.connectionStatus = connection.connectionStatus;
+
+      this.breadcrumbs$ = this.applicationService.waitForAppEntity$.pipe(
+        map(app => this.getBreadcrumbs(app.entity.entity)),
+        first()
+      );
     }
   }
 }

--- a/src/frontend/app/shared/components/cards/card-app-instances/card-app-instances.component.html
+++ b/src/frontend/app/shared/components/cards/card-app-instances/card-app-instances.component.html
@@ -5,7 +5,7 @@
   </mat-card-header>
   <mat-card-content class="card-app-instances__compact">
     <div *ngIf="!isEditing" class="card-app-instances__large">
-      <app-running-instances [instances]="(applicationService.application$ | async)?.app.entity?.instances" [cfGuid]="applicationService.cfGuid" [appGuid]="this.applicationService.appGuid">
+      <app-running-instances [instances]="(appService.application$ | async)?.app.entity?.instances" [cfGuid]="appService.cfGuid" [appGuid]="this.appService.appGuid">
       </app-running-instances>
     </div>
     <form [hidden]="!isEditing" class="card-app-instances__form">
@@ -14,22 +14,22 @@
       </mat-form-field>
     </form>
   </mat-card-content>
-  <mat-card-actions *ngIf="showActions && isRunning && !isEditing" class="card-app-instances__actions">
-    <button (click)="edit()" mat-icon-button [disabled]="applicationService.isUpdatingApp$ | async">
+  <mat-card-actions *ngIf="showActions && (appService.applicationRunning$ | async) && !isEditing" class="card-app-instances__actions">
+    <button (click)="edit()" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
           <mat-icon>edit</mat-icon>
       </button>
-    <button (click)="scaleDown()" mat-icon-button [disabled]="applicationService.isUpdatingApp$ | async">
+    <button (click)="scaleDown()" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
           <mat-icon>remove_circle_outline</mat-icon>
       </button>
-    <button (click)="scaleUp()" mat-icon-button [disabled]="applicationService.isUpdatingApp$ | async">
+    <button (click)="scaleUp()" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
           <mat-icon>add_circle_outline</mat-icon>
       </button>
   </mat-card-actions>
   <mat-card-actions *ngIf="showActions && isEditing" class="card-app-instances__actions">
-    <button (click)="finishEdit(false)" mat-icon-button [disabled]="applicationService.isUpdatingApp$ | async">
+    <button (click)="finishEdit(false)" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
           <mat-icon>clear</mat-icon>
       </button>
-    <button (click)="finishEdit(true)" mat-icon-button [disabled]="applicationService.isUpdatingApp$ | async">
+    <button (click)="finishEdit(true)" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
             <mat-icon>done</mat-icon>
         </button>
   </mat-card-actions>

--- a/src/frontend/app/shared/components/cards/card-app-instances/card-app-instances.component.ts
+++ b/src/frontend/app/shared/components/cards/card-app-instances/card-app-instances.component.ts
@@ -32,10 +32,10 @@ export class CardAppInstancesComponent implements OnInit, OnDestroy {
 
   constructor(
     private store: Store<AppState>,
-    public applicationService: ApplicationService,
+    public appService: ApplicationService,
     private renderer: Renderer,
     private confirmDialog: ConfirmationDialogService) {
-    this.status$ = this.applicationService.applicationState$.pipe(
+    this.status$ = this.appService.applicationState$.pipe(
       map(state => state.indicator)
     );
   }
@@ -52,14 +52,12 @@ export class CardAppInstancesComponent implements OnInit, OnDestroy {
   // Observable on the running instances count for the application
   private runningInstances$: Observable<number>;
 
-  private isRunning = false;
   private app: any;
 
   ngOnInit() {
-    this.sub = this.applicationService.application$.subscribe(app => {
+    this.sub = this.appService.application$.subscribe(app => {
       if (app.app.entity) {
         this.currentCount = app.app.entity.instances;
-        this.isRunning = app.app.entity.state === 'STARTED';
         this.app = app.app.entity;
       }
     });
@@ -94,7 +92,7 @@ export class CardAppInstancesComponent implements OnInit, OnDestroy {
 
   // Set instance count. Ask for confirmation if setting count to 0
   private setInstanceCount(value: number) {
-    const doUpdate = () => this.applicationService.updateApplication({ instances: value }, [AppMetadataTypes.STATS], this.app);
+    const doUpdate = () => this.appService.updateApplication({ instances: value }, [AppMetadataTypes.STATS], this.app);
     if (value === 0) {
       this.confirmDialog.open(appInstanceScaleToZeroConfirmation, doUpdate);
     } else {

--- a/src/frontend/app/shared/components/cards/card-app-uptime/card-app-uptime.component.html
+++ b/src/frontend/app/shared/components/cards/card-app-uptime/card-app-uptime.component.html
@@ -1,5 +1,5 @@
 <mat-card *ngIf="appData$ | async as appData" class="card-app-uptime">
-  <div class="card-app-uptime__contents">
+  <div class="card-app-uptime__contents" *ngIf="isRunning$ | async; else notRunning">
     <div class="card-app-uptime__main">
       <mat-card-header>
         <mat-card-title>Uptime</mat-card-title>
@@ -14,3 +14,10 @@
     </div>
   </div>
 </mat-card>
+<ng-template #notRunning>
+  <mat-card-content>
+    <mat-card-header>
+      <mat-card-title>Application is not running</mat-card-title>
+    </mat-card-header>
+  </mat-card-content>
+</ng-template>

--- a/src/frontend/app/shared/components/cards/card-app-uptime/card-app-uptime.component.html
+++ b/src/frontend/app/shared/components/cards/card-app-uptime/card-app-uptime.component.html
@@ -1,5 +1,5 @@
 <mat-card *ngIf="appData$ | async as appData" class="card-app-uptime">
-  <div class="card-app-uptime__contents" *ngIf="isRunning$ | async; else notRunning">
+  <div class="card-app-uptime__contents" *ngIf="appService.applicationRunning$ | async; else notRunning">
     <div class="card-app-uptime__main">
       <mat-card-header>
         <mat-card-title>Uptime</mat-card-title>

--- a/src/frontend/app/shared/components/cards/card-app-uptime/card-app-uptime.component.ts
+++ b/src/frontend/app/shared/components/cards/card-app-uptime/card-app-uptime.component.ts
@@ -20,6 +20,7 @@ export class CardAppUptimeComponent implements OnInit {
     averageUptime: number,
     runningCount: number
   }>;
+  isRunning$: Observable<boolean>;
 
   ngOnInit() {
     this.appData$ = this.appMonitor.appMonitor$.pipe(
@@ -35,6 +36,9 @@ export class CardAppUptimeComponent implements OnInit {
         averageUptime: 0,
         runningCount: 0
       })
+    );
+    this.isRunning$ = this.appService.application$.pipe(
+      map(app => app ? app.app.entity.state === 'STARTED' : false)
     );
   }
 }

--- a/src/frontend/app/shared/components/cards/card-app-uptime/card-app-uptime.component.ts
+++ b/src/frontend/app/shared/components/cards/card-app-uptime/card-app-uptime.component.ts
@@ -12,7 +12,7 @@ import { ApplicationService } from '../../../../features/applications/applicatio
 })
 export class CardAppUptimeComponent implements OnInit {
 
-  constructor(private appService: ApplicationService, private appMonitor: ApplicationMonitorService) { }
+  constructor(public appService: ApplicationService, private appMonitor: ApplicationMonitorService) { }
 
   appData$: Observable<{
     maxUptime: number,
@@ -20,7 +20,6 @@ export class CardAppUptimeComponent implements OnInit {
     averageUptime: number,
     runningCount: number
   }>;
-  isRunning$: Observable<boolean>;
 
   ngOnInit() {
     this.appData$ = this.appMonitor.appMonitor$.pipe(
@@ -36,9 +35,6 @@ export class CardAppUptimeComponent implements OnInit {
         averageUptime: 0,
         runningCount: 0
       })
-    );
-    this.isRunning$ = this.appService.application$.pipe(
-      map(app => app ? app.app.entity.state === 'STARTED' : false)
     );
   }
 }

--- a/src/frontend/app/shared/components/cards/card-app-usage/card-app-usage.component.ts
+++ b/src/frontend/app/shared/components/cards/card-app-usage/card-app-usage.component.ts
@@ -22,7 +22,7 @@ export class CardAppUsageComponent implements OnInit {
   ngOnInit() {
     this.appData$ = Observable.combineLatest(
       this.appMonitor.appMonitor$.startWith(null),
-      this.appService.application$.map(data => data.app.entity.state === 'STARTED'),
+      this.appService.applicationRunning$,
     ).pipe(
       map(([monitor, isRunning]) => ({
         monitor: monitor,

--- a/src/frontend/app/shared/components/cards/card-app-usage/card-app-usage.component.ts
+++ b/src/frontend/app/shared/components/cards/card-app-usage/card-app-usage.component.ts
@@ -5,6 +5,7 @@ import { map, share } from 'rxjs/operators';
 import { ApplicationMonitorService } from '../../../../features/applications/application-monitor.service';
 import { ApplicationService } from '../../../../features/applications/application.service';
 import { CardStatus } from '../../application-state/application-state.service';
+import { pathGet } from '../../../../core/utils.service';
 
 @Component({
   selector: 'app-card-app-usage',
@@ -20,13 +21,13 @@ export class CardAppUsageComponent implements OnInit {
 
   ngOnInit() {
     this.appData$ = Observable.combineLatest(
-      this.appMonitor.appMonitor$,
+      this.appMonitor.appMonitor$.startWith(null),
       this.appService.application$.map(data => data.app.entity.state === 'STARTED'),
     ).pipe(
       map(([monitor, isRunning]) => ({
         monitor: monitor,
         isRunning: isRunning,
-        status: !isRunning ? 'tentative' : monitor.status.usage
+        status: !isRunning ? 'tentative' : pathGet('status.usage', monitor)
       })),
       share()
     );

--- a/src/frontend/app/shared/components/code-block/code-block.component.html
+++ b/src/frontend/app/shared/components/code-block/code-block.component.html
@@ -1,10 +1,10 @@
-<div class="app-code-block" [ngClass]="{'app-code-block___success': _copySuccessWait}">
-  <div #preBlock [ngClass]="{'app-code-block__pre': codeBlockStyle === 'pre'}">
+<div class="app-code-block" [ngClass]="{'app-code-block__success': _copySuccessWait}">
+  <div #preBlock>
     <ng-content></ng-content>
   </div>
-  <div class="app-code-block___copied-div">
-    <span class="app-code-block___copied-msg">Copied to clipboard</span>
-    <mat-icon class="app-code-block___copied-icon">check_circle</mat-icon>
+  <div class="app-code-block__copied-div">
+    <span class="app-code-block__copied-msg">Copied to clipboard</span>
+    <mat-icon class="app-code-block__copied-icon">check_circle</mat-icon>
   </div>
-  <mat-icon class="app-code-block___copy-icon" *ngIf="!hideCopy && _canCopy" (click)="copyToClipboard($event)">content_copy</mat-icon>
+  <mat-icon class="app-code-block__copy-icon" *ngIf="!hideCopy && _canCopy" (click)="copyToClipboard($event)">content_copy</mat-icon>
 </div>

--- a/src/frontend/app/shared/components/code-block/code-block.component.scss
+++ b/src/frontend/app/shared/components/code-block/code-block.component.scss
@@ -10,14 +10,14 @@
     white-space: pre-line;
     word-wrap: break-word;
   }
-  &___copied-div,
-  &___copy-icon {
+  &__copied-div,
+  &__copy-icon {
     position: absolute;
     right: 10px;
     top: 10px;
     transition: opacity 250ms linear;
   }
-  &___copied-div {
+  &__copied-div {
     align-items: center;
     display: flex;
     opacity: 0;
@@ -25,12 +25,15 @@
       margin-right: 5px;
     }
   }
-  &___success {
+  &__copy-icon {
+    cursor: pointer;
+  }
+  &__success {
     .app-code-block {
-      &___copied-div {
+      &__copied-div {
         opacity: 1;
       }
-      &___copy-icon {
+      &__copy-icon {
         opacity: 0;
       }
     }

--- a/src/frontend/app/test-framework/application-service-helper.ts
+++ b/src/frontend/app/test-framework/application-service-helper.ts
@@ -61,6 +61,7 @@ export class ApplicationServiceMock {
     indicator: null,
     actions: {}
   });
+  applicationRunning$: Observable<boolean> = Observable.of(false);
 }
 
 export function generateTestApplicationServiceProvider(appGuid, cfGuid) {


### PR DESCRIPTION
- Add breadcrumbs to app ssh
- Use correct pointer cursor for copy icon in code block & BEM scss
- Add 'app not running' message to app uptime card
- Don't show app name valid tick on first enter or after clearing value
  - Add third 'empty' state to appApplicationNameUnique
  - Don't show status icon if there's a required error (sync validator failing blocks async validator from clearing status)
- Add validation to route step in create app, auto-select domain