### PR TITLE
Add user info to the response when connecting an endpoint

### DIFF
--- a/src/backend/app-core/repository/interfaces/structs.go
+++ b/src/backend/app-core/repository/interfaces/structs.go
@@ -93,10 +93,11 @@ type VCapApplicationData struct {
 }
 
 type LoginRes struct {
-	Account     string   `json:"account"`
-	TokenExpiry int64    `json:"token_expiry"`
-	APIEndpoint *url.URL `json:"api_endpoint"`
-	Admin       bool     `json:"admin"`
+	Account     string   	 		 `json:"account"`
+	TokenExpiry int64    		 	 `json:"token_expiry"`
+	APIEndpoint *url.URL 		 	 `json:"api_endpoint"`
+	Admin       bool    		 	 `json:"admin"`
+	User				*ConnectedUser `json:"user"`
 }
 
 type LoginHookFunc func(c echo.Context) error


### PR DESCRIPTION
Updated the backend API so that when connecting an endpoint, the user information for the endpoint is returned in the response.