### PR TITLE
Fix compression issue

### DIFF
--- a/src/backend/app-core/passthrough.go
+++ b/src/backend/app-core/passthrough.go
@@ -151,7 +151,8 @@ func fwdCNSIStandardHeaders(cnsiRequest *interfaces.CNSIRequest, req *http.Reque
 		// Skip these
 		//  - "Referer" causes CF to fail with a 403
 		//  - "Connection", "X-Cap-*" and "Cookie" are consumed by us
-		case k == "Connection", k == "Cookie", k == "Referer", strings.HasPrefix(strings.ToLower(k), "x-cap-"):
+		// - "Accept-Encoding" must be excluded otherwise the transport will expect us to handle the encoding/compression
+		case k == "Connection", k == "Cookie", k == "Referer", k == "Accept-Encoding", strings.HasPrefix(strings.ToLower(k), "x-cap-"):
 
 		// Forwarding everything else
 		default:
@@ -337,6 +338,7 @@ func (p *portalProxy) doRequest(cnsiRequest *interfaces.CNSIRequest, done chan<-
 		cnsiRequest.Error = err
 	} else if res.Body != nil {
 		cnsiRequest.StatusCode = res.StatusCode
+		cnsiRequest.Status = res.Status
 		cnsiRequest.Response, cnsiRequest.Error = ioutil.ReadAll(res.Body)
 		defer res.Body.Close()
 	}


### PR DESCRIPTION
This is a fix for the compression issue that does not require compression to be tuned off.

Long and short is the issue boiled down to the fact that when the back-end proxies API requests, it forwards (most of) the headers as well.

The golang http library (see: https://golang.org/src/net/http/transport.go, line 1973), assumes that if the Accept-Encoding header is set by the client, then it will handle uncompressing the response if it is compressed.

Since the browser typically sends us this header, we forward it on and in the case of backends using compression, we get back a compressed response which the go library assumes that we will uncompress, which we do not.

The fix is simply to not forward the Accepts-Encoding header and to let the go library do its thing - it will add in gzip and uncompress the response for us if necessary