### PR TITLE
Service Instance creation: Remove request to fetch service broker

### DIFF
--- a/src/frontend/app/features/service-catalog/service-summary/service-summary.component.html
+++ b/src/frontend/app/features/service-catalog/service-summary/service-summary.component.html
@@ -4,7 +4,7 @@
       <app-tile>
         <app-service-summary-card></app-service-summary-card>
       </app-tile>
-      <app-tile>
+      <app-tile *ngIf="servicesService.serviceBroker$ | async">
         <app-service-broker-card></app-service-broker-card>
       </app-tile>
     </app-tile-group>

--- a/src/frontend/app/features/service-catalog/service-tabs-base/service-tabs-base.component.ts
+++ b/src/frontend/app/features/service-catalog/service-tabs-base/service-tabs-base.component.ts
@@ -35,7 +35,7 @@ export class ServiceTabsBaseComponent {
   ];
 
   constructor(private servicesService: ServicesService, private store: Store<AppState>) {
-    this.hasVisiblePlans$ = this.servicesService.getVisibleServicePlans().pipe(
+    this.hasVisiblePlans$ = this.servicesService.servicePlans$.pipe(
       map(p => p.length > 0));
     this.toolTipText$ = this.hasVisiblePlans$.pipe(
       map(hasPlans => {

--- a/src/frontend/app/features/service-catalog/services-helper.ts
+++ b/src/frontend/app/features/service-catalog/services-helper.ts
@@ -1,40 +1,24 @@
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { Subscription } from 'rxjs';
+import { Observable, of as observableOf, Subscription } from 'rxjs';
+import { filter, first, share, switchMap } from 'rxjs/operators';
 
-import { IServiceBroker, IServiceInstance, IServicePlan, IServicePlanVisibility } from '../../core/cf-api-svc.types';
+import {
+  IService,
+  IServiceBroker,
+  IServiceInstance,
+  IServicePlan,
+  IServicePlanVisibility,
+} from '../../core/cf-api-svc.types';
 import { PaginationMonitorFactory } from '../../shared/monitors/pagination-monitor.factory';
 import { GetServiceInstances } from '../../store/actions/service-instances.actions';
+import { GetServicePlansForService } from '../../store/actions/service.actions';
 import { AppState } from '../../store/app-state';
-import { entityFactory, serviceInstancesSchemaKey } from '../../store/helpers/entity-factory';
+import { entityFactory, serviceInstancesSchemaKey, servicePlanSchemaKey } from '../../store/helpers/entity-factory';
 import { createEntityRelationPaginationKey } from '../../store/helpers/entity-relations.types';
 import { getPaginationObservables } from '../../store/reducers/pagination-reducer/pagination-reducer.helper';
 import { APIResource } from '../../store/types/api.types';
 import { getIdFromRoute } from '../cloud-foundry/cf.helpers';
-
-export const fetchVisiblePlans =
-  (svcPlans: APIResource<IServicePlan>[],
-    svcPlanVis: APIResource<IServicePlanVisibility>[],
-    svcBroker: APIResource<IServiceBroker>,
-    spaceGuid: string = null
-  ): APIResource<IServicePlan>[] => {
-    const visiblePlans: APIResource<IServicePlan>[] = [];
-    svcPlans.forEach(p => {
-      if (p.entity.public) {
-        visiblePlans.push(p);
-      } else if (svcPlanVis.filter(svcVis => svcVis.entity.service_plan_guid === p.metadata.guid).length > 0) {
-        // plan is visibilities
-        visiblePlans.push(p);
-      } else if (svcBroker.entity.space_guid) {
-
-        if (!spaceGuid || (svcBroker.entity.space_guid !== spaceGuid)) {
-          // Plan is space-scoped
-          visiblePlans.push(p);
-        }
-      }
-    });
-    return visiblePlans;
-  };
 
 
 export const getSvcAvailability = (servicePlan: APIResource<IServicePlan>,
@@ -92,4 +76,28 @@ export const getServiceInstancesInCf = (cfGuid: string, store: Store<AppState>, 
     action: new GetServiceInstances(cfGuid, paginationKey),
     paginationMonitor: paginationMonitorFactory.create(paginationKey, entityFactory(serviceInstancesSchemaKey))
   }, true).entities$;
+};
+
+export const getServicePlans = (
+  service$: Observable<APIResource<IService>>,
+  cfGuid: string
+): Observable<APIResource<IServicePlan>[]>  => {
+  return service$.pipe(
+    filter(p => !!p),
+    switchMap(service => {
+    if (service.entity.service_plans.length > 0) {
+      return observableOf(service.entity.service_plans);
+    } else {
+      const guid = service.metadata.guid;
+      const paginationKey = createEntityRelationPaginationKey(servicePlanSchemaKey, guid);
+      const getServicePlansAction = new GetServicePlansForService(guid, cfGuid, paginationKey);
+      // Could be a space-scoped service, make a request to fetch the plan
+      return getPaginationObservables<APIResource<IServicePlan>>({
+        store: this.store,
+        action: getServicePlansAction,
+        paginationMonitor: this.paginationMonitorFactory.create(getServicePlansAction.paginationKey, entityFactory(servicePlanSchemaKey))
+      }, true)
+        .entities$.pipe(share(), first());
+    }
+  }));
 };

--- a/src/frontend/app/features/service-catalog/services-helper.ts
+++ b/src/frontend/app/features/service-catalog/services-helper.ts
@@ -27,7 +27,7 @@ export const getSvcAvailability = (servicePlan: APIResource<IServicePlan>,
   const svcAvailability = {
     isPublic: false, spaceScoped: false, hasVisibilities: false, guid: servicePlan.metadata.guid, spaceGuid: null
   };
-  if (serviceBroker.entity.space_guid) {
+  if (serviceBroker && serviceBroker.entity.space_guid) {
     svcAvailability.spaceScoped = true;
     svcAvailability.spaceGuid = serviceBroker.entity.space_guid;
   } else {
@@ -80,7 +80,9 @@ export const getServiceInstancesInCf = (cfGuid: string, store: Store<AppState>, 
 
 export const getServicePlans = (
   service$: Observable<APIResource<IService>>,
-  cfGuid: string
+  cfGuid: string,
+  store: Store<AppState>,
+  paginationMonitorFactory: PaginationMonitorFactory
 ): Observable<APIResource<IServicePlan>[]>  => {
   return service$.pipe(
     filter(p => !!p),
@@ -93,9 +95,9 @@ export const getServicePlans = (
       const getServicePlansAction = new GetServicePlansForService(guid, cfGuid, paginationKey);
       // Could be a space-scoped service, make a request to fetch the plan
       return getPaginationObservables<APIResource<IServicePlan>>({
-        store: this.store,
+        store: store,
         action: getServicePlansAction,
-        paginationMonitor: this.paginationMonitorFactory.create(getServicePlansAction.paginationKey, entityFactory(servicePlanSchemaKey))
+        paginationMonitor: paginationMonitorFactory.create(getServicePlansAction.paginationKey, entityFactory(servicePlanSchemaKey))
       }, true)
         .entities$.pipe(share(), first());
     }

--- a/src/frontend/app/features/service-catalog/services.service.ts
+++ b/src/frontend/app/features/service-catalog/services.service.ts
@@ -195,7 +195,7 @@ export class ServicesService {
   private initBaseObservables() {
     this.servicePlanVisibilities$ = this.getServicePlanVisibilities();
     this.serviceExtraInfo$ = this.service$.pipe(map(o => JSON.parse(o.entity.extra)));
-    this.servicePlans$ = getServicePlans(this.service$, this.cfGuid);
+    this.servicePlans$ = getServicePlans(this.service$, this.cfGuid, this.store, this.paginationMonitorFactory);
     this.serviceBrokers$ = this.getServiceBrokers();
     this.serviceBroker$ = this.serviceBrokers$.pipe(
       filter(p => !!p && p.length > 0),

--- a/src/frontend/app/features/service-catalog/services.service.ts
+++ b/src/frontend/app/features/service-catalog/services.service.ts
@@ -29,7 +29,7 @@ import { createEntityRelationPaginationKey } from '../../store/helpers/entity-re
 import { getPaginationObservables } from '../../store/reducers/pagination-reducer/pagination-reducer.helper';
 import { APIResource } from '../../store/types/api.types';
 import { getIdFromRoute } from '../cloud-foundry/cf.helpers';
-import { getServiceInstancesInCf, getSvcAvailability } from './services-helper';
+import { getServiceInstancesInCf, getSvcAvailability, getServicePlans } from './services-helper';
 
 export interface ServicePlanAccessibility {
   spaceScoped?: boolean;
@@ -82,7 +82,6 @@ export class ServicesService {
     this.initBaseObservables();
   }
 
-
   getServicePlanVisibilities = () => {
     const paginationKey = createEntityRelationPaginationKey(servicePlanVisibilitySchemaKey, this.cfGuid);
     return getPaginationObservables<APIResource<IServicePlanVisibility>>(
@@ -124,36 +123,6 @@ export class ServicesService {
       map(s => s[0]),
       first()
     )
-
-  getVisibleServicePlans = () => {
-    return this.servicePlans$.pipe(
-      filter(p => !!p && p.length > 0),
-      map(o => o.filter(s => s.entity.bindable)),
-      combineLatest(this.servicePlanVisibilities$, this.serviceBrokers$, this.service$),
-      map(([svcPlans, svcPlanVis, svcBrokers, svc]) => this.fetchVisiblePlans(svcPlans, svcPlanVis, svcBrokers, svc)),
-
-    );
-  }
-
-  fetchVisiblePlans =
-    (svcPlans: APIResource<IServicePlan>[],
-      svcPlanVis: APIResource<IServicePlanVisibility>[],
-      svcBrokers: APIResource<IServiceBroker>[],
-      svc: APIResource<IService>): APIResource<IServicePlan>[] => {
-      const visiblePlans: APIResource<IServicePlan>[] = [];
-      svcPlans.forEach(p => {
-        if (p.entity.public) {
-          visiblePlans.push(p);
-        } else if (svcPlanVis.filter(svcVis => svcVis.entity.service_plan_guid === p.metadata.guid).length > 0) {
-          // plan is visibilities
-          visiblePlans.push(p);
-        } else if (svcBrokers.filter(s => s.metadata.guid === svc.entity.service_broker_guid)[0].entity.space_guid) {
-          // Plan is space-scoped
-          visiblePlans.push(p);
-        }
-      });
-      return visiblePlans;
-    }
 
   getServicePlanAccessibility = (servicePlan: APIResource<IServicePlan>): Observable<ServicePlanAccessibility> => {
     if (servicePlan.entity.public) {
@@ -226,7 +195,7 @@ export class ServicesService {
   private initBaseObservables() {
     this.servicePlanVisibilities$ = this.getServicePlanVisibilities();
     this.serviceExtraInfo$ = this.service$.pipe(map(o => JSON.parse(o.entity.extra)));
-    this.servicePlans$ = this.service$.pipe(map(o => o.entity.service_plans));
+    this.servicePlans$ = getServicePlans(this.service$, this.cfGuid);
     this.serviceBrokers$ = this.getServiceBrokers();
     this.serviceBroker$ = this.serviceBrokers$.pipe(
       filter(p => !!p && p.length > 0),

--- a/src/frontend/app/features/service-catalog/services.service.ts
+++ b/src/frontend/app/features/service-catalog/services.service.ts
@@ -201,7 +201,8 @@ export class ServicesService {
       filter(p => !!p && p.length > 0),
       combineLatest(this.service$),
       map(([brokers, service]) => brokers.filter(broker => broker.metadata.guid === service.entity.service_broker_guid)),
-      map(o => o[0]));
+      map(o => (o.length === 0 ? null : o[0]))
+    );
     this.allServiceInstances$ = this.getServiceInstances();
     this.serviceInstances$ = this.allServiceInstances$.pipe(
       map(instances => instances.filter(instance => instance.entity.service_guid === this.serviceGuid))

--- a/src/frontend/app/shared/components/add-service-instance/create-service-instance-helper.service.ts
+++ b/src/frontend/app/shared/components/add-service-instance/create-service-instance-helper.service.ts
@@ -1,32 +1,24 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { combineLatest as observableCombineLatest, Observable, of as observableOf } from 'rxjs';
-import { combineLatest, filter, first, map, publishReplay, refCount, share, switchMap } from 'rxjs/operators';
+import { filter, first, map, publishReplay, refCount, share, switchMap } from 'rxjs/operators';
 
-import {
-  IService,
-  IServiceBroker,
-  IServiceInstance,
-  IServicePlan,
-  IServicePlanVisibility,
-} from '../../../core/cf-api-svc.types';
+import { IService, IServiceInstance, IServicePlan, IServicePlanVisibility } from '../../../core/cf-api-svc.types';
 import { IOrganization, ISpace } from '../../../core/cf-api.types';
 import { EntityServiceFactory } from '../../../core/entity-service-factory.service';
 import { pathGet } from '../../../core/utils.service';
 import { CloudFoundryEndpointService } from '../../../features/cloud-foundry/services/cloud-foundry-endpoint.service';
-import { fetchVisiblePlans, getSvcAvailability } from '../../../features/service-catalog/services-helper';
+import { getServicePlans } from '../../../features/service-catalog/services-helper';
 import { ServicePlanAccessibility } from '../../../features/service-catalog/services.service';
-import { GetServiceBroker } from '../../../store/actions/service-broker.actions';
 import { GetServiceInstances } from '../../../store/actions/service-instances.actions';
 import { GetServicePlanVisibilities } from '../../../store/actions/service-plan-visibility.actions';
 import { GetServicePlanServiceInstances } from '../../../store/actions/service-plan.actions';
 import { GetService } from '../../../store/actions/service.actions';
-import { GetAllServicesForSpace, GetSpace, GetServiceInstancesForSpace } from '../../../store/actions/space.actions';
+import { GetAllServicesForSpace, GetServiceInstancesForSpace, GetSpace } from '../../../store/actions/space.actions';
 import { AppState } from '../../../store/app-state';
 import {
   entityFactory,
   organizationSchemaKey,
-  serviceBrokerSchemaKey,
   serviceInstancesSchemaKey,
   servicePlanVisibilitySchemaKey,
   serviceSchemaKey,
@@ -37,8 +29,8 @@ import { createEntityRelationKey, createEntityRelationPaginationKey } from '../.
 import { getPaginationObservables } from '../../../store/reducers/pagination-reducer/pagination-reducer.helper';
 import { selectCreateServiceInstanceServicePlan } from '../../../store/selectors/create-service-instance.selectors';
 import { APIResource } from '../../../store/types/api.types';
-import { PaginationMonitorFactory } from '../../monitors/pagination-monitor.factory';
 import { QParam } from '../../../store/types/pagination.types';
+import { PaginationMonitorFactory } from '../../monitors/pagination-monitor.factory';
 
 export enum CreateServiceInstanceMode {
   MARKETPLACE_MODE = 'marketPlaceMode',
@@ -48,7 +40,6 @@ export enum CreateServiceInstanceMode {
 @Injectable()
 export class CreateServiceInstanceHelperService {
   servicePlanVisibilities$: Observable<APIResource<IServicePlanVisibility>[]>;
-  serviceBroker$: Observable<APIResource<IServiceBroker>>;
   service$: Observable<APIResource<IService>>;
   // Is instance being created from the Marketplace
   public marketPlaceMode = false;
@@ -81,25 +72,6 @@ export class CreateServiceInstanceHelperService {
       refCount()
     );
 
-    this.serviceBroker$ = this.service$.pipe(
-      map(o => o.entity.service_broker_guid),
-      switchMap(guid => {
-        const brokerEntityService = this.entityServiceFactory.create<APIResource<IServiceBroker>>(
-          serviceBrokerSchemaKey,
-          entityFactory(serviceBrokerSchemaKey),
-          guid,
-          new GetServiceBroker(guid, this.cfGuid),
-          true
-        );
-        return brokerEntityService.waitForEntity$.pipe(
-          filter(o => !!o && !!o.entity),
-          map(o => o.entity),
-        );
-      }),
-      publishReplay(1),
-      refCount()
-    );
-
     const paginationKey = createEntityRelationPaginationKey(servicePlanVisibilitySchemaKey, this.cfGuid);
     this.servicePlanVisibilities$ = getPaginationObservables<APIResource<IServicePlanVisibility>>(
       {
@@ -118,24 +90,6 @@ export class CreateServiceInstanceHelperService {
   isMarketplace = () => this.mode === CreateServiceInstanceMode.MARKETPLACE_MODE;
   isAppServices = () => this.mode === CreateServiceInstanceMode.APP_SERVICES_MODE;
 
-  getVisibleServicePlans = () => {
-    return this.getServicePlans().pipe(
-      filter(p => !!p && p.length > 0),
-      map(o => o.filter(s => s.entity.bindable)),
-      combineLatest(this.getServicePlanVisibilities(), this.serviceBroker$),
-      map(([svcPlans, svcPlanVis, svcBrokers]) => fetchVisiblePlans(svcPlans, svcPlanVis, svcBrokers)),
-    );
-  }
-
-  getVisibleServicePlansForSpaceAndOrg = (orgGuid: string, spaceGuid: string): Observable<APIResource<IServicePlan>[]> => {
-    return this.getServicePlans().pipe(
-      filter(p => !!p),
-      map(o => o.filter(s => s.entity.bindable)),
-      combineLatest(this.getServicePlanVisibilitiesForOrg(orgGuid), this.serviceBroker$, this.service$),
-      map(([svcPlans, svcPlanVis, svcBrokers, svc]) => fetchVisiblePlans(svcPlans, svcPlanVis, svcBrokers, spaceGuid)),
-    );
-  }
-
   getServicePlanVisibilities = (): Observable<APIResource<IServicePlanVisibility>[]> =>
     this.servicePlanVisibilities$.pipe(filter(p => !!p))
 
@@ -146,17 +100,14 @@ export class CreateServiceInstanceHelperService {
     )
 
   getServicePlans(): Observable<APIResource<IServicePlan>[]> {
-    return this.service$.pipe(
-      filter(p => !!p),
-      map(o => o.entity.service_plans)
-    );
-  }
+    return getServicePlans(this.service$, this.cfGuid);
+    }
 
   getServiceName = () => {
     return this.service$
       .pipe(
         filter(p => !!p),
-        map(service => {
+        map((service: APIResource<IService>) => {
           const extraInfo = JSON.parse(service.entity.extra);
           if (extraInfo && extraInfo.displayName) {
             return extraInfo.displayName;
@@ -167,17 +118,10 @@ export class CreateServiceInstanceHelperService {
   }
 
   getServicePlanAccessibility = (servicePlan: APIResource<IServicePlan>): Observable<ServicePlanAccessibility> => {
-    if (servicePlan.entity.public) {
       return observableOf({
-        isPublic: true,
+        isPublic: servicePlan.entity.public,
         guid: servicePlan.metadata.guid
       });
-    }
-    return this.serviceBroker$.pipe(
-      combineLatest(this.getServicePlanVisibilities()),
-      filter(([p, q]) => !!p && !!q),
-      map(([serviceBroker, allServicePlanVisibilities]) => getSvcAvailability(servicePlan, serviceBroker, allServicePlanVisibilities))
-    );
   }
 
   getSelectedServicePlan = (): Observable<APIResource<IServicePlan>> => {

--- a/src/frontend/app/shared/components/add-service-instance/create-service-instance-helper.service.ts
+++ b/src/frontend/app/shared/components/add-service-instance/create-service-instance-helper.service.ts
@@ -8,7 +8,7 @@ import { IOrganization, ISpace } from '../../../core/cf-api.types';
 import { EntityServiceFactory } from '../../../core/entity-service-factory.service';
 import { pathGet } from '../../../core/utils.service';
 import { CloudFoundryEndpointService } from '../../../features/cloud-foundry/services/cloud-foundry-endpoint.service';
-import { getServicePlans } from '../../../features/service-catalog/services-helper';
+import { getServicePlans, getSvcAvailability } from '../../../features/service-catalog/services-helper';
 import { ServicePlanAccessibility } from '../../../features/service-catalog/services.service';
 import { GetServiceInstances } from '../../../store/actions/service-instances.actions';
 import { GetServicePlanVisibilities } from '../../../store/actions/service-plan-visibility.actions';
@@ -100,7 +100,7 @@ export class CreateServiceInstanceHelperService {
     )
 
   getServicePlans(): Observable<APIResource<IServicePlan>[]> {
-    return getServicePlans(this.service$, this.cfGuid);
+    return getServicePlans(this.service$, this.cfGuid, this.store, this.paginationMonitorFactory);
     }
 
   getServiceName = () => {
@@ -118,10 +118,16 @@ export class CreateServiceInstanceHelperService {
   }
 
   getServicePlanAccessibility = (servicePlan: APIResource<IServicePlan>): Observable<ServicePlanAccessibility> => {
+    if (servicePlan.entity.public) {
       return observableOf({
-        isPublic: servicePlan.entity.public,
+        isPublic: true,
         guid: servicePlan.metadata.guid
       });
+    }
+    return this.getServicePlanVisibilities().pipe(
+      filter(p => !!p),
+      map((allServicePlanVisibilities) => getSvcAvailability(servicePlan, null, allServicePlanVisibilities))
+    );
   }
 
   getSelectedServicePlan = (): Observable<APIResource<IServicePlan>> => {

--- a/src/frontend/app/shared/components/add-service-instance/select-plan-step/select-plan-step.component.ts
+++ b/src/frontend/app/shared/components/add-service-instance/select-plan-step/select-plan-step.component.ts
@@ -92,7 +92,7 @@ export class SelectPlanStepComponent implements OnDestroy {
       }),
       switchMap(state => {
         this.cSIHelperService = this.cSIHelperServiceFactory.create(state.cfGuid, state.serviceGuid);
-        return this.cSIHelperService.getVisibleServicePlansForSpaceAndOrg(state.orgGuid, state.spaceGuid);
+        return this.cSIHelperService.getServicePlans();
       }),
       tap(o => {
         if (o.length === 0) {

--- a/src/frontend/app/shared/components/add-service-instance/select-plan-step/select-plan-step.component.ts
+++ b/src/frontend/app/shared/components/add-service-instance/select-plan-step/select-plan-step.component.ts
@@ -139,8 +139,6 @@ export class SelectPlanStepComponent implements OnDestroy {
   }
 
   onEnter = () => {
-
-
     this.subscription = this.servicePlans$.pipe(
       filter(p => !!p && p.length > 0),
       tap(o => {
@@ -150,8 +148,6 @@ export class SelectPlanStepComponent implements OnDestroy {
         this.validate.next(this.stepperForm.valid);
       }),
     ).subscribe();
-
-
   }
 
   onNext = () => {

--- a/src/frontend/app/shared/components/cards/service-broker-card/service-broker-card.component.ts
+++ b/src/frontend/app/shared/components/cards/service-broker-card/service-broker-card.component.ts
@@ -28,6 +28,7 @@ export class ServiceBrokerCardComponent {
   ) {
     this.serviceBroker$ = this.servicesService.serviceBroker$;
     this.spaceLink$ = this.serviceBroker$.pipe(
+      filter(o => !!o),
       switchMap(broker => {
         const spaceGuid = broker.entity.space_guid;
         const spaceService = this.entityServiceFactory.create<APIResource<ISpace>>(spaceSchemaKey,

--- a/src/frontend/app/store/actions/service.actions.ts
+++ b/src/frontend/app/store/actions/service.actions.ts
@@ -52,3 +52,32 @@ export class GetService extends CFStartAction implements EntityInlineParentActio
   entityKey = serviceSchemaKey;
   options: RequestOptions;
 }
+
+export class GetServicePlansForService extends CFStartAction implements PaginationAction {
+  constructor(
+    public serviceGuid: string,
+    public endpointGuid: string,
+    public paginationKey: string,
+    public includeRelations: string[] = [
+      createEntityRelationKey(servicePlanSchemaKey, serviceSchemaKey),
+    ],
+    public populateMissing = true
+  ) {
+    super();
+    this.options = new RequestOptions();
+    this.options.url = `services/${serviceGuid}/service_plans`;
+    this.options.method = 'get';
+    this.options.params = new URLSearchParams();
+  }
+  actions = getActions('Service', 'Get Service plans');
+  entity = [entityFactory(servicePlanSchemaKey)];
+  entityKey = servicePlanSchemaKey;
+  options: RequestOptions;
+  initialParams = {
+    page: 1,
+    'results-per-page': 100,
+    'order-direction': 'desc',
+    'order-direction-field': 'creation',
+  };
+  flattenPagination = true;
+}


### PR DESCRIPTION
Space Developers are unable to make a request to fetch service brokers, therefore they are not able to create service instances.

Also fixes https://github.com/cloudfoundry-incubator/stratos/issues/2279