### PR TITLE
Two minor css fixes

### DIFF
--- a/src/frontend/app/shared/components/chips/chips.component.scss
+++ b/src/frontend/app/shared/components/chips/chips.component.scss
@@ -27,7 +27,7 @@
     // Overriding mat-chips overly specific styles.
     &.app-chip,
     &.app-chip + &.app-chip {
-      margin: $chip-padding 0 $chip-padding $chip-padding;
+      margin: $chip-padding;
     }
   }
   &__stacked,

--- a/src/frontend/app/shared/components/stepper/steppers/steppers.component.scss
+++ b/src/frontend/app/shared/components/stepper/steppers/steppers.component.scss
@@ -64,6 +64,7 @@
     margin: 12px 36px;
     min-height: 160px;
     overflow-y: auto;
+    padding: 0 2px; // Some cards/tables/etc will be clipped without this padding
   }
   &__wrapper {
     display: flex;


### PR DESCRIPTION
- Fix app chip list clipping (see service instance wall with a couple of small tags)
- Fix H clipping of cards/tables/etc in steppers