### PR TITLE
Fix duplicate deploy info when local folder

### DIFF
--- a/src/frontend/app/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
+++ b/src/frontend/app/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
@@ -96,7 +96,7 @@
                   <app-metadata-item *ngSwitchCase="'filefolder'" icon="folder" label="Folder">
                     Deployed from local folder
                   </app-metadata-item>
-                  <app-metadata-item *ngSwitchCase="'filefolder'" icon="insert_driev_file" label="File">
+                  <app-metadata-item *ngSwitchCase="'archive'" icon="insert_drive_file" label="File">
                     Deployed from local file
                   </app-metadata-item>
                 </span>


### PR DESCRIPTION
We show folder and file when you deploy from a local folder. This PR fixes this bug.