### PR TITLE
Fix for two app headers on the CF View

### DIFF
--- a/src/frontend/app/features/cloud-foundry/cloud-foundry.routing.ts
+++ b/src/frontend/app/features/cloud-foundry/cloud-foundry.routing.ts
@@ -117,16 +117,15 @@ const cloudFoundry: Routes = [{
         },
         {
           path: '',
-          // Root for Tabs
-          component: CloudFoundryTabsBaseComponent,
           data: {
             uiFullView: true
           },
+          component: CloudFoundryTabsBaseComponent,
           children: [
             {
               path: '',
               redirectTo: 'summary',
-              pathMatch: 'full'
+              pathMatch: 'full',
             },
             {
               path: 'summary',
@@ -136,6 +135,15 @@ const cloudFoundry: Routes = [{
               path: 'organizations',
               component: CloudFoundryOrganizationsComponent,
             },
+          ]
+        },
+        {
+          path: '',
+          // Root for Tabs
+          data: {
+            uiFullView: true
+          },
+          children: [
             {
               path: 'organizations/:orgId',
               component: CloudFoundryOrganizationBaseComponent,
@@ -160,6 +168,9 @@ const cloudFoundry: Routes = [{
             },
             {
               path: 'organizations/:orgId/spaces/:spaceId',
+              data: {
+                uiFullView: true
+              },
               component: CloudFoundrySpaceBaseComponent,
               children: [
                 {

--- a/src/frontend/app/features/cloud-foundry/cloud-foundry.routing.ts
+++ b/src/frontend/app/features/cloud-foundry/cloud-foundry.routing.ts
@@ -140,13 +140,13 @@ const cloudFoundry: Routes = [{
         {
           path: '',
           // Root for Tabs
-          data: {
-            uiFullView: true
-          },
           children: [
             {
               path: 'organizations/:orgId',
               component: CloudFoundryOrganizationBaseComponent,
+              data: {
+                uiFullView: true
+              },
               children: [
                 {
                   path: '',


### PR DESCRIPTION
The routes are not quite organised correctly, so we have two app-headers on page for the org and spaces view, since they include the header from the parent view.

Pretty sure this is the cause of some rendering issues we have seen with the page header being blank or not rendering correctly.