### PR TITLE
Setup: Add skip ssl option and improve error handling

### DIFF
--- a/src/backend/app-core/auth.go
+++ b/src/backend/app-core/auth.go
@@ -459,6 +459,7 @@ func (p *portalProxy) getUAAToken(body url.Values, skipSSLValidation bool, clien
 	res, err := h.Do(req)
 	if err != nil || res.StatusCode != http.StatusOK {
 		log.Errorf("Error performing http request - response: %v, error: %v", res, err)
+		log.Warnf("%v+", err)
 		return nil, interfaces.LogHTTPError(res, err)
 	}
 

--- a/src/backend/app-core/repository/interfaces/errors.go
+++ b/src/backend/app-core/repository/interfaces/errors.go
@@ -13,7 +13,7 @@ type ErrHTTPShadow struct {
 	LogMessage string
 }
 
-type errHTTPRequest struct {
+type ErrHTTPRequest struct {
 	Status     int
 	InnerError error
 	Response   string
@@ -33,7 +33,7 @@ func NewHTTPShadowError(status int, userFacingError string, fmtString string, ar
 	return shadowError
 }
 
-func (e errHTTPRequest) Error() string {
+func (e ErrHTTPRequest) Error() string {
 	body := "No request body"
 	if len(e.Response) != 0 {
 		body = e.Response
@@ -52,7 +52,7 @@ func LogHTTPError(r *http.Response, innerErr error) error {
 		status = r.StatusCode
 	}
 
-	return errHTTPRequest{
+	return ErrHTTPRequest{
 		Status:     status,
 		InnerError: innerErr,
 		Response:   string(b),

--- a/src/frontend/app/features/setup/uaa-wizard/console-uaa-wizard.component.html
+++ b/src/frontend/app/features/setup/uaa-wizard/console-uaa-wizard.component.html
@@ -14,24 +14,29 @@
     </app-step>
     <app-step title="UAA Endpoint" [valid]="validateUAAForm | async" [onNext]="uaaFormNext">
       <div class="uaa-wizard__form">
-        <p>Please enter the following information to allow Stratos to authenticate with your UAA:</p>
+        <p class="uaa-wizard__form-section">Please enter the following information to allow Stratos to authenticate with your UAA:</p>
         <form class="uaa-wizard__form" [formGroup]="uaaForm" class="stepper-form">
-          <mat-form-field>
-            <input matInput formControlName="apiUrl" placeholder="UAA Endpoint Url">
-          </mat-form-field>
-          <mat-form-field>
-            <input matInput formControlName="clientId" placeholder="Client ID">
-          </mat-form-field>
-          <mat-form-field>
-            <input matInput formControlName="clientSecret" placeholder="Client Secret">
-          </mat-form-field>
-          Enter the username and password of an admin user (this is used to retrieve scope metadata)
-          <mat-form-field>
-            <input matInput formControlName="adminUsername" placeholder="Admin Username">
-          </mat-form-field>
-          <mat-form-field>
-            <input matInput type="password" formControlName="adminPassword" placeholder="Admin Password">
-          </mat-form-field>
+          <div class="uaa-wizard__form-block">
+            <mat-form-field>
+              <input matInput formControlName="apiUrl" placeholder="UAA Endpoint Url">
+            </mat-form-field>
+            <mat-checkbox matInput formControlName="skipSll">Skip SSL validation for the UAA</mat-checkbox>
+            <mat-form-field>
+              <input matInput formControlName="clientId" placeholder="Client ID">
+            </mat-form-field>
+            <mat-form-field>
+              <input matInput formControlName="clientSecret" placeholder="Client Secret">
+            </mat-form-field>
+          </div>
+          <p class="uaa-wizard__form-section">Enter the username and password of an admin user (this is used to retrieve scope metadata)</p>
+          <div class="uaa-wizard__form-block">
+            <mat-form-field>
+              <input matInput formControlName="adminUsername" placeholder="Admin Username">
+            </mat-form-field>
+            <mat-form-field>
+              <input matInput type="password" formControlName="adminPassword" placeholder="Admin Password">
+            </mat-form-field>
+          </div>
         </form>
       </div>
     </app-step>

--- a/src/frontend/app/features/setup/uaa-wizard/console-uaa-wizard.component.html
+++ b/src/frontend/app/features/setup/uaa-wizard/console-uaa-wizard.component.html
@@ -43,7 +43,7 @@
     <app-step title="Stratos Admin Scope" [onNext]="uaaScopeNext">
       <app-loading-page [isLoading]="applyingSetup$" alert="Saving configuration" text="Please wait - this will take a few moments">
         <div class="uaa-wizard__form">
-          <p>Please select the UAA scope to use to identify Stratos Administrator users:</p>
+          <p>Please select the UAA scope to use to identify users as Stratos Administrators:</p>
           <form class="stepper-form">
             <mat-form-field>
               <mat-select selected="uaaScopes[0]" [(ngModel)]="selectedScope" name="UAAScope">

--- a/src/frontend/app/features/setup/uaa-wizard/console-uaa-wizard.component.scss
+++ b/src/frontend/app/features/setup/uaa-wizard/console-uaa-wizard.component.scss
@@ -14,7 +14,7 @@
     margin-left: 36px;
   }
   &__form-section {
-    margin: 12px 0 6px 0;
+    margin: 12px 0 6px;
   }
   &__intro {
     font-size: 18px;

--- a/src/frontend/app/features/setup/uaa-wizard/console-uaa-wizard.component.scss
+++ b/src/frontend/app/features/setup/uaa-wizard/console-uaa-wizard.component.scss
@@ -7,9 +7,14 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-    > p {
-      margin: 0 0 12px;
-    }
+  }
+  &__form-block {
+    display: flex;
+    flex-direction: column;
+    margin-left: 36px;
+  }
+  &__form-section {
+    margin: 12px 0 6px 0;
   }
   &__intro {
     font-size: 18px;
@@ -19,6 +24,10 @@
   form {
     min-width: 400px;
     width: 100%;
+
+    mat-checkbox {
+      padding: 6px 0;
+    }
   }
   app-steppers {
     display: flex;

--- a/src/frontend/app/features/setup/uaa-wizard/console-uaa-wizard.component.ts
+++ b/src/frontend/app/features/setup/uaa-wizard/console-uaa-wizard.component.ts
@@ -33,7 +33,7 @@ export class ConsoleUaaWizardComponent implements OnInit {
       uaa_endpoint: this.uaaForm.get('apiUrl').value,
       console_client: this.uaaForm.get('clientId').value,
       password: this.uaaForm.get('adminPassword').value,
-      skip_ssl_validation: true,
+      skip_ssl_validation: this.uaaForm.get('skipSll').value,
       username: this.uaaForm.get('adminUsername').value,
       console_client_secret: this.uaaForm.get('clientSecret').value,
     }));
@@ -45,7 +45,11 @@ export class ConsoleUaaWizardComponent implements OnInit {
         const success = !state.error;
         if (success) {
           this.uaaScopes = state.payload.scope;
-          this.selectedScope = 'stratos.admin';
+          if (this.uaaScopes.find(scope => scope === 'stratos.admin')) {
+            this.selectedScope = 'stratos.admin';
+          } else if (this.uaaScopes.find(scope => scope === 'cloud_controller.admin')) {
+            this.selectedScope = 'cloud_controller.admin';
+          }
         }
         return {
           success,
@@ -88,6 +92,7 @@ export class ConsoleUaaWizardComponent implements OnInit {
   ngOnInit() {
     this.uaaForm = new FormGroup({
       apiUrl: new FormControl('', [<any>Validators.required]),
+      skipSll: new FormControl(false),
       clientId: new FormControl('', [<any>Validators.required]),
       clientSecret: new FormControl(''),
       adminUsername: new FormControl('', [<any>Validators.required]),


### PR DESCRIPTION
This PR fixes/improves the setup UI:

- Adds the Skip SSL checkbox, as per V1
- Tweaks the layout slightly to make it clearer which options belong to the sections
- Tweaked the text every so slightly
- Improved the error messages, so the user gets better feedback as to which fields need to be fixed
- Defaults to stratos.admin then cloud_controller.admin for the scope