### PR TITLE
Fix various application deploy bugs

### DIFF
--- a/src/frontend/app/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
+++ b/src/frontend/app/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
@@ -82,7 +82,7 @@
           <mat-card-content>
             <span [ngSwitch]="deploySource.type">
                 <app-metadata-item *ngSwitchCase="'giturl'" icon="code" label="Git Url">
-                    <div matTooltip="{{ deploySource.branch + ' ' + deploySource.commit | slice:0:8}}"
+                    <div matTooltip="{{ deploySource.branch + ' ' + (deploySource.commit | slice:0:8)}}"
                     [matTooltipHideDelay]="1500">
 		    {{(applicationService.applicationStratProject$| async)?.deploySource.url}}
                   </div>

--- a/src/frontend/app/features/applications/deploy-application/deploy-application-deployer.ts
+++ b/src/frontend/app/features/applications/deploy-application/deploy-application-deployer.ts
@@ -158,14 +158,11 @@ export class DeployApplicationDeployer {
   }
 
   sendProjectInfo = (appSource: DeployApplicationSource) => {
-    if (appSource.type.id === 'git') {
-      if (appSource.type.subType === 'github') {
+    if (appSource.type.id === 'github') {
         return this.sendGitHubSourceMetadata(appSource);
-      }
-      if (appSource.type.subType === 'giturl') {
+    } else if (appSource.type.id === 'giturl') {
         return this.sendGitUrlSourceMetadata(appSource);
-      }
-    } else if (appSource.type.id === 'fs') {
+    } else if (appSource.type.id === 'file' || appSource.type.id === 'folder') {
       return this.sendLocalSourceMetadata();
     }
     return '';
@@ -248,7 +245,13 @@ export class DeployApplicationDeployer {
           'Failed to deploy app!');
         break;
       case SocketEventTypes.SOURCE_REQUIRED:
-        this.inputStream.next(this.sendProjectInfo(this.applicationSource));
+        const sourceInfo = this.sendProjectInfo(this.applicationSource);
+        if (!sourceInfo) {
+          this.onClose(log, 'Deploy Failed - Unknown source type',
+          'Failed to deploy the app - unknown source type');
+        } else {
+          this.inputStream.next(sourceInfo);
+        }
         break;
       case SocketEventTypes.EVENT_CLONED:
       case SocketEventTypes.EVENT_FETCHED_MANIFEST:

--- a/src/frontend/app/features/applications/deploy-application/deploy-application-deployer.ts
+++ b/src/frontend/app/features/applications/deploy-application/deploy-application-deployer.ts
@@ -172,7 +172,7 @@ export class DeployApplicationDeployer {
     const github = {
       project: appSource.projectName,
       branch: appSource.branch.name,
-      type: appSource.type.subType,
+      type: appSource.type.id,
       commit: appSource.commit
     };
 
@@ -188,7 +188,7 @@ export class DeployApplicationDeployer {
     const gitUrl = {
       url: appSource.projectName,
       branch: appSource.branch.name,
-      type: appSource.type.subType
+      type: appSource.type.id
     };
 
     const msg = {

--- a/src/frontend/app/features/applications/deploy-application/deploy-application-step2/deploy-application-fs/deploy-application-fs.component.html
+++ b/src/frontend/app/features/applications/deploy-application/deploy-application-step2/deploy-application-fs/deploy-application-fs.component.html
@@ -1,9 +1,12 @@
 <div class="deploy-app-local">
-  <div class="deploy-app-local__title">Deploy from local File or Folder</div>
-  <div>
-    <input #localPathSelectFile fileread="localPathFile" type="file" class="deploy-app-local__input" name="localPathSelectFile" id="localPathSelectFile" (change)="onFileChange($event)" />
-    <input #localPathSelectFolder webkitdirectory fileread="localPathFile" type="file" class="deploy-app-local__input" name="localPathSelectFolder" id="localPathSelectFolder" (change)="onFileChange($event)" />Choose an
-    <button (click)="localPathSelectFile.click()" color="primary" mat-button mat-raised-button>Application Archive file</button> or an
+  <div *ngIf="sourceType === 'file'" class="deploy-app-local__title">Deploy from local Application File archive</div>
+  <div *ngIf="sourceType === 'folder'" class="deploy-app-local__title">Deploy from local Application Folder</div>
+  <div *ngIf="sourceType === 'file'">
+    <input #localPathSelectFile fileread="localPathFile" type="file" class="deploy-app-local__input" name="localPathSelectFile" id="localPathSelectFile" (change)="onFileChange($event)" /> Choose an
+    <button (click)="localPathSelectFile.click()" color="primary" mat-button mat-raised-button>Application Archive file</button>
+  </div>
+  <div *ngIf="sourceType === 'folder'">
+    <input #localPathSelectFolder webkitdirectory fileread="localPathFile" type="file" class="deploy-app-local__input" name="localPathSelectFolder" id="localPathSelectFolder" (change)="onFileChange($event)" /> Choose an
     <button (click)="localPathSelectFolder.click()" color="primary" mat-button mat-raised-button>Application Folder</button>
   </div>
   <div *ngIf="(sourceData$ | async) as source" class="deploy-app-local__info">

--- a/src/frontend/app/features/applications/deploy-application/deploy-application-step2/deploy-application-fs/deploy-application-fs.component.ts
+++ b/src/frontend/app/features/applications/deploy-application/deploy-application-step2/deploy-application-fs/deploy-application-fs.component.ts
@@ -22,6 +22,8 @@ export class DeployApplicationFsComponent implements ControlValueAccessor {
   private propagateChange: Function;
   constructor() { }
 
+  @Input('sourceType') sourceType: string;
+
   sourceData$ = new BehaviorSubject<FileScannerInfo>(undefined);
 
   // Handle result of a file input form field selection

--- a/src/frontend/app/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
+++ b/src/frontend/app/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
@@ -10,80 +10,72 @@
       </mat-select>
     </mat-form-field>
     <div *ngIf="(sourceType$ | async)?.id as sourceType">
-      <app-deploy-application-fs #fsChooser *ngIf="sourceType === 'fs'" required name="fsLocalSource" [(ngModel)]="fsSourceData">
+      <app-deploy-application-fs #fsChooser *ngIf="sourceType === 'file' || sourceType === 'folder'" [sourceType]="sourceType" required name="fsLocalSource" [(ngModel)]="fsSourceData">
       </app-deploy-application-fs>
-      <div *ngIf="sourceType === 'git'">
-      <div>
-        <mat-radio-group [disabled]="isRedeploy" [(ngModel)]="sourceSubType" name="sourceSubType" (change)="setSourceSubType($event.value)" class="deploy-step2-form__radio" required>
-          <mat-radio-button *ngFor="let type of sourceSubTypes" name="sourceSubType" [value]="type">
-            {{ type.name }}
-          </mat-radio-button>
-        </mat-radio-group>
-      </div>
-      <div *ngIf="(sourceSubType$ | async) === 'github'">
-        <div class="github-project-details">
-          <div>
-            <mat-form-field>
-              <input matInput [disabled]="isRedeploy" [(ngModel)]="repository" placeholder="Project" name="projectName" appGithubProjectExists required>
-              <mat-error *ngIf="sourceSelectionForm.controls.projectName?.hasError('githubProjectExists')">
-                Project doesn't exist
-              </mat-error>
-            </mat-form-field>
-          </div>
-          <div *ngIf="projectInfo$| async as projectInfo" class="deploy-step2-form__project-info-group">
+      <div *ngIf="sourceType === 'github' || sourceType === 'giturl'">
+        <div *ngIf="sourceType === 'github'">
+          <div class="github-project-details">
             <div>
-              <img src="{{projectInfo.owner.avatar_url}}">
+              <mat-form-field>
+                <input matInput [disabled]="isRedeploy" [(ngModel)]="repository" placeholder="Project" name="projectName" appGithubProjectExists required>
+                <mat-error *ngIf="sourceSelectionForm.controls.projectName?.hasError('githubProjectExists')">
+                  Project doesn't exist
+                </mat-error>
+              </mat-form-field>
+            </div>
+            <div *ngIf="projectInfo$| async as projectInfo" class="deploy-step2-form__project-info-group">
+              <div>
+                <img src="{{projectInfo.owner.avatar_url}}">
+              </div>
+              <div src="description">
+                <div>
+                  <a href="{{projectInfo.html_url}}" target="_blank">{{projectInfo.full_name}}</a>
+                </div>
+                <div class="centered">
+                  {{projectInfo.description}}
+                </div>
+              </div>
+            </div>
+          </div>
+          <mat-form-field>
+            <mat-select class="reset-margin" placeholder="Branch" [disabled]="isRedeploy || !repository || sourceSelectionForm.controls.projectName?.hasError('githubProjectExists')" [(ngModel)]="repositoryBranch" name="repositoryBranch" (selectionChange)="updateBranchName($event.value)"
+              required>
+              <mat-option *ngFor="let branch of repositoryBranches$ | async" [value]="branch">
+                {{ branch.name }}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+          <div *ngIf="isRedeploy && commitInfo" class="deploy-step2-form__project-info-group">
+            <div>
+              <img src="{{commitInfo.author.avatar_url}}">
             </div>
             <div src="description">
               <div>
-                <a href="{{projectInfo.html_url}}" target="_blank">{{projectInfo.full_name}}</a>
+                <a href="{{commitInfo.html_url}}" target="_blank">{{commitInfo.sha | limitTo:8}}</a>
               </div>
-              <div class="centered">
-                {{projectInfo.description}}
+              <div>
+                {{commitInfo.commit.message}}
+              </div>
+              <div class="author-info">
+                <div>
+                  {{commitInfo.commit.author.name}}
+                </div>
+                <div>
+                  {{commitInfo.commit.author.date | date: 'medium'}}
+                </div>
               </div>
             </div>
           </div>
         </div>
-        <mat-form-field>
-          <mat-select class="reset-margin" placeholder="Branch" [disabled]="isRedeploy || !repository || sourceSelectionForm.controls.projectName?.hasError('githubProjectExists')" [(ngModel)]="repositoryBranch" name="repositoryBranch" (selectionChange)="updateBranchName($event.value)"
-            required>
-            <mat-option *ngFor="let branch of repositoryBranches$ | async" [value]="branch">
-              {{ branch.name }}
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
-        <div *ngIf="isRedeploy && commitInfo" class="deploy-step2-form__project-info-group">
-          <div>
-            <img src="{{commitInfo.author.avatar_url}}">
-          </div>
-          <div src="description">
-            <div>
-              <a href="{{commitInfo.html_url}}" target="_blank">{{commitInfo.sha | limitTo:8}}</a>
-            </div>
-            <div>
-              {{commitInfo.commit.message}}
-            </div>
-            <div class="author-info">
-              <div>
-                {{commitInfo.commit.author.name}}
-              </div>
-              <div>
-                {{commitInfo.commit.author.date | date: 'medium'}}
-              </div>
-            </div>
-          </div>
+        <div *ngIf="sourceType === 'giturl'">
+          <mat-form-field>
+            <input matInput [disabled]="isRedeploy" [(ngModel)]="gitUrl" placeholder="Git URL" name="gitUrl" required>
+          </mat-form-field>
+          <mat-form-field>
+            <input matInput [(ngModel)]="gitUrlBranchName" placeholder="Branch or Tag" name="urlBranchName" required>
+          </mat-form-field>
         </div>
-      </div>
-      <div *ngIf="(sourceSubType$ | async) === 'giturl'">
-        <mat-form-field>
-          <input matInput [disabled]="isRedeploy" [(ngModel)]="repository" placeholder="Project" name="projectName" required>
-        </mat-form-field>
-        <mat-form-field>
-          <input matInput [(ngModel)]="repositoryBranch.name" placeholder="Branch or Tag" name="projectBranch" required>
-        </mat-form-field>
       </div>
     </div>
-  </div>
-    
   </div>
 </form>

--- a/src/frontend/app/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
+++ b/src/frontend/app/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
@@ -13,7 +13,6 @@ import {
   FetchCommit,
   SaveAppDetails,
   SetAppSourceDetails,
-  SetAppSourceSubType,
   SetBranch,
   SetDeployBranch,
 } from '../../../../store/actions/deploy-applications.actions';

--- a/src/frontend/app/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.ts
+++ b/src/frontend/app/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.ts
@@ -1,4 +1,3 @@
-
 import {
   of as observableOf,
   combineLatest as observableCombineLatest,
@@ -61,10 +60,6 @@ export class DeployApplicationStep3Component implements OnDestroy {
     private http: HttpClient,
   ) {
     this.deployer = new DeployApplicationDeployer(store, cfOrgSpaceService, http);
-    this.initDeployer();
-  }
-
-  private initDeployer() {
     // Observables
     this.errorSub = this.deployer.status$.pipe(
       filter((status) => status.error)
@@ -77,11 +72,13 @@ export class DeployApplicationStep3Component implements OnDestroy {
           return validated || status.error;
         })
       );
+    this.initDeployer();
+  }
+
+  private initDeployer() {
     this.deploySub = this.deployer.status$.pipe(
       filter(status => status.deploying),
-    ).subscribe(deploying => {
-      // Deploying
-    });
+    ).subscribe();
   }
 
   private destroyDeployer() {

--- a/src/frontend/app/features/applications/deploy-application/deploy-application.component.html
+++ b/src/frontend/app/features/applications/deploy-application/deploy-application.component.html
@@ -9,10 +9,10 @@
   <app-step [title]="'Source'" [valid]="step2.validate | async" [onNext]="step2.onNext" [nextButtonText]="(appGuid || (skipConfig$ | async)) ? deployButtonText : 'Next'">
     <app-deploy-application-step2 [isRedeploy]="!!appGuid" #step2></app-deploy-application-step2>
   </app-step>
-  <app-step [hidden]="appGuid || (step2.sourceType$ | async)?.id  !== 'git'" [title]="'Source Config'" [valid]="step2_1.validate | async" [skip]="skipConfig$ | async" [onLeave]="step2_1.onLeave" [onEnter]="step2_1.onEnter" [onNext]="step2_1.onNext" [nextButtonText]="deployButtonText">
+  <app-step [hidden]="appGuid || !(step2.sourceTypeGithub$ | async)" [title]="'Source Config'" [valid]="step2_1.validate | async" [skip]="skipConfig$ | async" [onLeave]="step2_1.onLeave" [onEnter]="step2_1.onEnter" [onNext]="step2_1.onNext" [nextButtonText]="deployButtonText">
     <app-deploy-application-step2-1 #step2_1></app-deploy-application-step2-1>
   </app-step>
-  <app-step [hidden]="isRedeploy || (step2.sourceType$ | async)?.id  !== 'fs'" title="Source Upload" [valid]="step2_2.valid$ | async" [skip]="step2_2.skip$ | async" [onLeave]="step2_2.onLeave" [onEnter]="step2_2.onEnter" [onNext]="step2_2.onNext" [nextButtonText]="deployButtonText">
+  <app-step [hidden]="isRedeploy || !(step2.sourceTypeNeedsUpload$ | async)" title="Source Upload" [valid]="step2_2.valid$ | async" [skip]="step2_2.skip$ | async" [onLeave]="step2_2.onLeave" [onEnter]="step2_2.onEnter" [onNext]="step2_2.onNext" [nextButtonText]="deployButtonText">
     <app-deploy-application-step-source-upload #step2_2></app-deploy-application-step-source-upload>
   </app-step>
   <app-step [title]="deployButtonText" [valid]="step3.valid$ | async" [canClose]="step3.closeable$ | async" disablePrevious=true cancelButtonText="Close" [onEnter]="step3.onEnter" [onNext]="step3.onNext" finishButtonText="Go to App Summary">

--- a/src/frontend/app/features/applications/deploy-application/deploy-application.component.ts
+++ b/src/frontend/app/features/applications/deploy-application/deploy-application.component.ts
@@ -39,8 +39,8 @@ export class DeployApplicationComponent implements OnInit, OnDestroy {
 
     this.skipConfig$ = this.store.select<DeployApplicationSource>(selectApplicationSource).pipe(
       map((appSource: DeployApplicationSource) => {
-        if (appSource && appSource.type && appSource.type) {
-          return appSource.type.id === 'git' && appSource.type.subType === 'giturl';
+        if (appSource && appSource.type) {
+          return appSource.type.id === 'giturl';
         }
         return false;
       })

--- a/src/frontend/app/shared/components/list/list-types/github-commits/github-commits-list-config-app-tab.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/github-commits/github-commits-list-config-app-tab.service.ts
@@ -46,9 +46,8 @@ export class GithubCommitsListConfigServiceAppTab extends GithubCommitsListConfi
       // Set Source type
       this.store.dispatch(
         new SetAppSourceDetails({
-          name: 'Git',
-          id: 'git',
-          subType: 'github'
+          name: 'GitHub',
+          id: 'github'
         })
       );
       // Set branch

--- a/src/frontend/app/shared/components/list/list-types/github-commits/github-commits-list-config-deploy.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/github-commits/github-commits-list-config-deploy.service.ts
@@ -29,7 +29,7 @@ export class GithubCommitsListConfigServiceDeploy extends GithubCommitsListConfi
     });
 
     this.store.select<DeployApplicationSource>(selectApplicationSource).pipe(
-      map((appSource: DeployApplicationSource) => appSource.type.id === 'git' && appSource.type.subType === 'github' ? {
+      map((appSource: DeployApplicationSource) => appSource.type.id === 'github' ? {
         projectName: appSource.projectName,
         sha: appSource.branch.name,
         commitSha: appSource.commit ? appSource.commit.sha : null

--- a/src/frontend/app/store/actions/deploy-applications.actions.ts
+++ b/src/frontend/app/store/actions/deploy-applications.actions.ts
@@ -7,7 +7,6 @@ import { IRequestAction } from '../types/request.types';
 import { githubBranchesSchemaKey, githubCommitSchemaKey } from '../helpers/entity-factory';
 
 export const SET_APP_SOURCE_DETAILS = '[Deploy App] Application Source';
-export const SET_APP_SOURCE_SUB_TYPE = '[Deploy App] Set App Source Sub Type';
 export const CHECK_PROJECT_EXISTS = '[Deploy App] Check Projet exists';
 export const PROJECT_DOESNT_EXIST = '[Deploy App] Project Doesn\'t exist';
 export const PROJECT_EXISTS = '[Deploy App] Project exists';
@@ -29,11 +28,6 @@ export const FETCH_BRANCH_FAILED = '[GitHub] Fetch branch failed';
 export class SetAppSourceDetails implements Action {
   constructor(public sourceType: SourceType) { }
   type = SET_APP_SOURCE_DETAILS;
-}
-
-export class SetAppSourceSubType implements Action {
-  constructor(public subType: SourceType) { }
-  type = SET_APP_SOURCE_SUB_TYPE;
 }
 
 export class CheckProjectExists implements Action {

--- a/src/frontend/app/store/reducers/deploy-app.reducer.ts
+++ b/src/frontend/app/store/reducers/deploy-app.reducer.ts
@@ -1,5 +1,4 @@
 import {
-  SET_APP_SOURCE_SUB_TYPE,
   PROJECT_EXISTS,
   PROJECT_DOESNT_EXIST,
   CHECK_PROJECT_EXISTS,
@@ -33,10 +32,6 @@ export function deployAppReducer(state: DeployApplicationState = defaultState, a
       return {
         ...state, applicationSource: { ...state.applicationSource, type: action.sourceType }
       };
-    case SET_APP_SOURCE_SUB_TYPE:
-      const sourceType = { ...state.applicationSource.type, subType: action.subType.id };
-      const appSource = { ...state.applicationSource, type: sourceType };
-      return { ...state, applicationSource: appSource };
     case SET_DEPLOY_CF_SETTINGS:
       return {
         ...state, cloudFoundryDetails: action.cloudFoundryDetails

--- a/src/frontend/app/store/selectors/deploy-application.selector.ts
+++ b/src/frontend/app/store/selectors/deploy-application.selector.ts
@@ -12,7 +12,6 @@ export const selectDeployAppState = (state: AppState) => state.deployApplication
 
 export const getApplicationSource = (state: DeployApplicationState) => state.applicationSource;
 export const getSourceType = (state: DeployApplicationSource) => state && state.type;
-export const getSourceSubType = (state: SourceType) => state && state.subType;
 export const getApplicationProjectName = (state: DeployApplicationSource) => state && state.projectName;
 export const getProjectExists = (state: DeployApplicationState) => state && state.projectExists;
 export const getCommit = (state: DeployApplicationSource) => state && state.commit;
@@ -27,13 +26,6 @@ export const selectSourceType = compose(
   selectDeployAppState
 );
 export const selectApplicationSource = compose(
-  getApplicationSource,
-  selectDeployAppState
-);
-
-export const selectSourceSubType = compose(
-  getSourceSubType,
-  getSourceType,
   getApplicationSource,
   selectDeployAppState
 );

--- a/src/frontend/app/store/types/deploy-application.types.ts
+++ b/src/frontend/app/store/types/deploy-application.types.ts
@@ -6,7 +6,6 @@ import { GithubCommit, GitBranch } from './github.types';
 export interface SourceType {
   name: string;
   id: string;
-  subType?: string;
 }
 
 export enum DeployState {


### PR DESCRIPTION
This PR fixes a few app deploy bugs. It:

- Removes subtype and changes the selection to 4 types - GitHub, Git URL, App File, App Folder to simplify the UI
- Sets GitHub back to the default choice
- Creates new form field models for the Git URL case, so it does not share these with GitHub
- Fixes a bug where the close button did not get enabled when deploying form file or folder