### PR TITLE
Fix multiple add/deploy app icons on app wall after fresh stepper visit

### DIFF
--- a/src/frontend/app/features/applications/application-wall/application-wall.component.html
+++ b/src/frontend/app/features/applications/application-wall/application-wall.component.html
@@ -3,11 +3,11 @@
   <div class="page-header-right">
     <ng-container *appUserPermission="canCreateApplication">
       <button mat-icon-button [routerLink]="'/applications/new/'">
-      <mat-icon>add</mat-icon>
-    </button>
+        <mat-icon>add</mat-icon>
+      </button>
       <button mat-icon-button [routerLink]="'/applications/deploy/'">
-      <mat-icon>file_upload</mat-icon>
-    </button>
+        <mat-icon>file_upload</mat-icon>
+      </button>
     </ng-container>
   </div>
 </app-page-header>

--- a/src/frontend/app/shared/user-permission.directive.ts
+++ b/src/frontend/app/shared/user-permission.directive.ts
@@ -1,7 +1,9 @@
-import { Directive, Input, TemplateRef, ViewContainerRef, OnDestroy, OnInit } from '@angular/core';
-import { CurrentUserPermissionsService } from '../core/current-user-permissions.service';
-import { CurrentUserPermissions } from '../core/current-user-permissions.config';
+import { Directive, Input, OnDestroy, OnInit, TemplateRef, ViewContainerRef } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
+
+import { CurrentUserPermissions } from '../core/current-user-permissions.config';
+import { CurrentUserPermissionsService } from '../core/current-user-permissions.service';
+import { distinctUntilChanged, startWith } from 'rxjs/operators';
 
 @Directive({
   selector: '[appUserPermission]'
@@ -34,6 +36,10 @@ export class UserPermissionDirective implements OnDestroy, OnInit {
       this.appUserPermissionEndpointGuid,
       this.getOrgOrSpaceGuid(),
       this.getSpaceGuid()
+    ).pipe(
+      // Ensure we don't create multiple instances if true is emitted multiple times
+      distinctUntilChanged(),
+      startWith(false)
     ).subscribe(
       can => {
         if (can) {

--- a/src/frontend/app/shared/user-permission.directive.ts
+++ b/src/frontend/app/shared/user-permission.directive.ts
@@ -3,7 +3,6 @@ import { Subscription } from 'rxjs/Subscription';
 
 import { CurrentUserPermissions } from '../core/current-user-permissions.config';
 import { CurrentUserPermissionsService } from '../core/current-user-permissions.service';
-import { distinctUntilChanged, startWith } from 'rxjs/operators';
 
 @Directive({
   selector: '[appUserPermission]'
@@ -36,10 +35,6 @@ export class UserPermissionDirective implements OnDestroy, OnInit {
       this.appUserPermissionEndpointGuid,
       this.getOrgOrSpaceGuid(),
       this.getSpaceGuid()
-    ).pipe(
-      // Ensure we don't create multiple instances if true is emitted multiple times
-      distinctUntilChanged(),
-      startWith(false)
     ).subscribe(
       can => {
         if (can) {


### PR DESCRIPTION
- Bug
  - load app whilst in a stepper that returns to the app wall (create app)
  - hit cancel
  - app wall shows multiple add/deploy app icons
- Fix
  - Ensure permissions directive doesn't create multiple instances when check emits multiple trues