### PR TITLE
Fix update of endpoints table on register endpoint

### DIFF
--- a/src/frontend/app/features/endpoints/create-endpoint/create-endpoint.component.ts
+++ b/src/frontend/app/features/endpoints/create-endpoint/create-endpoint.component.ts
@@ -5,11 +5,4 @@ import { Component, OnInit } from '@angular/core';
   templateUrl: './create-endpoint.component.html',
   styleUrls: ['./create-endpoint.component.scss']
 })
-export class CreateEndpointComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
-
-}
+export class CreateEndpointComponent { }

--- a/src/frontend/app/store/effects/endpoint.effects.ts
+++ b/src/frontend/app/store/effects/endpoint.effects.ts
@@ -14,7 +14,6 @@ import {
   DISCONNECT_ENDPOINTS_FAILED,
   DISCONNECT_ENDPOINTS_SUCCESS,
   DisconnectEndpoint,
-  GetAllEndpoints,
   GetAllEndpointsSuccess,
   REGISTER_ENDPOINTS,
   REGISTER_ENDPOINTS_FAILED,
@@ -26,11 +25,11 @@ import {
   UnregisterEndpoint,
 } from '../actions/endpoint.actions';
 import { ClearPaginationOfEntity } from '../actions/pagination.actions';
-import { GET_SYSTEM_INFO_SUCCESS, GetSystemSuccess } from '../actions/system.actions';
+import { GET_SYSTEM_INFO_SUCCESS, GetSystemInfo, GetSystemSuccess } from '../actions/system.actions';
 import { AppState } from '../app-state';
 import { ApiRequestTypes } from '../reducers/api-request-reducer/request-helpers';
 import { NormalizedResponse } from '../types/api.types';
-import { endpointStoreNames, EndpointType } from '../types/endpoint.types';
+import { EndpointModel, endpointStoreNames, EndpointType } from '../types/endpoint.types';
 import {
   IRequestAction,
   StartRequestAction,
@@ -171,7 +170,6 @@ export class EndpointsEffect {
       );
     });
 
-
   private getEndpointUpdateAction(guid, type, updatingKey) {
     return {
       entityKey: endpointStoreNames.type,
@@ -204,20 +202,27 @@ export class EndpointsEffect {
     return this.http.post(url, body || {}, {
       headers,
       params
-    }).map(endpoint => {
+    }).mergeMap((endpoint: EndpointModel) => {
+      const actions = [];
       if (actionStrings[0]) {
-        this.store.dispatch({ type: actionStrings[0], guid: apiAction.guid, endpointType: endpointType });
+        actions.push({ type: actionStrings[0], guid: apiAction.guid, endpointType: endpointType, endpoint });
       }
       if (apiActionType === 'delete') {
-        this.store.dispatch(new ClearPaginationOfEntity(apiAction.entityKey, apiAction.guid));
+        actions.push(new ClearPaginationOfEntity(apiAction.entityKey, apiAction.guid));
       }
-      return new WrapperRequestActionSuccess(null, apiAction, apiActionType);
+      if (apiActionType === 'create') {
+        actions.push(new GetSystemInfo());
+      }
+      actions.push(new WrapperRequestActionSuccess(null, apiAction, apiActionType));
+      return actions;
     })
       .catch(e => {
+        const actions = [];
         if (actionStrings[1]) {
-          this.store.dispatch({ type: actionStrings[1], guid: apiAction.guid });
+          actions.push({ type: actionStrings[1], guid: apiAction.guid });
         }
-        return [new WrapperRequestActionFailed('Could not connect', apiAction, apiActionType)];
+        actions.push(new WrapperRequestActionFailed('Could not connect', apiAction, apiActionType));
+        return actions;
       });
   }
 }


### PR DESCRIPTION
- Previously I think we refreshed the table every time we visited the page. This was removed hence the issue
- Now whenever we create an endpoint we make a full sysinfo request
- Ideally we could take the response of the create, stick it in the request data and pagination section, however we don't have the toolset for this yet
- Have also tidied up the obs chain (only real change it the sys info bit)
