### PR TITLE
Set cookie domain in helm chart

### DIFF
--- a/deploy/kubernetes/console/templates/deployment.yaml
+++ b/deploy/kubernetes/console/templates/deployment.yaml
@@ -182,6 +182,10 @@ spec:
         - name: SKIP_SSL_VALIDATION 
           value: {{default "true" .Values.uaa.skipSSLValidation | quote}}
         {{- end }}
+        {{- if .Values.env.DOMAIN }}  
+        - name: COOKIE_DOMAIN
+          value: {{.Values.env.DOMAIN}}
+        {{- end }}
         ports:
         - containerPort: 3003
           name: proxy


### PR DESCRIPTION
This PR ensures we set COOKIE_DOMAIN when we deploy via Helm.