### PR TITLE
Fix exception thrown in space routes, ensure single request sent for non-local lists

### DIFF
--- a/src/frontend/app/shared/components/list/data-sources-controllers/list-data-source.ts
+++ b/src/frontend/app/shared/components/list/data-sources-controllers/list-data-source.ts
@@ -163,6 +163,12 @@ export abstract class ListDataSource<T, A = T> extends DataSource<T> implements 
     this.externalDestroy = config.destroy || (() => { });
     this.addItem = this.getEmptyType();
     this.entityKey = this.sourceScheme.key;
+    if (!this.isLocal && this.config.listConfig) {
+      // This is a non-local data source so the results-per-page should match the initial page size. This will avoid making two calls
+      // (one for the page size in the action and another when the initial page size is set)
+      this.action.initialParams = this.action.initialParams || {};
+      this.action.initialParams['results-per-page'] = this.config.listConfig.pageSizeOptions[0];
+    }
   }
 
   private getRefreshFunction(config: IListDataSourceConfig<A, T>) {

--- a/src/frontend/app/shared/components/list/list-types/cf-space-routes/cf-space-routes-data-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-space-routes/cf-space-routes-data-source.ts
@@ -9,6 +9,7 @@ import {
   entityFactory,
   routeSchemaKey,
   spaceSchemaKey,
+  domainSchemaKey,
 } from '../../../../../store/helpers/entity-factory';
 import {
   createEntityRelationKey,
@@ -29,10 +30,10 @@ export class CfSpaceRoutesDataSource extends ListDataSource<APIResource> {
     spaceGuid: string,
     cfGuid: string
   ) {
-    // const paginationKey = getPaginationKey('cf-space-routes', cfGuid, spaceGuid);
     const paginationKey = createEntityRelationPaginationKey(spaceSchemaKey, spaceGuid);
     const action = new GetSpaceRoutes(spaceGuid, cfGuid, paginationKey, [
       createEntityRelationKey(routeSchemaKey, applicationSchemaKey),
+      createEntityRelationKey(routeSchemaKey, domainSchemaKey),
     ]);
     const { rowStateManager, sub } = SpaceRouteDataSourceHelper.getRowStateManager(
       store,

--- a/src/frontend/app/shared/components/list/list-types/cf-space-routes/cf-space-routes-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-space-routes/cf-space-routes-list-config.service.ts
@@ -171,20 +171,20 @@ export class CfSpaceRoutesListConfigService implements IListConfig<APIResource> 
     this.store
       .select(selectEntity<EntityInfo>('domain', item.entity.domain_guid))
       .pipe(
-      take(1),
-      tap(domain => {
-        const routeUrl = getRoute(item, false, false, domain);
-        const confirmation = new ConfirmationDialogConfig(
-          'Delete Route',
-          `Are you sure you want to delete the route \n\'${routeUrl}\'?`,
-          'Delete',
-          true
-        );
-        this.confirmDialog.open(confirmation, () => {
-          this.dispatchDeleteAction(item);
-          this.getDataSource().selectClear();
-        });
-      })
+        take(1),
+        tap(domain => {
+          const routeUrl = getRoute(item, false, false, domain);
+          const confirmation = new ConfirmationDialogConfig(
+            'Delete Route',
+            `Are you sure you want to delete the route \n\'${routeUrl}\'?`,
+            'Delete',
+            true
+          );
+          this.confirmDialog.open(confirmation, () => {
+            this.dispatchDeleteAction(item);
+            this.getDataSource().selectClear();
+          });
+        })
       )
       .subscribe();
   }
@@ -193,20 +193,20 @@ export class CfSpaceRoutesListConfigService implements IListConfig<APIResource> 
     this.store
       .select(selectEntity<EntityInfo>('domain', item.entity.domain_guid))
       .pipe(
-      take(1),
-      tap(domain => {
-        const routeUrl = getRoute(item, false, false, domain);
-        const confirmation = new ConfirmationDialogConfig(
-          'Unmap Route from Application',
-          `Are you sure you want to unmap the route \'${routeUrl}\'?`,
-          'Unmap',
-          true
-        );
-        this.confirmDialog.open(confirmation, () => {
-          this.dispatchUnmapAction(item);
-          this.getDataSource().selectClear();
-        });
-      })
+        take(1),
+        tap(domain => {
+          const routeUrl = getRoute(item, false, false, domain);
+          const confirmation = new ConfirmationDialogConfig(
+            'Unmap Route from Application',
+            `Are you sure you want to unmap the route \'${routeUrl}\'?`,
+            'Unmap',
+            true
+          );
+          this.confirmDialog.open(confirmation, () => {
+            this.dispatchUnmapAction(item);
+            this.getDataSource().selectClear();
+          });
+        })
       )
       .subscribe();
   }


### PR DESCRIPTION
- Space routes were fetched without required domain entity
- Two requests instead of one were made for space apps, service instances and routes
  - First request was with default high page size
  - Second request was for initial page size
  - Now we up front set the action page size to the initial page size