### PR TITLE
Return better error information from API passthroughs

### DIFF
--- a/src/backend/app-core/passthrough.go
+++ b/src/backend/app-core/passthrough.go
@@ -87,8 +87,6 @@ func buildJSONResponse(cnsiList []string, responses map[string]*interfaces.CNSIR
 		case !ok:
 			response = []byte(`{"error": "Request timed out"}`)
 		case cnsiResponse.Error != nil:
-			log.Error("error")
-			log.Errorf("%v+", cnsiResponse.Error)
 			response = []byte(fmt.Sprintf(`{"error": {"statusCode": 500, "status": "%q"}}`, cnsiResponse.Error.Error()))
 		case cnsiResponse.Response != nil:
 			response = cnsiResponse.Response

--- a/src/backend/app-core/passthrough.go
+++ b/src/backend/app-core/passthrough.go
@@ -85,7 +85,7 @@ func buildJSONResponse(cnsiList []string, responses map[string]*interfaces.CNSIR
 		cnsiResponse, ok := responses[guid]
 		switch {
 		case !ok:
-			response = []byte(`{"error": "Request timed out"}`)
+			response = []byte(`{"error": {"statusCode": 500, "status": "Request timed out"}}`)
 		case cnsiResponse.Error != nil:
 			response = []byte(fmt.Sprintf(`{"error": {"statusCode": 500, "status": "%q"}}`, cnsiResponse.Error.Error()))
 		case cnsiResponse.Response != nil:

--- a/src/backend/app-core/passthrough.go
+++ b/src/backend/app-core/passthrough.go
@@ -87,13 +87,19 @@ func buildJSONResponse(cnsiList []string, responses map[string]*interfaces.CNSIR
 		case !ok:
 			response = []byte(`{"error": "Request timed out"}`)
 		case cnsiResponse.Error != nil:
-			response = []byte(fmt.Sprintf(`{"error": %q}`, cnsiResponse.Error.Error()))
+			log.Error("error")
+			log.Errorf("%v+", cnsiResponse.Error)
+			response = []byte(fmt.Sprintf(`{"error": {"statusCode": 500, "status": "%q"}}`, cnsiResponse.Error.Error()))
 		case cnsiResponse.Response != nil:
 			response = cnsiResponse.Response
 		}
 		// Check the HTTP Status code to make sure that it is actually a valid response
 		if cnsiResponse.StatusCode >= 400 {
-			response = []byte(fmt.Sprintf(`{"error": "Unexpected HTTP status code: %d"}`, cnsiResponse.StatusCode))
+			errorJson, err := json.Marshal(cnsiResponse)
+			if err != nil {
+				errorJson = []byte(fmt.Sprintf(`{"statusCode": 500, "status": "Failed to proxy request"}"`))
+			}
+			response = []byte(fmt.Sprintf(`{"error": %s, "errorResponse": %s}`, errorJson, string(cnsiResponse.Response)))
 		}
 		if len(response) > 0 {
 			jsonResponse[guid] = (*json.RawMessage)(&response)
@@ -324,7 +330,7 @@ func (p *portalProxy) doRequest(cnsiRequest *interfaces.CNSIRequest, done chan<-
 	case interfaces.AuthTypeOIDC:
 		res, err = p.doOidcFlowRequest(cnsiRequest, req)
 	default:
-	res, err = p.doOauthFlowRequest(cnsiRequest, req)
+		res, err = p.doOauthFlowRequest(cnsiRequest, req)
 	}
 
 	if err != nil {

--- a/src/backend/app-core/repository/interfaces/structs.go
+++ b/src/backend/app-core/repository/interfaces/structs.go
@@ -102,13 +102,13 @@ type LoginRes struct {
 type LoginHookFunc func(c echo.Context) error
 
 type ProxyRequestInfo struct {
-	EndpointGUID    string
-	URI *url.URL
-	UserGUID string
-	ResultGUID string
-	Headers http.Header
-	Body []byte
-	Method string
+	EndpointGUID string
+	URI          *url.URL
+	UserGUID     string
+	ResultGUID   string
+	Headers      http.Header
+	Body         []byte
+	Method       string
 }
 
 type SessionStorer interface {
@@ -142,9 +142,9 @@ type Info struct {
 // Extends CNSI Record and adds the user
 type EndpointDetail struct {
 	*CNSIRecord
-	User     *ConnectedUser    `json:"user"`
-	Metadata map[string]string `json:"metadata,omitempty"`
-	TokenMetadata string			 `json:"-"`
+	User          *ConnectedUser    `json:"user"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	TokenMetadata string            `json:"-"`
 }
 
 // Versions - response returned to caller from a getVersions action
@@ -164,19 +164,20 @@ type ConsoleConfig struct {
 
 // CNSIRequest
 type CNSIRequest struct {
-	GUID     string
-	UserGUID string
+	GUID     string `json:"-"`
+	UserGUID string `json:"-"`
 
-	Method      string
-	Body        []byte
-	Header      http.Header
-	URL         *url.URL
-	StatusCode  int
-	PassThrough bool
+	Method      string      `json:"-"`
+	Body        []byte      `json:"-"`
+	Header      http.Header `json:"-"`
+	URL         *url.URL    `json:"-"`
+	StatusCode  int         `json:"statusCode"`
+	Status      string      `json:"status"`
+	PassThrough bool        `json:"-"`
 
-	Response []byte
-	Error    error
-	ResponseGUID	string
+	Response     []byte `json:"-"`
+	Error        error  `json:"-"`
+	ResponseGUID string `json:"-"`
 }
 
 type PortalConfig struct {

--- a/src/frontend/app/shared/monitors/internal-event.monitor.ts
+++ b/src/frontend/app/shared/monitors/internal-event.monitor.ts
@@ -51,7 +51,8 @@ export class InternalEventMonitor {
         return Object.keys(state).reduce<string[]>((array, key) => {
           const events = state[key];
           const hasErrorEvent = !!events.find(event => {
-            return event.severity === InternalEventSeverity.ERROR && event.timestamp > time;
+            const isError500 = event.eventCode[0] === '5';
+            return event.severity === InternalEventSeverity.ERROR && isError500 && event.timestamp > time;
           });
           if (hasErrorEvent) {
             array.push(key);

--- a/src/frontend/app/store/effects/api.effects.ts
+++ b/src/frontend/app/store/effects/api.effects.ts
@@ -139,7 +139,7 @@ export class APIEffect {
     ).catch(error => {
       const endpoints: string[] = options.headers.get(endpointHeader).split((','));
       endpoints.forEach(endpoint => this.store.dispatch(new SendEventAction(endpointSchemaKey, endpoint, {
-        eventCode: error.status || 500,
+        eventCode: error.status || '500',
         severity: InternalEventSeverity.ERROR,
         message: 'Jetstream API request error',
         metadata: {

--- a/src/frontend/app/store/types/internal-events.types.ts
+++ b/src/frontend/app/store/types/internal-events.types.ts
@@ -7,7 +7,7 @@ export const CLEAR_EVENTS = '[Internal Event] Clear';
 export interface InternalEventState {
   message?: string;
   timestamp?: number;
-  eventCode: string | number;
+  eventCode: string;
   severity: InternalEventSeverity;
   metadata: {
     [key: string]: any;


### PR DESCRIPTION
When proxying, the wrapper responses will now contain better error information.