### PR TITLE
Allow users to disable compression in the backend proxy

### DIFF
--- a/src/backend/app-core/main.go
+++ b/src/backend/app-core/main.go
@@ -427,6 +427,7 @@ func initializeHTTPClients(timeout int64, connectionTimeout int64) {
 		TLSHandshakeTimeout: 10 * time.Second, // 10 seconds is a sound default value (default is 0)
 		TLSClientConfig:     &tls.Config{InsecureSkipVerify: false},
 		MaxIdleConnsPerHost: 6, // (default is 2)
+		DisableCompression: true,
 	}
 	httpClient.Transport = tr
 	httpClient.Timeout = time.Duration(timeout) * time.Second
@@ -437,6 +438,7 @@ func initializeHTTPClients(timeout int64, connectionTimeout int64) {
 		TLSHandshakeTimeout: 10 * time.Second, // 10 seconds is a sound default value (default is 0)
 		TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
 		MaxIdleConnsPerHost: 6, // (default is 2)
+		DisableCompression: true,
 	}
 
 	httpClientSkipSSL.Transport = trSkipSSL

--- a/src/backend/app-core/passthrough.go
+++ b/src/backend/app-core/passthrough.go
@@ -321,6 +321,9 @@ func (p *portalProxy) doRequest(cnsiRequest *interfaces.CNSIRequest, done chan<-
 	// Copy original headers through, except custom portal-proxy Headers
 	fwdCNSIStandardHeaders(cnsiRequest, req)
 
+	// Always disable gzip compression for our requests
+	req.Header.Set("Accept-Encoding", "identity")
+
 	// Mkae the request using the appropriate auth helper
 	switch tokenRec.AuthType {
 	case interfaces.AuthTypeHttpBasic:


### PR DESCRIPTION
Some CF installations may enable HTTP compression for all requests. This patch allows you to disable this via Accept-Encoding header controlled via new environment variable.

## Description
A new environment variable, DISABLE_COMPRESSION, can be set to `true` to disable compression using the `Accept-Encoding` header during the passthrough request process.

## Motivation and Context
Some CF operators may enable compression for all clients via proxy or load balancer. This plays havoc with the golang http client, since it fails to automatically negotiate this. This failure in decompression causes issues in properly reading the JSON responses from the CF API, causing the backend to throw errors.

## How Has This Been Tested?
This patch was tested manually using the following scenarios:
- unset
- set to false
- set to true
backend tests have been run to make sure that there are no breaking changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message