### PR TITLE
Only enable the close button when the app has been created

### DIFF
--- a/src/frontend/app/features/applications/deploy-application/deploy-application.component.html
+++ b/src/frontend/app/features/applications/deploy-application/deploy-application.component.html
@@ -8,7 +8,7 @@
   <app-step [title]="'Source'" [valid]="step2.validate | async" [onNext]="step2.onNext" [nextButtonText]="deployButtonText">
     <app-deploy-application-step2 [isRedeploy]="isRedeploy" #step2></app-deploy-application-step2>
   </app-step>
-  <app-step [title]="'Deploy'" [valid]="step3.validate | async" disablePrevious=true cancelButtonText="Close" [onNext]="step3.onNext" finishButtonText="Go to App Summary">
+  <app-step [title]="'Deploy'" [valid]="step3.validate | async" cancelRequiresValid=true disablePrevious=true cancelButtonText="Close" [onNext]="step3.onNext" finishButtonText="Go to App Summary">
     <app-deploy-application-step3 #step3></app-deploy-application-step3>
   </app-step>
 </app-steppers>

--- a/src/frontend/app/shared/components/stepper/step/step.component.ts
+++ b/src/frontend/app/shared/components/stepper/step/step.component.ts
@@ -48,6 +48,9 @@ export class StepComponent implements OnInit {
   @Input('disablePrevious')
   disablePrevious = false;
 
+  @Input('cancelRequiresValid')
+  cancelRequiresValid = false;
+
   @Input('blocked$')
   blocked$: Observable<boolean>;
 

--- a/src/frontend/app/shared/components/stepper/steppers/steppers.component.html
+++ b/src/frontend/app/shared/components/stepper/steppers/steppers.component.html
@@ -21,7 +21,7 @@
           <button *ngIf="steps.length !== 1" color="accent" mat-button mat-raised-button (click)="setActive(currentIndex - 1)" [disabled]="!canGoto(currentIndex - 1)">Previous</button>
         </div>
         <div class="steppers__navigation-right">
-          <button color="primary" mat-button [routerLink]="cancel$ | async" [queryParams]="cancelQueryParams$ | async" *ngIf="cancel">{{ this.getCancelButtonText(currentIndex) }}</button>
+          <button color="primary" mat-button [routerLink]="cancel$ | async" [queryParams]="cancelQueryParams$ | async" [disabled]="!canCancel(currentIndex)" *ngIf="cancel">{{ this.getCancelButtonText(currentIndex) }}</button>
           <button color="primary" type="submit" mat-button mat-raised-button (click)="goNext(currentIndex)" [disabled]="(steps[currentIndex].blocked$ | async) || !canGoNext(currentIndex)">{{ this.getNextButtonText(currentIndex) }}</button>
         </div>
       </div>

--- a/src/frontend/app/shared/components/stepper/steppers/steppers.component.ts
+++ b/src/frontend/app/shared/components/stepper/steppers/steppers.component.ts
@@ -147,6 +147,12 @@ export class SteppersComponent implements OnInit, AfterContentInit {
     return true;
   }
 
+  canCancel(index) {
+    // If step has 'cancelRequiresValid' set then use the same gate as the next button
+    if (!this.steps[index]) return false;
+    return this.steps[index].cancelRequiresValid ? this.canGoNext(index) : true;
+  }  
+
   getIconLigature(step: StepComponent, index: number): 'done' {
     return 'done';
   }

--- a/src/frontend/app/shared/components/stepper/steppers/steppers.component.ts
+++ b/src/frontend/app/shared/components/stepper/steppers/steppers.component.ts
@@ -149,9 +149,11 @@ export class SteppersComponent implements OnInit, AfterContentInit {
 
   canCancel(index) {
     // If step has 'cancelRequiresValid' set then use the same gate as the next button
-    if (!this.steps[index]) return false;
+    if (!this.steps[index]) {
+      return false;
+    }
     return this.steps[index].cancelRequiresValid ? this.canGoNext(index) : true;
-  }  
+  }
 
   getIconLigature(step: StepComponent, index: number): 'done' {
     return 'done';


### PR DESCRIPTION
Fixes issue where if you close the deploy app before the app has been created, it does not show on the app wall.

Added ability to disable the close button until the same conditions as the next button are met