### PR TITLE
Change DB schema and backend to support storing a client/secret for each Endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .idea
 *.iml
 npm-debug.log

--- a/build/bk-build-utils.js
+++ b/build/bk-build-utils.js
@@ -138,7 +138,7 @@
   }
 
   function test(path) {
-    return spawnProcess('go', ['test', '-v'], path, env);
+    return spawnProcess('go', ['test', './...', '-v'], path, env);
   }
 
   function getVersion() {

--- a/components/app-core/backend/auth.go
+++ b/components/app-core/backend/auth.go
@@ -215,7 +215,7 @@ func (p *portalProxy) fetchToken(cnsiGUID string, c echo.Context) (*UAAResponse,
 
 	tokenEndpoint := fmt.Sprintf("%s/oauth/token", endpoint)
 
-	uaaRes, u, err := p.login(c, cnsiRecord.SkipSSLValidation, cnsiRecord.ClientId, "", tokenEndpoint)
+	uaaRes, u, err := p.login(c, cnsiRecord.SkipSSLValidation, cnsiRecord.ClientId, cnsiRecord.ClientSecret, tokenEndpoint)
 
 	if err != nil {
 		return nil, nil, nil, interfaces.NewHTTPShadowError(

--- a/components/app-core/backend/auth.go
+++ b/components/app-core/backend/auth.go
@@ -215,15 +215,7 @@ func (p *portalProxy) fetchToken(cnsiGUID string, c echo.Context) (*UAAResponse,
 
 	tokenEndpoint := fmt.Sprintf("%s/oauth/token", endpoint)
 
-	clientID, err := p.GetClientId(cnsiRecord.CNSIType)
-	if err != nil {
-		return nil, nil, nil, interfaces.NewHTTPShadowError(
-			http.StatusBadRequest,
-			"Endpoint type has not been registered",
-			"Endpoint type has not been registered %s: %s", cnsiRecord.CNSIType, err)
-	}
-
-	uaaRes, u, err := p.login(c, cnsiRecord.SkipSSLValidation, clientID, "", tokenEndpoint)
+	uaaRes, u, err := p.login(c, cnsiRecord.SkipSSLValidation, cnsiRecord.ClientId, "", tokenEndpoint)
 
 	if err != nil {
 		return nil, nil, nil, interfaces.NewHTTPShadowError(
@@ -233,14 +225,6 @@ func (p *portalProxy) fetchToken(cnsiGUID string, c echo.Context) (*UAAResponse,
 	}
 	return uaaRes, u, &cnsiRecord, nil
 
-}
-
-func (p *portalProxy) GetClientId(cnsiType string) (string, error) {
-	plugin, err := p.GetEndpointTypeSpec(cnsiType)
-	if err != nil {
-		return "", errors.New("Endpoint type not registered")
-	}
-	return plugin.GetClientId(), nil
 }
 
 func (p *portalProxy) logoutOfCNSI(c echo.Context) error {

--- a/components/app-core/backend/auth_test.go
+++ b/components/app-core/backend/auth_test.go
@@ -182,8 +182,8 @@ func TestLoginToCNSI(t *testing.T) {
 			DopplerLoggingEndpoint: mockDopplerEndpoint,
 		}
 
-		expectedCNSIRow := sqlmock.NewRows([]string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation"}).
-			AddRow(mockCNSIGUID, mockCNSI.Name, stringCFType, mockUAA.URL, mockCNSI.AuthorizationEndpoint, mockCNSI.TokenEndpoint, mockCNSI.DopplerLoggingEndpoint, true)
+		expectedCNSIRow := sqlmock.NewRows([]string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation", "client_id", "client_secret"}).
+			AddRow(mockCNSIGUID, mockCNSI.Name, stringCFType, mockUAA.URL, mockCNSI.AuthorizationEndpoint, mockCNSI.TokenEndpoint, mockCNSI.DopplerLoggingEndpoint, true, mockCNSI.ClientId, mockCNSI.ClientSecret)
 
 		mock.ExpectQuery(selectAnyFromCNSIs).
 			WithArgs(mockCNSIGUID).

--- a/components/app-core/backend/auth_test.go
+++ b/components/app-core/backend/auth_test.go
@@ -183,7 +183,7 @@ func TestLoginToCNSI(t *testing.T) {
 		}
 
 		expectedCNSIRow := sqlmock.NewRows([]string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation", "client_id", "client_secret"}).
-			AddRow(mockCNSIGUID, mockCNSI.Name, stringCFType, mockUAA.URL, mockCNSI.AuthorizationEndpoint, mockCNSI.TokenEndpoint, mockCNSI.DopplerLoggingEndpoint, true, mockCNSI.ClientId, mockCNSI.ClientSecret)
+			AddRow(mockCNSIGUID, mockCNSI.Name, stringCFType, mockUAA.URL, mockCNSI.AuthorizationEndpoint, mockCNSI.TokenEndpoint, mockCNSI.DopplerLoggingEndpoint, true, mockCNSI.ClientId, cipherClientSecret)
 
 		mock.ExpectQuery(selectAnyFromCNSIs).
 			WithArgs(mockCNSIGUID).

--- a/components/app-core/backend/cnsi.go
+++ b/components/app-core/backend/cnsi.go
@@ -46,7 +46,15 @@ func (p *portalProxy) RegisterEndpoint(c echo.Context, fetchInfo interfaces.Info
 		skipSSLValidation = false
 	}
 
-	newCNSI, err := p.DoRegisterEndpoint(cnsiName, apiEndpoint, skipSSLValidation, fetchInfo)
+	cfclientid :=  c.FormValue("cf_client_id")
+	cfclientsecret := c.FormValue("cf_client_secret")
+
+	if cfclientid == "" {
+		cfclientid = p.GetConfig().CFClient
+		cfclientsecret = p.GetConfig().CFClientSecret
+	}
+
+	newCNSI, err := p.DoRegisterEndpoint(cnsiName, apiEndpoint, skipSSLValidation, cfclientid, cfclientsecret, fetchInfo)
 	if err != nil {
 		return err
 	}
@@ -55,7 +63,7 @@ func (p *portalProxy) RegisterEndpoint(c echo.Context, fetchInfo interfaces.Info
 	return nil
 }
 
-func (p *portalProxy) DoRegisterEndpoint(cnsiName string, apiEndpoint string, skipSSLValidation bool, fetchInfo interfaces.InfoFunc) (interfaces.CNSIRecord, error) {
+func (p *portalProxy) DoRegisterEndpoint(cnsiName string, apiEndpoint string, skipSSLValidation bool, clientId string, clientSecret string, fetchInfo interfaces.InfoFunc) (interfaces.CNSIRecord, error) {
 
 	if len(cnsiName) == 0 || len(apiEndpoint) == 0 {
 		return interfaces.CNSIRecord{}, interfaces.NewHTTPShadowError(
@@ -107,6 +115,8 @@ func (p *portalProxy) DoRegisterEndpoint(cnsiName string, apiEndpoint string, sk
 	newCNSI.Name = cnsiName
 	newCNSI.APIEndpoint = apiEndpointURL
 	newCNSI.SkipSSLValidation = skipSSLValidation
+	newCNSI.ClientId = clientId
+	newCNSI.ClientSecret = clientSecret
 
 	err = p.setCNSIRecord(guid, newCNSI)
 

--- a/components/app-core/backend/cnsi_test.go
+++ b/components/app-core/backend/cnsi_test.go
@@ -25,13 +25,15 @@ func TestRegisterCFCluster(t *testing.T) {
 		"cnsi_name":           "Some fancy CF Cluster",
 		"api_endpoint":        mockV2Info.URL,
 		"skip_ssl_validation": "true",
+		"cf_client_id":			mockClientId,
+		"cf_client_secret":		mockClientSecret,
 	})
 
 	_, _, ctx, pp, db, mock := setupHTTPTest(req)
 	defer db.Close()
 
 	mock.ExpectExec(insertIntoCNSIs).
-		WithArgs(sqlmock.AnyArg(), "Some fancy CF Cluster", "cf", mockV2Info.URL, mockAuthEndpoint, mockTokenEndpoint, mockDopplerEndpoint, true).
+		WithArgs(sqlmock.AnyArg(), "Some fancy CF Cluster", "cf", mockV2Info.URL, mockAuthEndpoint, mockTokenEndpoint, mockDopplerEndpoint, true, mockClientId, mockClientSecret).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	if err := pp.RegisterEndpoint(ctx, getCFPlugin(pp, "cf").Info); err != nil {

--- a/components/app-core/backend/cnsi_test.go
+++ b/components/app-core/backend/cnsi_test.go
@@ -25,15 +25,15 @@ func TestRegisterCFCluster(t *testing.T) {
 		"cnsi_name":           "Some fancy CF Cluster",
 		"api_endpoint":        mockV2Info.URL,
 		"skip_ssl_validation": "true",
-		"cf_client_id":			mockClientId,
-		"cf_client_secret":		mockClientSecret,
+		"cnsi_client_id":			mockClientId,
+		"cnsi_client_secret":		mockClientSecret,
 	})
 
 	_, _, ctx, pp, db, mock := setupHTTPTest(req)
 	defer db.Close()
 
 	mock.ExpectExec(insertIntoCNSIs).
-		WithArgs(sqlmock.AnyArg(), "Some fancy CF Cluster", "cf", mockV2Info.URL, mockAuthEndpoint, mockTokenEndpoint, mockDopplerEndpoint, true, mockClientId, mockClientSecret).
+		WithArgs(sqlmock.AnyArg(), "Some fancy CF Cluster", "cf", mockV2Info.URL, mockAuthEndpoint, mockTokenEndpoint, mockDopplerEndpoint, true, mockClientId, sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	if err := pp.RegisterEndpoint(ctx, getCFPlugin(pp, "cf").Info); err != nil {

--- a/components/app-core/backend/datastore/datastore.go
+++ b/components/app-core/backend/datastore/datastore.go
@@ -99,6 +99,8 @@ func NewDatabaseConnectionParametersFromConfig(dc DatabaseConfig) (DatabaseConfi
 		if dc.SSLMode == string(SSLDisabled) || dc.SSLMode == string(SSLRequired) ||
 			dc.SSLMode == string(SSLVerifyCA) || dc.SSLMode == string(SSLVerifyFull) {
 			return dc, nil
+		} else {
+			return dc, fmt.Errorf("Invalid SSL mode: %v", dc.SSLMode)
 		}
 	} else if dc.DatabaseProvider == MYSQL {
 		return dc, nil

--- a/components/app-core/backend/datastore/datastore.go
+++ b/components/app-core/backend/datastore/datastore.go
@@ -267,7 +267,7 @@ func Ping(db *sql.DB) error {
 // SQLite uses ?
 func ModifySQLStatement(sql string, databaseProvider string) string {
 	if databaseProvider == SQLITE || databaseProvider == MYSQL {
-		sqlParamReplace := regexp.MustCompile("\\$[0-9]")
+		sqlParamReplace := regexp.MustCompile("\\$[0-9]+")
 		return sqlParamReplace.ReplaceAllString(sql, "?")
 	}
 

--- a/components/app-core/backend/mock_server_test.go
+++ b/components/app-core/backend/mock_server_test.go
@@ -168,18 +168,18 @@ func expectOneRow() sqlmock.Rows {
 
 func expectCFRow() sqlmock.Rows {
 	return sqlmock.NewRows(rowFieldsForCNSI).
-		AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, mockClientSecret)
+		AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, cipherClientSecret)
 }
 
 func expectCERow() sqlmock.Rows {
 	return sqlmock.NewRows(rowFieldsForCNSI).
-		AddRow(mockCEGUID, "Some fancy HCE Cluster", "hce", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, "", true, mockClientId, mockClientSecret)
+		AddRow(mockCEGUID, "Some fancy HCE Cluster", "hce", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, "", true, mockClientId, cipherClientSecret)
 }
 
 func expectCFAndCERows() sqlmock.Rows {
 	return sqlmock.NewRows(rowFieldsForCNSI).
-		AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, mockClientSecret).
-		AddRow(mockCEGUID, "Some fancy HCE Cluster", "hce", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, "", true, mockClientId, mockClientSecret)
+		AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, cipherClientSecret).
+		AddRow(mockCEGUID, "Some fancy HCE Cluster", "hce", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, "", true, mockClientId, cipherClientSecret)
 }
 
 func expectTokenRow() sqlmock.Rows {
@@ -292,6 +292,8 @@ const (
 var rowFieldsForCNSI = []string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation", "client_id", "client_secret"}
 
 var mockEncryptionKey = make([]byte, 32)
+
+var cipherClientSecret,_ = crypto.EncryptToken(mockEncryptionKey,mockClientSecret)
 
 var mockV2InfoResponse = interfaces.V2Info{
 	AuthorizationEndpoint:  mockAuthEndpoint,

--- a/components/app-core/backend/mock_server_test.go
+++ b/components/app-core/backend/mock_server_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/SUSE/stratos-ui/components/app-core/backend/repository/crypto"
 	"github.com/SUSE/stratos-ui/components/app-core/backend/repository/interfaces"
+	// Uncomment to run tests on non-linux
+	//"github.com/SUSE/stratos-ui/components/app-core/backend/plugin_cloudfoundry"
 )
 
 type mockServer struct {
@@ -114,6 +116,13 @@ func setupMockPGStore(db *sql.DB) *mockPGStore {
 func initCFPlugin(pp *portalProxy) interfaces.StratosPlugin {
 	p, err := plugin.Open("../../cloud-foundry/backend/cloud-foundry.so")
 	if err != nil {
+		// Uncomment to run tests on non-linux
+		//cfPlugin, err := plugin_cloudfoundry.Init(pp)
+		//if err == nil {
+		//	return cfPlugin
+		//}
+	//}
+	//if err != nil {
 		log.Printf("Failed to load plugin!")
 	}
 	init, _ := p.Lookup("Init")
@@ -159,18 +168,18 @@ func expectOneRow() sqlmock.Rows {
 
 func expectCFRow() sqlmock.Rows {
 	return sqlmock.NewRows(rowFieldsForCNSI).
-		AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true)
+		AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, mockClientSecret)
 }
 
 func expectCERow() sqlmock.Rows {
 	return sqlmock.NewRows(rowFieldsForCNSI).
-		AddRow(mockCEGUID, "Some fancy HCE Cluster", "hce", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, "", true)
+		AddRow(mockCEGUID, "Some fancy HCE Cluster", "hce", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, "", true, mockClientId, mockClientSecret)
 }
 
 func expectCFAndCERows() sqlmock.Rows {
 	return sqlmock.NewRows(rowFieldsForCNSI).
-		AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true).
-		AddRow(mockCEGUID, "Some fancy HCE Cluster", "hce", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, "", true)
+		AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, mockClientSecret).
+		AddRow(mockCEGUID, "Some fancy HCE Cluster", "hce", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, "", true, mockClientId, mockClientSecret)
 }
 
 func expectTokenRow() sqlmock.Rows {
@@ -265,6 +274,8 @@ const (
 	mockAuthEndpoint    = "https://login.127.0.0.1"
 	mockTokenEndpoint   = "https://uaa.127.0.0.1"
 	mockDopplerEndpoint = "https://doppler.127.0.0.1"
+	mockClientId		= "stratos_clientid"
+	mockClientSecret	= "big_secret"
 	mockProxyVersion    = 20161117141922
 
 	stringCFType = "cf"
@@ -278,7 +289,7 @@ const (
 	getDbVersion        = `SELECT version_id FROM goose_db_version WHERE is_applied = '1' ORDER BY id DESC LIMIT 1`
 )
 
-var rowFieldsForCNSI = []string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation"}
+var rowFieldsForCNSI = []string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation", "client_id", "client_secret"}
 
 var mockEncryptionKey = make([]byte, 32)
 

--- a/components/app-core/backend/oauth_requests.go
+++ b/components/app-core/backend/oauth_requests.go
@@ -22,16 +22,8 @@ func (p *portalProxy) doOauthFlowRequest(cnsiRequest *CNSIRequest, req *http.Req
 	got401 := false
 	expTime := time.Unix(tokenRec.TokenExpiry, 0)
 	for {
-		clientID, err := p.GetClientId(cnsi.CNSIType)
-		if err != nil {
-			return nil, interfaces.NewHTTPShadowError(
-				http.StatusBadRequest,
-				"Endpoint type has not been registered",
-				"Endpoint type has not been registered %s: %s", cnsi.CNSIType, err)
-		}
-
 		if got401 || expTime.Before(time.Now()) {
-			refreshedTokenRec, err := p.RefreshToken(cnsi.SkipSSLValidation, cnsiRequest.GUID, cnsiRequest.UserGUID, clientID, "", cnsi.TokenEndpoint)
+			refreshedTokenRec, err := p.RefreshToken(cnsi.SkipSSLValidation, cnsiRequest.GUID, cnsiRequest.UserGUID, cnsi.ClientId, "", cnsi.TokenEndpoint)
 			if err != nil {
 				return nil, fmt.Errorf("Couldn't refresh token for CNSI with GUID %s", cnsiRequest.GUID)
 			}

--- a/components/app-core/backend/oauth_requests_test.go
+++ b/components/app-core/backend/oauth_requests_test.go
@@ -105,8 +105,8 @@ func TestDoOauthFlowRequestWithValidToken(t *testing.T) {
 			WillReturnRows(expectedCNSITokenRow)
 
 		//  p.GetCNSIRecord(r.GUID) -> cnsiRepo.Find(guid)
-		expectedCNSIRecordRow := sqlmock.NewRows([]string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation"}).
-			AddRow(mockCNSI.GUID, mockCNSI.Name, mockCNSI.CNSIType, mockURLasString, mockCNSI.AuthorizationEndpoint, mockCNSI.TokenEndpoint, mockCNSI.DopplerLoggingEndpoint, true)
+		expectedCNSIRecordRow := sqlmock.NewRows([]string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation", "client_id", "client_secret"}).
+			AddRow(mockCNSI.GUID, mockCNSI.Name, mockCNSI.CNSIType, mockURLasString, mockCNSI.AuthorizationEndpoint, mockCNSI.TokenEndpoint, mockCNSI.DopplerLoggingEndpoint, true, mockCNSI.ClientId, mockCNSI.ClientSecret)
 		mock.ExpectQuery(selectAnyFromCNSIs).
 			WithArgs(mockCNSIGUID).
 			WillReturnRows(expectedCNSIRecordRow)
@@ -234,8 +234,8 @@ func TestDoOauthFlowRequestWithExpiredToken(t *testing.T) {
 			WillReturnRows(expectedCNSITokenRow)
 
 		//  p.GetCNSIRecord(r.GUID) -> cnsiRepo.Find(guid)
-		expectedCNSIRecordRow := sqlmock.NewRows([]string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation"}).
-			AddRow(mockCNSI.GUID, mockCNSI.Name, mockCNSI.CNSIType, mockURLasString, mockCNSI.AuthorizationEndpoint, mockCNSI.TokenEndpoint, mockCNSI.DopplerLoggingEndpoint, true)
+		expectedCNSIRecordRow := sqlmock.NewRows([]string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation", "client_id", "client_secret"}).
+			AddRow(mockCNSI.GUID, mockCNSI.Name, mockCNSI.CNSIType, mockURLasString, mockCNSI.AuthorizationEndpoint, mockCNSI.TokenEndpoint, mockCNSI.DopplerLoggingEndpoint, true, mockCNSI.ClientId, mockCNSI.ClientSecret)
 		mock.ExpectQuery(selectAnyFromCNSIs).
 			WithArgs(mockCNSIGUID).
 			WillReturnRows(expectedCNSIRecordRow)

--- a/components/app-core/backend/oauth_requests_test.go
+++ b/components/app-core/backend/oauth_requests_test.go
@@ -106,7 +106,7 @@ func TestDoOauthFlowRequestWithValidToken(t *testing.T) {
 
 		//  p.GetCNSIRecord(r.GUID) -> cnsiRepo.Find(guid)
 		expectedCNSIRecordRow := sqlmock.NewRows([]string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation", "client_id", "client_secret"}).
-			AddRow(mockCNSI.GUID, mockCNSI.Name, mockCNSI.CNSIType, mockURLasString, mockCNSI.AuthorizationEndpoint, mockCNSI.TokenEndpoint, mockCNSI.DopplerLoggingEndpoint, true, mockCNSI.ClientId, mockCNSI.ClientSecret)
+			AddRow(mockCNSI.GUID, mockCNSI.Name, mockCNSI.CNSIType, mockURLasString, mockCNSI.AuthorizationEndpoint, mockCNSI.TokenEndpoint, mockCNSI.DopplerLoggingEndpoint, true, mockCNSI.ClientId, cipherClientSecret)
 		mock.ExpectQuery(selectAnyFromCNSIs).
 			WithArgs(mockCNSIGUID).
 			WillReturnRows(expectedCNSIRecordRow)
@@ -235,7 +235,7 @@ func TestDoOauthFlowRequestWithExpiredToken(t *testing.T) {
 
 		//  p.GetCNSIRecord(r.GUID) -> cnsiRepo.Find(guid)
 		expectedCNSIRecordRow := sqlmock.NewRows([]string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation", "client_id", "client_secret"}).
-			AddRow(mockCNSI.GUID, mockCNSI.Name, mockCNSI.CNSIType, mockURLasString, mockCNSI.AuthorizationEndpoint, mockCNSI.TokenEndpoint, mockCNSI.DopplerLoggingEndpoint, true, mockCNSI.ClientId, mockCNSI.ClientSecret)
+			AddRow(mockCNSI.GUID, mockCNSI.Name, mockCNSI.CNSIType, mockURLasString, mockCNSI.AuthorizationEndpoint, mockCNSI.TokenEndpoint, mockCNSI.DopplerLoggingEndpoint, true, mockCNSI.ClientId, cipherClientSecret)
 		mock.ExpectQuery(selectAnyFromCNSIs).
 			WithArgs(mockCNSIGUID).
 			WillReturnRows(expectedCNSIRecordRow)

--- a/components/app-core/backend/passthrough_test.go
+++ b/components/app-core/backend/passthrough_test.go
@@ -263,8 +263,8 @@ func TestValidateCNSIListWithValidGUID(t *testing.T) {
 		_, _, _, pp, db, mock := setupHTTPTest(req)
 		defer db.Close()
 
-		expectedCNSIRecordRow := sqlmock.NewRows([]string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation"}).
-			AddRow("valid-guid-abc123", "mock-name", "cf", "http://localhost", "http://localhost", "http://localhost", mockDopplerEndpoint, true)
+		expectedCNSIRecordRow := sqlmock.NewRows([]string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation", "client_id", "client_secret"}).
+			AddRow("valid-guid-abc123", "mock-name", "cf", "http://localhost", "http://localhost", "http://localhost", mockDopplerEndpoint, true, mockClientId, mockClientSecret)
 		mock.ExpectQuery(selectAnyFromCNSIs).
 			WithArgs("valid-guid-abc123").
 			WillReturnRows(expectedCNSIRecordRow)

--- a/components/app-core/backend/passthrough_test.go
+++ b/components/app-core/backend/passthrough_test.go
@@ -264,7 +264,7 @@ func TestValidateCNSIListWithValidGUID(t *testing.T) {
 		defer db.Close()
 
 		expectedCNSIRecordRow := sqlmock.NewRows([]string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint", "token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation", "client_id", "client_secret"}).
-			AddRow("valid-guid-abc123", "mock-name", "cf", "http://localhost", "http://localhost", "http://localhost", mockDopplerEndpoint, true, mockClientId, mockClientSecret)
+			AddRow("valid-guid-abc123", "mock-name", "cf", "http://localhost", "http://localhost", "http://localhost", mockDopplerEndpoint, true, mockClientId, cipherClientSecret)
 		mock.ExpectQuery(selectAnyFromCNSIs).
 			WithArgs("valid-guid-abc123").
 			WillReturnRows(expectedCNSIRecordRow)

--- a/components/app-core/backend/repository/cnsis/cnsis.go
+++ b/components/app-core/backend/repository/cnsis/cnsis.go
@@ -18,12 +18,12 @@ type RegisteredCluster struct {
 
 // Repository is an application of the repository pattern for storing CNSI Records
 type Repository interface {
-	List() ([]*interfaces.CNSIRecord, error)
+	List(encryptionKey []byte) ([]*interfaces.CNSIRecord, error)
 	ListByUser(userGUID string) ([]*RegisteredCluster, error)
-	Find(guid string) (interfaces.CNSIRecord, error)
-	FindByAPIEndpoint(endpoint string) (interfaces.CNSIRecord, error)
+	Find(guid string, encryptionKey []byte) (interfaces.CNSIRecord, error)
+	FindByAPIEndpoint(endpoint string, encryptionKey []byte) (interfaces.CNSIRecord, error)
 	Delete(guid string) error
-	Save(guid string, cnsiRecord interfaces.CNSIRecord) error
+	Save(guid string, cnsiRecord interfaces.CNSIRecord, encryptionKey []byte) error
 }
 
 type Endpoint interface{

--- a/components/app-core/backend/repository/cnsis/pgsql_cnsis.go
+++ b/components/app-core/backend/repository/cnsis/pgsql_cnsis.go
@@ -210,9 +210,6 @@ func (p *PostgresCNSIRepository) FindByAPIEndpoint(endpoint string) (interfaces.
 // Save - Persist a CNSI Record to a datastore
 func (p *PostgresCNSIRepository) Save(guid string, cnsi interfaces.CNSIRecord) error {
 	log.Println("Save")
-	println(saveCNSI, guid, cnsi.Name, fmt.Sprintf("%s", cnsi.CNSIType),
-		fmt.Sprintf("%s", cnsi.APIEndpoint), cnsi.AuthorizationEndpoint, cnsi.TokenEndpoint, cnsi.DopplerLoggingEndpoint, cnsi.SkipSSLValidation,
-		cnsi.ClientId, cnsi.ClientSecret)
 	if _, err := p.db.Exec(saveCNSI, guid, cnsi.Name, fmt.Sprintf("%s", cnsi.CNSIType),
 		fmt.Sprintf("%s", cnsi.APIEndpoint), cnsi.AuthorizationEndpoint, cnsi.TokenEndpoint, cnsi.DopplerLoggingEndpoint, cnsi.SkipSSLValidation,
 			cnsi.ClientId, cnsi.ClientSecret); err != nil {

--- a/components/app-core/backend/repository/cnsis/pgsql_cnsis.go
+++ b/components/app-core/backend/repository/cnsis/pgsql_cnsis.go
@@ -12,18 +12,18 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-var listCNSIs = `SELECT guid, name, cnsi_type, api_endpoint, auth_endpoint, token_endpoint, doppler_logging_endpoint, skip_ssl_validation
+var listCNSIs = `SELECT guid, name, cnsi_type, api_endpoint, auth_endpoint, token_endpoint, doppler_logging_endpoint, skip_ssl_validation, client_id, client_secret
 							FROM cnsis`
 
 var listCNSIsByUser = `SELECT c.guid, c.name, c.cnsi_type, c.api_endpoint, t.user_guid, t.token_expiry, c.skip_ssl_validation, t.disconnected
 										FROM cnsis c, tokens t
 										WHERE c.guid = t.cnsi_guid AND t.token_type=$1 AND t.user_guid=$2 AND t.disconnected = '0'`
 
-var findCNSI = `SELECT guid, name, cnsi_type, api_endpoint, auth_endpoint, token_endpoint, doppler_logging_endpoint, skip_ssl_validation
+var findCNSI = `SELECT guid, name, cnsi_type, api_endpoint, auth_endpoint, token_endpoint, doppler_logging_endpoint, skip_ssl_validation, client_id, client_secret
 						FROM cnsis
 						WHERE guid=$1`
 
-var findCNSIByAPIEndpoint = `SELECT guid, name, cnsi_type, api_endpoint, auth_endpoint, token_endpoint, doppler_logging_endpoint, skip_ssl_validation
+var findCNSIByAPIEndpoint = `SELECT guid, name, cnsi_type, api_endpoint, auth_endpoint, token_endpoint, doppler_logging_endpoint, skip_ssl_validation, client_id, client_secret
 						FROM cnsis
 						WHERE api_endpoint=$1`
 
@@ -75,7 +75,7 @@ func (p *PostgresCNSIRepository) List() ([]*interfaces.CNSIRecord, error) {
 
 		cnsi := new(interfaces.CNSIRecord)
 
-		err := rows.Scan(&cnsi.GUID, &cnsi.Name, &pCNSIType, &pURL, &cnsi.AuthorizationEndpoint, &cnsi.TokenEndpoint, &cnsi.DopplerLoggingEndpoint, &cnsi.SkipSSLValidation)
+		err := rows.Scan(&cnsi.GUID, &cnsi.Name, &pCNSIType, &pURL, &cnsi.AuthorizationEndpoint, &cnsi.TokenEndpoint, &cnsi.DopplerLoggingEndpoint, &cnsi.SkipSSLValidation, &cnsi.ClientId, &cnsi.ClientSecret)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to scan CNSI records: %v", err)
 		}
@@ -152,7 +152,7 @@ func (p *PostgresCNSIRepository) Find(guid string) (interfaces.CNSIRecord, error
 	cnsi := new(interfaces.CNSIRecord)
 
 	err := p.db.QueryRow(findCNSI, guid).Scan(&cnsi.GUID, &cnsi.Name, &pCNSIType, &pURL,
-		&cnsi.AuthorizationEndpoint, &cnsi.TokenEndpoint, &cnsi.DopplerLoggingEndpoint, &cnsi.SkipSSLValidation)
+		&cnsi.AuthorizationEndpoint, &cnsi.TokenEndpoint, &cnsi.DopplerLoggingEndpoint, &cnsi.SkipSSLValidation, &cnsi.ClientId, &cnsi.ClientSecret)
 
 	switch {
 	case err == sql.ErrNoRows:
@@ -185,7 +185,7 @@ func (p *PostgresCNSIRepository) FindByAPIEndpoint(endpoint string) (interfaces.
 	cnsi := new(interfaces.CNSIRecord)
 
 	err := p.db.QueryRow(findCNSIByAPIEndpoint, endpoint).Scan(&cnsi.GUID, &cnsi.Name, &pCNSIType, &pURL,
-		&cnsi.AuthorizationEndpoint, &cnsi.TokenEndpoint, &cnsi.DopplerLoggingEndpoint, &cnsi.SkipSSLValidation)
+		&cnsi.AuthorizationEndpoint, &cnsi.TokenEndpoint, &cnsi.DopplerLoggingEndpoint, &cnsi.SkipSSLValidation, &cnsi.ClientId, &cnsi.ClientSecret)
 
 	switch {
 	case err == sql.ErrNoRows:

--- a/components/app-core/backend/repository/cnsis/pgsql_cnsis.go
+++ b/components/app-core/backend/repository/cnsis/pgsql_cnsis.go
@@ -27,8 +27,8 @@ var findCNSIByAPIEndpoint = `SELECT guid, name, cnsi_type, api_endpoint, auth_en
 						FROM cnsis
 						WHERE api_endpoint=$1`
 
-var saveCNSI = `INSERT INTO cnsis (guid, name, cnsi_type, api_endpoint, auth_endpoint, token_endpoint, doppler_logging_endpoint, skip_ssl_validation)
-						VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+var saveCNSI = `INSERT INTO cnsis (guid, name, cnsi_type, api_endpoint, auth_endpoint, token_endpoint, doppler_logging_endpoint, skip_ssl_validation, client_id, client_secret)
+						VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
 
 var deleteCNSI = `DELETE FROM cnsis WHERE guid = $1`
 
@@ -210,8 +210,12 @@ func (p *PostgresCNSIRepository) FindByAPIEndpoint(endpoint string) (interfaces.
 // Save - Persist a CNSI Record to a datastore
 func (p *PostgresCNSIRepository) Save(guid string, cnsi interfaces.CNSIRecord) error {
 	log.Println("Save")
+	println(saveCNSI, guid, cnsi.Name, fmt.Sprintf("%s", cnsi.CNSIType),
+		fmt.Sprintf("%s", cnsi.APIEndpoint), cnsi.AuthorizationEndpoint, cnsi.TokenEndpoint, cnsi.DopplerLoggingEndpoint, cnsi.SkipSSLValidation,
+		cnsi.ClientId, cnsi.ClientSecret)
 	if _, err := p.db.Exec(saveCNSI, guid, cnsi.Name, fmt.Sprintf("%s", cnsi.CNSIType),
-		fmt.Sprintf("%s", cnsi.APIEndpoint), cnsi.AuthorizationEndpoint, cnsi.TokenEndpoint, cnsi.DopplerLoggingEndpoint, cnsi.SkipSSLValidation); err != nil {
+		fmt.Sprintf("%s", cnsi.APIEndpoint), cnsi.AuthorizationEndpoint, cnsi.TokenEndpoint, cnsi.DopplerLoggingEndpoint, cnsi.SkipSSLValidation,
+			cnsi.ClientId, cnsi.ClientSecret); err != nil {
 		return fmt.Errorf("Unable to Save CNSI record: %v", err)
 	}
 

--- a/components/app-core/backend/repository/cnsis/pgsql_cnsis_test.go
+++ b/components/app-core/backend/repository/cnsis/pgsql_cnsis_test.go
@@ -108,8 +108,8 @@ func TestPgSQLCNSIs(t *testing.T) {
 
 			// general setup
 			u, _ := url.Parse(mockAPIEndpoint)
-			r1 := &interfaces.CNSIRecord{GUID: mockCFGUID, Name: "Some fancy CF Cluster", CNSIType: "cf", APIEndpoint: u, AuthorizationEndpoint: mockAuthEndpoint, TokenEndpoint: mockAuthEndpoint, DopplerLoggingEndpoint: mockDopplerEndpoint, SkipSSLValidation: true}
-			r2 := &interfaces.CNSIRecord{GUID: mockCEGUID, Name: "Some fancy HCE Cluster", CNSIType: "hce", APIEndpoint: u, AuthorizationEndpoint: mockAuthEndpoint, TokenEndpoint: mockAuthEndpoint, DopplerLoggingEndpoint: "", SkipSSLValidation: true}
+			r1 := &interfaces.CNSIRecord{GUID: mockCFGUID, Name: "Some fancy CF Cluster", CNSIType: "cf", APIEndpoint: u, AuthorizationEndpoint: mockAuthEndpoint, TokenEndpoint: mockAuthEndpoint, DopplerLoggingEndpoint: mockDopplerEndpoint, SkipSSLValidation: true, ClientId: mockClientId, ClientSecret: mockClientSecret}
+			r2 := &interfaces.CNSIRecord{GUID: mockCEGUID, Name: "Some fancy HCE Cluster", CNSIType: "hce", APIEndpoint: u, AuthorizationEndpoint: mockAuthEndpoint, TokenEndpoint: mockAuthEndpoint, DopplerLoggingEndpoint: "", SkipSSLValidation: true, ClientId: mockClientId, ClientSecret: mockClientSecret}
 			expectedList = append(expectedList, r1, r2)
 
 			mockCFAndCERows = sqlmock.NewRows(rowFieldsForCNSI).
@@ -177,7 +177,7 @@ func TestPgSQLCNSIs(t *testing.T) {
 	Convey("Given a request for a list of CNSIs for a user", t, func() {
 
 		var (
-			rowFieldsForCluster = []string{"guid", "name", "cnsi_type", "api_endpoint", "account", "token_expiry", "skip_ssl_validation"}
+			rowFieldsForCluster = []string{"guid", "name", "cnsi_type", "api_endpoint", "account", "token_expiry", "skip_ssl_validation", "disconnected"}
 			expectedList        []*RegisteredCluster
 			mockAccount         = "asd-gjfg-bob"
 		)
@@ -239,8 +239,8 @@ func TestPgSQLCNSIs(t *testing.T) {
 			expectedList = append(expectedList, r1, r2)
 
 			mockClusterList = sqlmock.NewRows(rowFieldsForCluster).
-				AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAccount, mockTokenExpiry, true).
-				AddRow(mockCEGUID, "Some fancy HCE Cluster", "hce", mockAPIEndpoint, mockAccount, mockTokenExpiry, true)
+				AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAccount, mockTokenExpiry, true, false).
+				AddRow(mockCEGUID, "Some fancy HCE Cluster", "hce", mockAPIEndpoint, mockAccount, mockTokenExpiry, true, false)
 			mock.ExpectQuery(selectFromCNSIandTokensWhere).
 				WillReturnRows(mockClusterList)
 
@@ -312,7 +312,7 @@ func TestPgSQLCNSIs(t *testing.T) {
 
 			// General setup
 			u, _ := url.Parse(mockAPIEndpoint)
-			expectedCNSIRecord := interfaces.CNSIRecord{GUID: mockCFGUID, Name: "Some fancy CF Cluster", CNSIType: "cf", APIEndpoint: u, AuthorizationEndpoint: mockAuthEndpoint, TokenEndpoint: mockAuthEndpoint, DopplerLoggingEndpoint: mockDopplerEndpoint, SkipSSLValidation: true}
+			expectedCNSIRecord := interfaces.CNSIRecord{GUID: mockCFGUID, Name: "Some fancy CF Cluster", CNSIType: "cf", APIEndpoint: u, AuthorizationEndpoint: mockAuthEndpoint, TokenEndpoint: mockAuthEndpoint, DopplerLoggingEndpoint: mockDopplerEndpoint, SkipSSLValidation: true, ClientId: mockClientId, ClientSecret: mockClientSecret}
 
 			rs := sqlmock.NewRows(rowFieldsForCNSI).
 				AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, mockClientSecret)
@@ -409,7 +409,7 @@ func TestPgSQLCNSIs(t *testing.T) {
 
 			// General setup
 			u, _ := url.Parse(mockAPIEndpoint)
-			expectedCNSIRecord := interfaces.CNSIRecord{GUID: mockCFGUID, Name: "Some fancy CF Cluster", CNSIType: "cf", APIEndpoint: u, AuthorizationEndpoint: mockAuthEndpoint, TokenEndpoint: mockAuthEndpoint, DopplerLoggingEndpoint: mockDopplerEndpoint, SkipSSLValidation: true}
+			expectedCNSIRecord := interfaces.CNSIRecord{GUID: mockCFGUID, Name: "Some fancy CF Cluster", CNSIType: "cf", APIEndpoint: u, AuthorizationEndpoint: mockAuthEndpoint, TokenEndpoint: mockAuthEndpoint, DopplerLoggingEndpoint: mockDopplerEndpoint, SkipSSLValidation: true, ClientId: mockClientId, ClientSecret: mockClientSecret}
 
 			rs := sqlmock.NewRows(rowFieldsForCNSI).
 				AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, mockClientSecret)
@@ -507,10 +507,10 @@ func TestPgSQLCNSIs(t *testing.T) {
 
 			// General setup
 			u, _ := url.Parse(mockAPIEndpoint)
-			cnsi := interfaces.CNSIRecord{GUID: mockCFGUID, Name: "Some fancy CF Cluster", CNSIType: "cf", APIEndpoint: u, AuthorizationEndpoint: mockAuthEndpoint, TokenEndpoint: mockAuthEndpoint, DopplerLoggingEndpoint: mockDopplerEndpoint, SkipSSLValidation: true}
+			cnsi := interfaces.CNSIRecord{GUID: mockCFGUID, Name: "Some fancy CF Cluster", CNSIType: "cf", APIEndpoint: u, AuthorizationEndpoint: mockAuthEndpoint, TokenEndpoint: mockAuthEndpoint, DopplerLoggingEndpoint: mockDopplerEndpoint, SkipSSLValidation: true, ClientId: mockClientId, ClientSecret: mockClientSecret}
 
 			mock.ExpectExec(insertIntoCNSIs).
-				WithArgs(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true).
+				WithArgs(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, mockClientSecret).
 				WillReturnResult(sqlmock.NewResult(1, 1))
 
 			Convey("there should be no error returned", func() {
@@ -527,11 +527,11 @@ func TestPgSQLCNSIs(t *testing.T) {
 
 			// General setup
 			u, _ := url.Parse(mockAPIEndpoint)
-			cnsi := interfaces.CNSIRecord{GUID: mockCFGUID, Name: "Some fancy CF Cluster", CNSIType: "cf", APIEndpoint: u, AuthorizationEndpoint: mockAuthEndpoint, TokenEndpoint: mockAuthEndpoint, DopplerLoggingEndpoint: mockDopplerEndpoint, SkipSSLValidation: true}
+			cnsi := interfaces.CNSIRecord{GUID: mockCFGUID, Name: "Some fancy CF Cluster", CNSIType: "cf", APIEndpoint: u, AuthorizationEndpoint: mockAuthEndpoint, TokenEndpoint: mockAuthEndpoint, DopplerLoggingEndpoint: mockDopplerEndpoint, SkipSSLValidation: true,  ClientId: mockClientId, ClientSecret: mockClientSecret}
 			expectedErrorMessage := fmt.Sprintf("Unable to Save CNSI record: %s", unknownDBError)
 
 			mock.ExpectExec(insertIntoCNSIs).
-				WithArgs(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true).
+				WithArgs(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, mockClientSecret).
 				WillReturnError(errors.New(unknownDBError))
 
 			Convey("there should be an error returned", func() {

--- a/components/app-core/backend/repository/cnsis/pgsql_cnsis_test.go
+++ b/components/app-core/backend/repository/cnsis/pgsql_cnsis_test.go
@@ -21,6 +21,8 @@ func TestPgSQLCNSIs(t *testing.T) {
 		mockAPIEndpoint     = "https://api.127.0.0.1"
 		mockAuthEndpoint    = "https://login.127.0.0.1"
 		mockDopplerEndpoint = "https://doppler.127.0.0.1"
+		mockClientId		= "stratos_clientid"
+		mockClientSecret	= "stratos_secret"
 		unknownDBError      = "Unknown Database Error"
 
 		selectAnyFromCNSIs           = `SELECT (.+) FROM cnsis`
@@ -29,7 +31,7 @@ func TestPgSQLCNSIs(t *testing.T) {
 		insertIntoCNSIs              = `INSERT INTO cnsis`
 		deleteFromCNSIs              = `DELETE FROM cnsis WHERE (.+)`
 		rowFieldsForCNSI             = []string{"guid", "name", "cnsi_type", "api_endpoint", "auth_endpoint",
-			"token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation"}
+			"token_endpoint", "doppler_logging_endpoint", "skip_ssl_validation", "client_id", "client_secret"}
 	)
 
 	Convey("Given a request for a new reference to a CNSI Repository", t, func() {
@@ -111,8 +113,8 @@ func TestPgSQLCNSIs(t *testing.T) {
 			expectedList = append(expectedList, r1, r2)
 
 			mockCFAndCERows = sqlmock.NewRows(rowFieldsForCNSI).
-				AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true).
-				AddRow(mockCEGUID, "Some fancy HCE Cluster", "hce", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, "", true)
+				AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, mockClientSecret).
+				AddRow(mockCEGUID, "Some fancy HCE Cluster", "hce", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, "", true, mockClientId, mockClientSecret)
 			mock.ExpectQuery(selectAnyFromCNSIs).
 				WillReturnRows(mockCFAndCERows)
 
@@ -313,7 +315,7 @@ func TestPgSQLCNSIs(t *testing.T) {
 			expectedCNSIRecord := interfaces.CNSIRecord{GUID: mockCFGUID, Name: "Some fancy CF Cluster", CNSIType: "cf", APIEndpoint: u, AuthorizationEndpoint: mockAuthEndpoint, TokenEndpoint: mockAuthEndpoint, DopplerLoggingEndpoint: mockDopplerEndpoint, SkipSSLValidation: true}
 
 			rs := sqlmock.NewRows(rowFieldsForCNSI).
-				AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true)
+				AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, mockClientSecret)
 			mock.ExpectQuery(selectFromCNSIsWhere).
 				WillReturnRows(rs)
 
@@ -410,7 +412,7 @@ func TestPgSQLCNSIs(t *testing.T) {
 			expectedCNSIRecord := interfaces.CNSIRecord{GUID: mockCFGUID, Name: "Some fancy CF Cluster", CNSIType: "cf", APIEndpoint: u, AuthorizationEndpoint: mockAuthEndpoint, TokenEndpoint: mockAuthEndpoint, DopplerLoggingEndpoint: mockDopplerEndpoint, SkipSSLValidation: true}
 
 			rs := sqlmock.NewRows(rowFieldsForCNSI).
-				AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true)
+				AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, mockClientSecret)
 			mock.ExpectQuery(selectFromCNSIsWhere).
 				WillReturnRows(rs)
 

--- a/components/app-core/backend/repository/interfaces/endpoints.go
+++ b/components/app-core/backend/repository/interfaces/endpoints.go
@@ -7,7 +7,6 @@ import (
 type EndpointPlugin interface {
 	Info(apiEndpoint string, skipSSLValidation bool) (CNSIRecord, interface{}, error)
 	GetType() string
-	GetClientId() string
 	Register(echoContext echo.Context) error
 }
 

--- a/components/app-core/backend/repository/interfaces/portal_proxy.go
+++ b/components/app-core/backend/repository/interfaces/portal_proxy.go
@@ -11,7 +11,7 @@ type PortalProxy interface {
 	GetHttpClient(skipSSLValidation bool) http.Client
 	RegisterEndpoint(c echo.Context, fetchInfo InfoFunc) error
 
-	DoRegisterEndpoint(cnsiName string, apiEndpoint string, skipSSLValidation bool, fetchInfo InfoFunc) (CNSIRecord, error)
+	DoRegisterEndpoint(cnsiName string, apiEndpoint string, skipSSLValidation bool, clientId string, clientSecret string, fetchInfo InfoFunc) (CNSIRecord, error)
 
 	GetEndpointTypeSpec(typeName string) (EndpointPlugin, error)
 

--- a/components/app-core/backend/repository/interfaces/portal_proxy.go
+++ b/components/app-core/backend/repository/interfaces/portal_proxy.go
@@ -34,8 +34,6 @@ type PortalProxy interface {
 	GetCNSIUser(cnsiGUID string, userGUID string) (*ConnectedUser, bool)
 	GetConfig() *PortalConfig
 
-	GetClientId(cnsiType string) (string, error)
-
 	// UAA Token
 	GetUAATokenRecord(userGUID string) (TokenRecord, error)
 	RefreshUAAToken(userGUID string) (TokenRecord, error)

--- a/components/app-core/backend/repository/interfaces/structs.go
+++ b/components/app-core/backend/repository/interfaces/structs.go
@@ -29,6 +29,8 @@ type CNSIRecord struct {
 	TokenEndpoint          string   `json:"token_endpoint"`
 	DopplerLoggingEndpoint string   `json:"doppler_logging_endpoint"`
 	SkipSSLValidation      bool     `json:"skip_ssl_validation"`
+	ClientId			   string 	`json:"client_id"`
+	ClientSecret 		   string 	`json:"-"`
 }
 
 //TODO this could be moved back to tokens subpackage, and extensions could import it?

--- a/components/app-core/backend/repository/tokens/pgsql_tokens_test.go
+++ b/components/app-core/backend/repository/tokens/pgsql_tokens_test.go
@@ -13,15 +13,16 @@ import (
 )
 
 const (
-	mockUAAToken = `eyJhbGciOiJSUzI1NiIsImtpZCI6ImxlZ2FjeS10b2tlbi1rZXkiLCJ0eXAiOiJKV1QifQ.eyJqdGkiOiI2ZGIyYTI5NGYyYWE0OGNlYjI1NDgzMDk4ZDNjY2Q3YyIsInN1YiI6Ijg4YmNlYWE1LWJkY2UtNDdiOC04MmYzLTRhZmMxNGYyNjZmOSIsInNjb3BlIjpbIm9wZW5pZCIsInNjaW0ucmVhZCIsImNsb3VkX2NvbnRyb2xsZXIuYWRtaW4iLCJ1YWEudXNlciIsImNsb3VkX2NvbnRyb2xsZXIucmVhZCIsInBhc3N3b3JkLndyaXRlIiwicm91dGluZy5yb3V0ZXJfZ3JvdXBzLnJlYWQiLCJjbG91ZF9jb250cm9sbGVyLndyaXRlIiwiZG9wcGxlci5maXJlaG9zZSIsInNjaW0ud3JpdGUiXSwiY2xpZW50X2lkIjoiY2YiLCJjaWQiOiJjZiIsImF6cCI6ImNmIiwiZ3JhbnRfdHlwZSI6InBhc3N3b3JkIiwidXNlcl9pZCI6Ijg4YmNlYWE1LWJkY2UtNDdiOC04MmYzLTRhZmMxNGYyNjZmOSIsIm9yaWdpbiI6InVhYSIsInVzZXJfbmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbiIsImF1dGhfdGltZSI6MTQ2Nzc2OTgxNiwicmV2X3NpZyI6IjE0MGUwMjZiIiwiaWF0IjoxNDY3NzY5ODE2LCJleHAiOjE0Njc3NzA0MTYsImlzcyI6Imh0dHBzOi8vdWFhLmV4YW1wbGUuY29tL29hdXRoL3Rva2VuIiwiemlkIjoidWFhIiwiYXVkIjpbImNmIiwib3BlbmlkIiwic2NpbSIsImNsb3VkX2NvbnRyb2xsZXIiLCJ1YWEiLCJwYXNzd29yZCIsInJvdXRpbmcucm91dGVyX2dyb3VwcyIsImRvcHBsZXIiXX0.q2u0JX42Qiwr0ZsBU5Y6bF74_0URWmmBYTLf8l7of_6huFoMkyqvirEYcbYbATt6Hz2zcN6xlXcInALxQ6nt6Jk01kZHRNYfuu6QziLHHw2o_dJWk9iipiermUze7BvSGtU_JXx45BSBNVFxvRxG9Yv54Lwa9FvyhMSmK3CI5S8NtVDchzrsH3sMsIjlTAb-L7sch-OOQ7ncWH1JoGMtw8sTbiaHvfNJQclSq8Ro11NUtRHiWeGFFxYIerzKO-TrSpDojFJrYVuK1m0YPmBDa_dY3cneRuppagRIn8oI0VFHF8BckrIqNCHvOMoVz6uzHebo9LK7H5z5SluxJ2vYUgPiHE_Tyo-7gELnNSy8qL4Bk9yTxNseeGiq13TSTGOtNnbrv1eq4ZeW7eafseLceKIZH2QZlXVzwd_aWbuKRv9ApDwy4AcSbpM0XtU89IjUEDoOf3IDWV2YZTZkEaXZ52Mhztb1O_IVpHyyks88P67RoANFt83MnCai9U3stCX45LEsg9oz2djrVnfHDzRNQVlg9hKJYbxsa2R5tpnftjhz-hfpsoPRxBkJDKM2islyd-gLqHtsERiZEoifu93VRE0Jvk6vaCNdStw7y4mq73Co6ykNUYA78SlT9lCwDJRQHTJiDWg33EeKpXne8joZbElwrKNcv93X1qxxvmp1wXQ bearer eyJhbGciOiJSUzI1NiIsImtpZCI6ImxlZ2FjeS10b2tlbi1rZXkiLCJ0eXAiOiJKV1QifQ.eyJqdGkiOiI2ZGIyYTI5NGYyYWE0OGNlYjI1NDgzMDk4ZDNjY2Q3Yy1yIiwic3ViIjoiODhiY2VhYTUtYmRjZS00N2I4LTgyZjMtNGFmYzE0ZjI2NmY5Iiwic2NvcGUiOlsib3BlbmlkIiwic2NpbS5yZWFkIiwiY2xvdWRfY29udHJvbGxlci5hZG1pbiIsInVhYS51c2VyIiwiY2xvdWRfY29udHJvbGxlci5yZWFkIiwicGFzc3dvcmQud3JpdGUiLCJyb3V0aW5nLnJvdXRlcl9ncm91cHMucmVhZCIsImNsb3VkX2NvbnRyb2xsZXIud3JpdGUiLCJkb3BwbGVyLmZpcmVob3NlIiwic2NpbS53cml0ZSJdLCJpYXQiOjE0Njc3Njk4MTYsImV4cCI6MTQ3MDM2MTgxNiwiY2lkIjoiY2YiLCJjbGllbnRfaWQiOiJjZiIsImlzcyI6Imh0dHBzOi8vdWFhLmV4YW1wbGUuY29tL29hdXRoL3Rva2VuIiwiemlkIjoidWFhIiwiZ3JhbnRfdHlwZSI6InBhc3N3b3JkIiwidXNlcl9uYW1lIjoiYWRtaW4iLCJvcmlnaW4iOiJ1YWEiLCJ1c2VyX2lkIjoiODhiY2VhYTUtYmRjZS00N2I4LTgyZjMtNGFmYzE0ZjI2NmY5IiwicmV2X3NpZyI6IjE0MGUwMjZiIiwiYXVkIjpbImNmIiwib3BlbmlkIiwic2NpbSIsImNsb3VkX2NvbnRyb2xsZXIiLCJ1YWEiLCJwYXNzd29yZCIsInJvdXRpbmcucm91dGVyX2dyb3VwcyIsImRvcHBsZXIiXX0.K5M_isGkEBAN_MaXqkVvJfHG86rGIUkDgsHaFnoKOA1x5FNC4APDvhImWJZ8zbFHhXT3PYHTyeSf_HQaFDFUHFvGZUhSSry2ID4kdU5kRyZ-y3ydkv2mq32BlUQBSC9ap0r5vFTv7BY1yf2EcDaKGe4v4ODMhTm2SIkdTyk2ZcLXHIucS0xgSZdjgxNqh3pnKtmcFkw72-CyREW4_2Nbvn_7U2UNUCb2SeAuWmYaNAOkuGveB8jAhg9ftTrxn5GNtNe1sdVycm51X1O0dGPt_rLbwkRDCdNpm0La_xzLqZEl60_YUqwo33eOChFgqXB5y_0Pzs9gD__uExrIXYIgMsltFELXryyRUDKTTHZEEw1bnLTbQfF-GAnS0E0CaTU_kcDVqDYcqfh0TCcr7nGCEozExMPm3J0OGUSP3FQAD5mDICsKKcSIi_kIjggkJ87tuNAY6QOW1WzBoRizXJVS4jb3QOnrii2LmH786qBYJMX0nH__JRYEU-HWLi_OGXVTo03Pe9QcB8qJvbu2DGRfQdBfjhvgt2AItY4voJnZcjwT29q144C5wvJ2_W8cUzNY-Xw_tN_fWK4LWCu6KRNLVLO2MNbl0aOfkvb1U5NZJUpUUC2jG3cZM2c8232YNFKVjdjbf-Mlx17OxOYQ5XtG5BiSEj7BA6s5hWftUXEUchg`
-	mockCNSIToken = mockUAAToken
-	mockUserGuid = "foo-bar"
-	mockCNSIGuid = "foo-bar"
-	countTokensSql = `SELECT COUNT`
-	insertTokenSql = `INSERT INTO tokens`
-	updateUAATokenSql = `UPDATE tokens`
-	findUAATokenSql = `SELECT auth_token, refresh_token, token_expiry FROM tokens .*`
-	deleteFromTokensSql = `DELETE FROM tokens`
+	mockUAAToken                    = `eyJhbGciOiJSUzI1NiIsImtpZCI6ImxlZ2FjeS10b2tlbi1rZXkiLCJ0eXAiOiJKV1QifQ.eyJqdGkiOiI2ZGIyYTI5NGYyYWE0OGNlYjI1NDgzMDk4ZDNjY2Q3YyIsInN1YiI6Ijg4YmNlYWE1LWJkY2UtNDdiOC04MmYzLTRhZmMxNGYyNjZmOSIsInNjb3BlIjpbIm9wZW5pZCIsInNjaW0ucmVhZCIsImNsb3VkX2NvbnRyb2xsZXIuYWRtaW4iLCJ1YWEudXNlciIsImNsb3VkX2NvbnRyb2xsZXIucmVhZCIsInBhc3N3b3JkLndyaXRlIiwicm91dGluZy5yb3V0ZXJfZ3JvdXBzLnJlYWQiLCJjbG91ZF9jb250cm9sbGVyLndyaXRlIiwiZG9wcGxlci5maXJlaG9zZSIsInNjaW0ud3JpdGUiXSwiY2xpZW50X2lkIjoiY2YiLCJjaWQiOiJjZiIsImF6cCI6ImNmIiwiZ3JhbnRfdHlwZSI6InBhc3N3b3JkIiwidXNlcl9pZCI6Ijg4YmNlYWE1LWJkY2UtNDdiOC04MmYzLTRhZmMxNGYyNjZmOSIsIm9yaWdpbiI6InVhYSIsInVzZXJfbmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbiIsImF1dGhfdGltZSI6MTQ2Nzc2OTgxNiwicmV2X3NpZyI6IjE0MGUwMjZiIiwiaWF0IjoxNDY3NzY5ODE2LCJleHAiOjE0Njc3NzA0MTYsImlzcyI6Imh0dHBzOi8vdWFhLmV4YW1wbGUuY29tL29hdXRoL3Rva2VuIiwiemlkIjoidWFhIiwiYXVkIjpbImNmIiwib3BlbmlkIiwic2NpbSIsImNsb3VkX2NvbnRyb2xsZXIiLCJ1YWEiLCJwYXNzd29yZCIsInJvdXRpbmcucm91dGVyX2dyb3VwcyIsImRvcHBsZXIiXX0.q2u0JX42Qiwr0ZsBU5Y6bF74_0URWmmBYTLf8l7of_6huFoMkyqvirEYcbYbATt6Hz2zcN6xlXcInALxQ6nt6Jk01kZHRNYfuu6QziLHHw2o_dJWk9iipiermUze7BvSGtU_JXx45BSBNVFxvRxG9Yv54Lwa9FvyhMSmK3CI5S8NtVDchzrsH3sMsIjlTAb-L7sch-OOQ7ncWH1JoGMtw8sTbiaHvfNJQclSq8Ro11NUtRHiWeGFFxYIerzKO-TrSpDojFJrYVuK1m0YPmBDa_dY3cneRuppagRIn8oI0VFHF8BckrIqNCHvOMoVz6uzHebo9LK7H5z5SluxJ2vYUgPiHE_Tyo-7gELnNSy8qL4Bk9yTxNseeGiq13TSTGOtNnbrv1eq4ZeW7eafseLceKIZH2QZlXVzwd_aWbuKRv9ApDwy4AcSbpM0XtU89IjUEDoOf3IDWV2YZTZkEaXZ52Mhztb1O_IVpHyyks88P67RoANFt83MnCai9U3stCX45LEsg9oz2djrVnfHDzRNQVlg9hKJYbxsa2R5tpnftjhz-hfpsoPRxBkJDKM2islyd-gLqHtsERiZEoifu93VRE0Jvk6vaCNdStw7y4mq73Co6ykNUYA78SlT9lCwDJRQHTJiDWg33EeKpXne8joZbElwrKNcv93X1qxxvmp1wXQ bearer eyJhbGciOiJSUzI1NiIsImtpZCI6ImxlZ2FjeS10b2tlbi1rZXkiLCJ0eXAiOiJKV1QifQ.eyJqdGkiOiI2ZGIyYTI5NGYyYWE0OGNlYjI1NDgzMDk4ZDNjY2Q3Yy1yIiwic3ViIjoiODhiY2VhYTUtYmRjZS00N2I4LTgyZjMtNGFmYzE0ZjI2NmY5Iiwic2NvcGUiOlsib3BlbmlkIiwic2NpbS5yZWFkIiwiY2xvdWRfY29udHJvbGxlci5hZG1pbiIsInVhYS51c2VyIiwiY2xvdWRfY29udHJvbGxlci5yZWFkIiwicGFzc3dvcmQud3JpdGUiLCJyb3V0aW5nLnJvdXRlcl9ncm91cHMucmVhZCIsImNsb3VkX2NvbnRyb2xsZXIud3JpdGUiLCJkb3BwbGVyLmZpcmVob3NlIiwic2NpbS53cml0ZSJdLCJpYXQiOjE0Njc3Njk4MTYsImV4cCI6MTQ3MDM2MTgxNiwiY2lkIjoiY2YiLCJjbGllbnRfaWQiOiJjZiIsImlzcyI6Imh0dHBzOi8vdWFhLmV4YW1wbGUuY29tL29hdXRoL3Rva2VuIiwiemlkIjoidWFhIiwiZ3JhbnRfdHlwZSI6InBhc3N3b3JkIiwidXNlcl9uYW1lIjoiYWRtaW4iLCJvcmlnaW4iOiJ1YWEiLCJ1c2VyX2lkIjoiODhiY2VhYTUtYmRjZS00N2I4LTgyZjMtNGFmYzE0ZjI2NmY5IiwicmV2X3NpZyI6IjE0MGUwMjZiIiwiYXVkIjpbImNmIiwib3BlbmlkIiwic2NpbSIsImNsb3VkX2NvbnRyb2xsZXIiLCJ1YWEiLCJwYXNzd29yZCIsInJvdXRpbmcucm91dGVyX2dyb3VwcyIsImRvcHBsZXIiXX0.K5M_isGkEBAN_MaXqkVvJfHG86rGIUkDgsHaFnoKOA1x5FNC4APDvhImWJZ8zbFHhXT3PYHTyeSf_HQaFDFUHFvGZUhSSry2ID4kdU5kRyZ-y3ydkv2mq32BlUQBSC9ap0r5vFTv7BY1yf2EcDaKGe4v4ODMhTm2SIkdTyk2ZcLXHIucS0xgSZdjgxNqh3pnKtmcFkw72-CyREW4_2Nbvn_7U2UNUCb2SeAuWmYaNAOkuGveB8jAhg9ftTrxn5GNtNe1sdVycm51X1O0dGPt_rLbwkRDCdNpm0La_xzLqZEl60_YUqwo33eOChFgqXB5y_0Pzs9gD__uExrIXYIgMsltFELXryyRUDKTTHZEEw1bnLTbQfF-GAnS0E0CaTU_kcDVqDYcqfh0TCcr7nGCEozExMPm3J0OGUSP3FQAD5mDICsKKcSIi_kIjggkJ87tuNAY6QOW1WzBoRizXJVS4jb3QOnrii2LmH786qBYJMX0nH__JRYEU-HWLi_OGXVTo03Pe9QcB8qJvbu2DGRfQdBfjhvgt2AItY4voJnZcjwT29q144C5wvJ2_W8cUzNY-Xw_tN_fWK4LWCu6KRNLVLO2MNbl0aOfkvb1U5NZJUpUUC2jG3cZM2c8232YNFKVjdjbf-Mlx17OxOYQ5XtG5BiSEj7BA6s5hWftUXEUchg`
+	mockCNSIToken                   = mockUAAToken
+	mockUserGuid                    = "foo-bar"
+	mockCNSIGuid                    = "foo-bar"
+	countTokensSql                  = `SELECT COUNT`
+	insertTokenSql                  = `INSERT INTO tokens`
+	updateUAATokenSql               = `UPDATE tokens`
+	findUAATokenSql                 = `SELECT auth_token, refresh_token, token_expiry FROM tokens .*`
+	findUAATokenSqlWithDisconnected = `SELECT auth_token, refresh_token, token_expiry, disconnected FROM tokens .*`
+	deleteFromTokensSql             = `DELETE FROM tokens`
 )
 
 var mockTokenExpiry = time.Now().AddDate(0, 0, 1).Unix()
@@ -209,14 +210,14 @@ func TestSaveCNSITokens(t *testing.T) {
 					So(mock.ExpectationsWereMet(), ShouldBeNil)
 				})
 
-				Convey("Should suceed to insert", func() {
+				Convey("Should succeed to insert", func() {
 
 					rs := sqlmock.NewRows([]string{"COUNT"}).AddRow("value")
 					mock.ExpectQuery(countTokensSql).
 						WillReturnRows(rs)
 
 					mock.ExpectExec(insertTokenSql).
-						WithArgs(mockCNSIGuid, mockUserGuid, "cnsi", sqlmock.AnyArg(), sqlmock.AnyArg(), tokenRecord.TokenExpiry).
+						WithArgs(mockCNSIGuid, mockUserGuid, "cnsi", sqlmock.AnyArg(), sqlmock.AnyArg(), tokenRecord.TokenExpiry, false).
 						WillReturnResult(sqlmock.NewResult(1, 1))
 
 					err := repository.SaveCNSIToken(mockCNSIGuid, mockUserGuid, tokenRecord, mockEncryptionKey)
@@ -278,8 +279,8 @@ func TestFindUAATokens(t *testing.T) {
 		})
 
 		Convey("should fail to decrypt with invalid encryptionKey", func() {
-			rs := sqlmock.NewRows([]string{"auth_token", "refresh_token", "token_expiry", "disconnected"}).
-				AddRow(mockUAAToken, mockUAAToken, mockTokenExpiry, false)
+			rs := sqlmock.NewRows([]string{"auth_token", "refresh_token", "token_expiry"}).
+				AddRow(mockUAAToken, mockUAAToken, mockTokenExpiry)
 
 			mock.ExpectQuery(findUAATokenSql).
 				WillReturnRows(rs)
@@ -291,8 +292,8 @@ func TestFindUAATokens(t *testing.T) {
 
 		Convey("Success case", func() {
 
-			rs := sqlmock.NewRows([]string{"auth_token", "refresh_token", "token_expiry", "disconnected"}).
-				AddRow(mockUAAToken, mockUAAToken, mockTokenExpiry, false)
+			rs := sqlmock.NewRows([]string{"auth_token", "refresh_token", "token_expiry"}).
+				AddRow(mockUAAToken, mockUAAToken, mockTokenExpiry)
 
 			mock.ExpectQuery(findUAATokenSql).
 				WillReturnRows(rs)
@@ -333,7 +334,7 @@ func TestFindCNSITokens(t *testing.T) {
 		})
 
 		Convey("should throw exception when finding a non-existent token", func() {
-			mock.ExpectQuery(findUAATokenSql).
+			mock.ExpectQuery(findUAATokenSqlWithDisconnected).
 				WillReturnError(errors.New("doesnt exist"))
 			_, err := repository.FindCNSIToken(mockCNSIToken, mockUserGuid, mockEncryptionKey)
 
@@ -345,7 +346,7 @@ func TestFindCNSITokens(t *testing.T) {
 			rs := sqlmock.NewRows([]string{"auth_token", "refresh_token", "token_expiry", "disconnected"}).
 				AddRow(mockUAAToken, mockUAAToken, mockTokenExpiry, false)
 
-			mock.ExpectQuery(findUAATokenSql).
+			mock.ExpectQuery(findUAATokenSqlWithDisconnected).
 				WillReturnRows(rs)
 			_, err := repository.FindCNSIToken(mockCNSIToken, mockUserGuid, nil)
 
@@ -358,7 +359,7 @@ func TestFindCNSITokens(t *testing.T) {
 			rs := sqlmock.NewRows([]string{"auth_token", "refresh_token", "token_expiry", "disconnected"}).
 				AddRow(mockUAAToken, mockUAAToken, mockTokenExpiry, false)
 
-			mock.ExpectQuery(findUAATokenSql).
+			mock.ExpectQuery(findUAATokenSqlWithDisconnected).
 				WillReturnRows(rs)
 			tr, err := repository.FindCNSIToken(mockCNSIToken, mockUserGuid, mockEncryptionKey)
 
@@ -390,7 +391,7 @@ func TestListCNSITokensForUser(t *testing.T) {
 		})
 
 		Convey("should throw exception when finding a non-existent token", func() {
-			mock.ExpectQuery(findUAATokenSql).
+			mock.ExpectQuery(findUAATokenSqlWithDisconnected).
 				WillReturnError(errors.New("doesnt exist"))
 			_, err := repository.ListCNSITokensForUser(mockUserGuid, mockEncryptionKey)
 
@@ -403,7 +404,7 @@ func TestListCNSITokensForUser(t *testing.T) {
 			rs := sqlmock.NewRows([]string{"auth_token", "refresh_token", "token_expiry", "disconnected"}).
 				AddRow(mockUAAToken, mockUAAToken, mockTokenExpiry, false)
 
-			mock.ExpectQuery(findUAATokenSql).
+			mock.ExpectQuery(findUAATokenSqlWithDisconnected).
 				WillReturnRows(rs)
 			tr, err := repository.ListCNSITokensForUser(mockUserGuid, mockEncryptionKey)
 

--- a/components/cf-app-ssh/backend/cf_websocket_app_ssh.go
+++ b/components/cf-app-ssh/backend/cf_websocket_app_ssh.go
@@ -96,14 +96,9 @@ func (cfAppSsh *CFAppSsh) appSSH(c echo.Context) error {
 	// cf:APP-GUID/APP-INSTANCE-INDEX@SSH-ENDPOINT
 	username := fmt.Sprintf("cf:%s/%s@%s", appGUID, appInstance, host)
 
-	clientID, err := p.GetClientId("cf")
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Could not get client ID forCloud Foundry")
-	}
-
 	// Need to get SSH Code
 	// Refresh token first - makes sure it will be valid when we make the request to get the code
-	refreshedTokenRec, err := p.RefreshToken(cnsiRecord.SkipSSLValidation, cnsiRecord.GUID, userGUID, clientID, "", cnsiRecord.TokenEndpoint)
+	refreshedTokenRec, err := p.RefreshToken(cnsiRecord.SkipSSLValidation, cnsiRecord.GUID, userGUID, cnsiRecord.ClientId, cnsiRecord.ClientSecret, cnsiRecord.TokenEndpoint)
 	if err != nil {
 		return fmt.Errorf("Couldn't get refresh token for CNSI with GUID %s", cnsiRecord.GUID)
 	}

--- a/components/cloud-foundry/backend/cf_websocket_streams.go
+++ b/components/cloud-foundry/backend/cf_websocket_streams.go
@@ -87,7 +87,7 @@ func (c CloudFoundrySpecification) openNoaaConsumer(echoContext echo.Context) (*
 	}
 
 	ac.refreshToken = func() error {
-		newTokenRecord, err := c.portalProxy.RefreshToken(cnsiRecord.SkipSSLValidation, cnsiGUID, userGUID, "", "", cnsiRecord.TokenEndpoint)
+		newTokenRecord, err := c.portalProxy.RefreshToken(cnsiRecord.SkipSSLValidation, cnsiGUID, userGUID, cnsiRecord.ClientId, cnsiRecord.ClientSecret, cnsiRecord.TokenEndpoint)
 		if err != nil {
 			msg := fmt.Sprintf("Error refreshing token for CNSI %s : [%v]", cnsiGUID, err)
 			return echo.NewHTTPError(http.StatusUnauthorized, msg)

--- a/components/cloud-foundry/backend/main.go
+++ b/components/cloud-foundry/backend/main.go
@@ -72,7 +72,7 @@ func (c *CloudFoundrySpecification) cfLoginHook(context echo.Context) error {
 		cfEndpointSpec, _ := c.portalProxy.GetEndpointTypeSpec("cf")
 
 		// Auto-register the Cloud Foundry
-		cfCnsi, err = c.portalProxy.DoRegisterEndpoint("Cloud Foundry", cfAPI, true, cfEndpointSpec.Info)
+		cfCnsi, err = c.portalProxy.DoRegisterEndpoint("Cloud Foundry", cfAPI, true, c.portalProxy.GetConfig().CFClient, c.portalProxy.GetConfig().CFClientSecret, cfEndpointSpec.Info)
 		if err != nil {
 			log.Fatal("Could not auto-register Cloud Foundry endpoint", err)
 			return nil

--- a/components/cloud-foundry/backend/main.go
+++ b/components/cloud-foundry/backend/main.go
@@ -9,7 +9,6 @@ import (
 
 	"errors"
 
-	"github.com/SUSE/stratos-ui/components/app-core/backend/config"
 	"github.com/SUSE/stratos-ui/components/app-core/backend/repository/interfaces"
 	log "github.com/Sirupsen/logrus"
 	"github.com/labstack/echo"
@@ -43,14 +42,6 @@ func (c *CloudFoundrySpecification) GetMiddlewarePlugin() (interfaces.Middleware
 
 func (c *CloudFoundrySpecification) GetType() string {
 	return EndpointType
-}
-
-func (c *CloudFoundrySpecification) GetClientId() string {
-	if clientId, err := config.GetValue(CLIENT_ID_KEY); err == nil {
-		return clientId
-	}
-
-	return "cf"
 }
 
 func (c *CloudFoundrySpecification) Register(echoContext echo.Context) error {

--- a/deploy/db/migrations/20180605183300_CFClient.go
+++ b/deploy/db/migrations/20180605183300_CFClient.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Up is executed when this migration is applied
-func Up_20170829154900(txn *sql.Tx) {
+func Up_20180605183300(txn *sql.Tx) {
 	databaseProvider := os.Getenv("DATABASE_PROVIDER")
 	fmt.Printf("ENV is: %s", databaseProvider)
 
@@ -27,7 +27,7 @@ func Up_20170829154900(txn *sql.Tx) {
 }
 
 // Down is executed when this migration is rolled back
-func Down_20170829154900(txn *sql.Tx) {
+func Down_20180605183300(txn *sql.Tx) {
 	dropColumn := "ALTER TABLE cnsis DROP COLUMN client_id;"
 	_, err := txn.Exec(dropColumn)
 	if err != nil {

--- a/deploy/db/migrations/20180605183300_CFClient.go
+++ b/deploy/db/migrations/20180605183300_CFClient.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+)
+
+// Up is executed when this migration is applied
+func Up_20170829154900(txn *sql.Tx) {
+	databaseProvider := os.Getenv("DATABASE_PROVIDER")
+	fmt.Printf("ENV is: %s", databaseProvider)
+
+	alterCnsis := "ALTER TABLE cnsis ADD COLUMN client_id boolean NOT NULL DEFAULT 'cf';"
+
+	_, err := txn.Exec(alterCnsis)
+	if err != nil {
+		fmt.Printf("Failed to migrate due to: %v", err)
+	}
+
+	alterCnsis = "ALTER TABLE cnsis ADD COLUMN client_secret boolean NOT NULL DEFAULT '';"
+
+	_, err = txn.Exec(alterCnsis)
+	if err != nil {
+		fmt.Printf("Failed to migrate due to: %v", err)
+	}
+}
+
+// Down is executed when this migration is rolled back
+func Down_20170829154900(txn *sql.Tx) {
+	dropColumn := "ALTER TABLE cnsis DROP COLUMN client_id;"
+	_, err := txn.Exec(dropColumn)
+	if err != nil {
+		fmt.Printf("Failed to migrate due to: %v", err)
+	}
+
+	dropColumn = "ALTER TABLE cnsis DROP COLUMN client_secret;"
+	_, err = txn.Exec(dropColumn)
+	if err != nil {
+		fmt.Printf("Failed to migrate due to: %v", err)
+	}
+
+}

--- a/deploy/db/migrations/20180605183300_CFClient.go
+++ b/deploy/db/migrations/20180605183300_CFClient.go
@@ -10,15 +10,19 @@ import (
 func Up_20180605183300(txn *sql.Tx) {
 	databaseProvider := os.Getenv("DATABASE_PROVIDER")
 	fmt.Printf("ENV is: %s", databaseProvider)
+	binaryDataType := "BYTEA"
+	if databaseProvider == "mysql" {
+		binaryDataType = "BLOB"
+	}
 
-	alterCnsis := "ALTER TABLE cnsis ADD COLUMN client_id boolean NOT NULL DEFAULT 'cf';"
+	alterCnsis := "ALTER TABLE cnsis ADD COLUMN client_id VARCHAR(255) NOT NULL;"
 
 	_, err := txn.Exec(alterCnsis)
 	if err != nil {
 		fmt.Printf("Failed to migrate due to: %v", err)
 	}
 
-	alterCnsis = "ALTER TABLE cnsis ADD COLUMN client_secret boolean NOT NULL DEFAULT '';"
+	alterCnsis = "ALTER TABLE cnsis ADD COLUMN client_secret " + binaryDataType + " NOT NULL;"
 
 	_, err = txn.Exec(alterCnsis)
 	if err != nil {

--- a/deploy/db/sqlite_schema.sql
+++ b/deploy/db/sqlite_schema.sql
@@ -20,6 +20,8 @@ CREATE TABLE IF NOT EXISTS cnsis (
   token_endpoint            VARCHAR(255)  NOT NULL,
   doppler_logging_endpoint  VARCHAR(255)  NOT NULL,
   skip_ssl_validation       BOOLEAN       NOT NULL DEFAULT FALSE,
+  client_id                 VARCHAR(255)  NOT NULL DEFAULT 'cf',
+  client_secret             VARCHAR(255)  NOT NULL DEFAULT '',
   last_updated              TIMESTAMP DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/deploy/db/sqlite_schema.sql
+++ b/deploy/db/sqlite_schema.sql
@@ -20,8 +20,8 @@ CREATE TABLE IF NOT EXISTS cnsis (
   token_endpoint            VARCHAR(255)  NOT NULL,
   doppler_logging_endpoint  VARCHAR(255)  NOT NULL,
   skip_ssl_validation       BOOLEAN       NOT NULL DEFAULT FALSE,
-  client_id                 VARCHAR(255)  NOT NULL DEFAULT 'cf',
-  client_secret             VARCHAR(255)  NOT NULL DEFAULT '',
+  client_id                 VARCHAR(255)  NOT NULL,
+  client_secret             BYTEA         NOT NULL,
   last_updated              TIMESTAMP DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/index.yaml
+++ b/index.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 entries:
   console:
   - apiVersion: v1
-    created: 2018-06-02T00:44:57.893370754Z
+    created: 2018-06-05T00:44:43.222966204Z
     description: A Helm chart for deploying Stratos UI Console
-    digest: 59fc4d5b8e7948cb43a39db4b99327cad303f2c126800be1d4975c15b99a0bd3
+    digest: c58680051cb710c5da10287f05fc94b4b80d025fcc2bfb194a5999323db4eee6
     name: console
     urls:
-    - https://github.com/cloudfoundry-incubator/stratos/releases/download/2.0.0-dev/console-helm-chart-v2.0.0-dev-1ac4eb30.tgz
-    version: 2.0.0-dev-1ac4eb30
+    - https://github.com/cloudfoundry-incubator/stratos/releases/download/2.0.0-dev/console-helm-chart-v2.0.0-dev-630a04db.tgz
+    version: 2.0.0-dev-630a04db
   - apiVersion: v1
     created: 2018-04-12T13:14:55.249329644Z
     description: A Helm chart for deploying Stratos UI Console


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This a pull request to support storing a client_id and client_secret in the cnsis DB table. This is needed to support SSO when different endpoints have unique client/secret credentials.

## Description
<!--- Describe your changes in detail -->

This PR does not make any functional changes. It allows to a different client/secret to be stored for each endpoint in the cnsis DB. Whenever logging into an endpoint, its unique client/secret is pulled from its database entry. The default client/secret is still "cf", "". So there are no breaking changes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Required to support SSO for multiple endpoints.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message