### PR TITLE
Log stream fixes

### DIFF
--- a/src/backend/cloudfoundry/cf_websocket_streams.go
+++ b/src/backend/cloudfoundry/cf_websocket_streams.go
@@ -83,8 +83,14 @@ func (c CloudFoundrySpecification) openNoaaConsumer(echoContext echo.Context) (*
 		return nil, fmt.Errorf("Failed to get record for CNSI %s: [%v]", cnsiGUID, err)
 	}
 
+	// Only need to get Client ID once
+	clientID, err := c.portalProxy.GetClientId(cnsiRecord.CNSIType)
+	if err != nil {
+		return nil, fmt.Errorf("Could not get client ID for endpoint: %s", cnsiGUID)
+	}
+
 	ac.refreshToken = func() error {
-		newTokenRecord, err := c.portalProxy.RefreshOAuthToken(cnsiRecord.SkipSSLValidation, cnsiGUID, userGUID, "", "", cnsiRecord.TokenEndpoint)
+		newTokenRecord, err := c.portalProxy.RefreshOAuthToken(cnsiRecord.SkipSSLValidation, cnsiGUID, userGUID, clientID, "", cnsiRecord.TokenEndpoint)
 		if err != nil {
 			msg := fmt.Sprintf("Error refreshing token for CNSI %s : [%v]", cnsiGUID, err)
 			return echo.NewHTTPError(http.StatusUnauthorized, msg)

--- a/src/frontend/app/shared/components/log-viewer/log-viewer.component.html
+++ b/src/frontend/app/shared/components/log-viewer/log-viewer.component.html
@@ -9,7 +9,7 @@
 
   <div *ngIf="statusMessage$ | async as message">
 
-  <div class="log-viewer__message" *ngIf="message.message" [ngClass]="{'log-viewer__messageError': message.isError}">
+  <div class="log-viewer__message" *ngIf="message.message" [ngClass]="{'log-viewer__message-error': message.isError}">
     <div class="log-viewer__messageText">{{ message.message }}</div>
   </div>
 </div>  

--- a/src/frontend/app/shared/components/log-viewer/log-viewer.component.html
+++ b/src/frontend/app/shared/components/log-viewer/log-viewer.component.html
@@ -7,7 +7,10 @@
     <button *ngIf="!( isLocked$ | async )" (click)="scrollToBottom()" class="log-viewer__scrollButton" mat-raised-button color="primary">Scroll to Bottom</button>
   </div>
 
-  <div class="log-viewer__message" *ngIf="message">
-    <div class="log-viewer__messageText">{{ message }}</div>
+  <div *ngIf="statusMessage$ | async as message">
+
+  <div class="log-viewer__message" *ngIf="message.message" [ngClass]="{'log-viewer__messageError': message.isError}">
+    <div class="log-viewer__messageText">{{ message.message }}</div>
   </div>
+</div>  
 </div>

--- a/src/frontend/app/shared/components/log-viewer/log-viewer.component.theme.scss
+++ b/src/frontend/app/shared/components/log-viewer/log-viewer.component.theme.scss
@@ -28,6 +28,9 @@
     background-color: mat-color($primary);
     color: mat-contrast($primary, 500);
   }
+  .log-viewer__messageError {
+    background-color: map-get($status-colors, danger);
+  }
   @each $colour-name,
   $colour in $ansi-colours {
     .ansi-#{$colour-name} {

--- a/src/frontend/app/shared/components/log-viewer/log-viewer.component.theme.scss
+++ b/src/frontend/app/shared/components/log-viewer/log-viewer.component.theme.scss
@@ -28,7 +28,7 @@
     background-color: mat-color($primary);
     color: mat-contrast($primary, 500);
   }
-  .log-viewer__messageError {
+  .log-viewer__message-error {
     background-color: map-get($status-colors, danger);
   }
   @each $colour-name,

--- a/src/frontend/app/shared/components/log-viewer/log-viewer.component.ts
+++ b/src/frontend/app/shared/components/log-viewer/log-viewer.component.ts
@@ -22,11 +22,15 @@ import {
   switchMap,
   tap,
   throttle,
-  timeInterval
+  timeInterval,
+  catchError
 } from 'rxjs/operators';
 import { AnsiColors } from './ansi-colors';
 
-
+interface LogStreamMessage {
+  message: string;
+  isError?: boolean;
+}
 
 @Component({
   selector: 'app-log-viewer',
@@ -62,7 +66,7 @@ export class LogViewerComponent implements OnInit, OnDestroy {
   public maxLogLines = 1000;
   public isHighThroughput$: Observable<boolean>;
   public isLocked$: Observable<boolean>;
-  public message: string;
+  public statusMessage$ = new BehaviorSubject<LogStreamMessage>({message: ''});
 
   public ngOnInit() {
     const contentElement = this.content.nativeElement;
@@ -152,16 +156,21 @@ export class LogViewerComponent implements OnInit, OnDestroy {
           containerElement.scrollTop = contentElement.clientHeight;
         }
       }))
-      .subscribe();
+      .subscribe(undefined, e => {
+        this.statusMessage$.next({
+          message: 'An error occurred connecting to the log stream websocket',
+          isError: true
+        });
+      });
 
     if (this.status) {
       this.statusSub = this.status.subscribe((wsStatus => {
         switch (wsStatus) {
           case 0:
-            this.message = 'Connecting....';
+            this.statusMessage$.next({message: 'Connecting....'});
             break;
           default:
-            this.message = undefined;
+            this.statusMessage$.next({message: ''});
             break;
         }
       }));


### PR DESCRIPTION
Fixes the issue where the "Connecting" message stays at the top of the log viewer when the stream is not active.

Adds an error state and shows error message is there is a problem connecting.

Fixes an issue with log streams and PCF Dev where we were not using the correct Client ID when refreshing the auth token, leading to a failure to show the log stream.