### PR TITLE
Enable unbind operation in space-services

### DIFF
--- a/src/frontend/app/shared/components/add-service-instance/add-service-instance/add-service-instance.component.html
+++ b/src/frontend/app/shared/components/add-service-instance/add-service-instance/add-service-instance.component.html
@@ -2,7 +2,7 @@
   {{ title$ | async }}
 </app-page-header>
 <div class="add-service-instance">
-  <app-steppers [cancel]="serviceInstancesUrl">
+  <app-steppers [cancel]="modeService.cancelUrl">
     <app-step *ngIf="modeService.viewDetail.showSelectCf" title="Cloud Foundry" [valid]="selectCF.validate | async" [onNext]="onNext" [blocked]="cfOrgSpaceService.isLoading$ | async">
       <app-create-application-step1 [stepperText]="stepperText" [isMarketplaceMode]="inMarketplaceMode" #selectCF></app-create-application-step1>
     </app-step>

--- a/src/frontend/app/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
+++ b/src/frontend/app/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
@@ -64,7 +64,6 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
   displaySelectServiceStep: boolean;
   displaySelectCfStep: boolean;
   title$: Observable<string>;
-  serviceInstancesUrl: string;
   servicesWallCreateInstance = false;
   stepperText = 'Select a Cloud Foundry instance, organization and space for the service instance.';
   bindAppStepperText = 'Bind App (Optional)';
@@ -98,7 +97,6 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
     } else if (this.modeService.isServicesWallMode()) {
       // Setup wizard for default mode
       this.servicesWallCreateInstance = true;
-      this.serviceInstancesUrl = `/services`;
       this.title$ = observableOf(`Create Service Instance`);
     }
 
@@ -140,7 +138,6 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
     const appId = getIdFromRoute(this.activatedRoute, 'id');
     const cfId = getIdFromRoute(this.activatedRoute, 'cfId');
     this.appId = appId;
-    this.serviceInstancesUrl = `/applications/${cfId}/${appId}/services`;
     this.bindAppStepperText = 'Binding Params (Optional)';
     const entityService = this.entityServiceFactory.create<APIResource<IApp>>(
       applicationSchemaKey,
@@ -165,7 +162,6 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
   private configureForEditServiceInstanceMode() {
     const { cfId, serviceInstanceId } = this.activatedRoute.snapshot.params;
     const entityService = this.getServiceInstanceEntityService(serviceInstanceId, cfId);
-    this.serviceInstancesUrl = `/services`;
     return entityService.waitForEntity$.pipe(
       filter(p => !!p),
       tap(serviceInstance => {
@@ -231,7 +227,6 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
     this.cSIHelperService = this.cSIHelperServiceFactory.create(cfId, serviceId);
     this.store.dispatch(new SetCreateServiceInstanceCFDetails(cfId));
     this.store.dispatch(new SetCreateServiceInstanceServiceGuid(serviceId));
-    this.serviceInstancesUrl = `/marketplace/${cfId}/${serviceId}/instances`;
     this.title$ = this.cSIHelperService.getServiceName().pipe(map(label => `Create Instance: ${label}`));
     this.marketPlaceMode = true;
     return this.cfOrgSpaceService.cf.list$.pipe(

--- a/src/frontend/app/shared/components/add-service-instance/csi-mode.service.ts
+++ b/src/frontend/app/shared/components/add-service-instance/csi-mode.service.ts
@@ -30,6 +30,7 @@ export class CsiModeService {
 
   private mode: string;
   public viewDetail: ViewDetail;
+  private cancelUrl: string;
 
   constructor(
     private activatedRoute: ActivatedRoute
@@ -41,6 +42,7 @@ export class CsiModeService {
 
     if (!!serviceId && !!cfId) {
       this.mode = CreateServiceInstanceMode.MARKETPLACE_MODE;
+      this.cancelUrl = `/marketplace/${cfId}/${serviceId}/instances`;
       this.viewDetail = {
         ...defaultViewDetail,
         showSelectService: false,
@@ -55,6 +57,12 @@ export class CsiModeService {
         showSelectService: false,
         showBindApp: false
       };
+      let returnUrl = `/services`;
+      const appId = this.activatedRoute.snapshot.queryParams.appId;
+      if (appId) {
+        returnUrl = `/applications/${cfId}/${appId}/services`;
+      }
+      this.cancelUrl = returnUrl;
     }
 
     if (!!id && !!cfId) {
@@ -63,11 +71,14 @@ export class CsiModeService {
         ...defaultViewDetail,
         showSelectCf: false,
       };
+      this.cancelUrl = `/applications/${cfId}/${id}/services`;
+
     }
 
     if (!cfId) {
       this.mode = CreateServiceInstanceMode.SERVICES_WALL_MODE;
       this.viewDetail = defaultViewDetail;
+      this.cancelUrl = `/services`;
     }
 
 

--- a/src/frontend/app/shared/components/list/list-types/app-sevice-bindings/app-service-binding-card/app-service-binding-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-sevice-bindings/app-service-binding-card/app-service-binding-card.component.ts
@@ -50,16 +50,27 @@ export class AppServiceBindingCardComponent extends CardCell<APIResource<IServic
     private currentUserPermissionsService: CurrentUserPermissionsService,
   ) {
     super();
-    this.cardMenu = [{
-      label: 'Unbind',
-      action: this.detach,
-      can: this.appService.waitForAppEntity$.pipe(
-        switchMap(app => this.currentUserPermissionsService.can(
-          CurrentUserPermissions.SERVICE_BINDING_EDIT,
-          this.appService.cfGuid,
-          app.entity.entity.space_guid
-        )))
-    }];
+    this.cardMenu = [
+      {
+        label: 'Edit',
+        action: this.edit,
+        can: this.appService.waitForAppEntity$.pipe(
+          switchMap(app => this.currentUserPermissionsService.can(
+            CurrentUserPermissions.SERVICE_BINDING_EDIT,
+            this.appService.cfGuid,
+            app.entity.entity.space_guid
+          )))
+      },
+      {
+        label: 'Unbind',
+        action: this.detach,
+        can: this.appService.waitForAppEntity$.pipe(
+          switchMap(app => this.currentUserPermissionsService.can(
+            CurrentUserPermissions.SERVICE_BINDING_EDIT,
+            this.appService.cfGuid,
+            app.entity.entity.space_guid
+          )))
+      }];
   }
   ngOnInit(): void {
     this.serviceInstance$ = this.entityServiceFactory.create<APIResource<IServiceInstance>>(
@@ -140,4 +151,11 @@ export class AppServiceBindingCardComponent extends CardCell<APIResource<IServic
       this.appService.cfGuid
     );
   }
+
+  edit = () => this.serviceActionHelperService.editServiceBinding(
+    this.row.entity.service_instance_guid,
+    this.appService.cfGuid,
+    { 'appId': this.appService.appGuid }
+  )
+
 }

--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-instances-list-config.base.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-instances-list-config.base.ts
@@ -27,8 +27,6 @@ import {
   TableCellServicePlanComponent,
 } from '../cf-spaces-service-instances/table-cell-service-plan/table-cell-service-plan.component';
 
-
-
 interface CanCache {
   [spaceGuid: string]: Observable<boolean>;
 }
@@ -111,7 +109,7 @@ export class CfServiceInstancesListConfigBase extends ListConfig<APIResource<ISe
     action: (item: APIResource) => this.deleteServiceBinding(item),
     label: 'Unbind',
     description: 'Unbind Service Instance',
-    createEnabled: (row$: Observable<APIResource<IServiceInstance>>) => row$.pipe(map(row => row.entity.service_bindings.length === 1)),
+    createEnabled: (row$: Observable<APIResource<IServiceInstance>>) => row$.pipe(map(row => row.entity.service_bindings.length !== 0)),
     createVisible: (row$: Observable<APIResource<IServiceInstance>>) =>
       row$.pipe(
         switchMap(
@@ -126,11 +124,11 @@ export class CfServiceInstancesListConfigBase extends ListConfig<APIResource<ISe
     label: 'Edit',
     description: 'Edit Service Instance',
     createVisible: (row$: Observable<APIResource<IServiceInstance>>) =>
-    row$.pipe(
-      switchMap(
-        row => this.can(this.canDetachCache, CurrentUserPermissions.SERVICE_BINDING_EDIT, row.entity.cfGuid, row.entity.space_guid)
+      row$.pipe(
+        switchMap(
+          row => this.can(this.canDetachCache, CurrentUserPermissions.SERVICE_BINDING_EDIT, row.entity.cfGuid, row.entity.space_guid)
+        )
       )
-    )
   };
 
   private can(cache: CanCache, perm: CurrentUserPermissions, cfGuid: string, spaceGuid: string): Observable<boolean> {

--- a/src/frontend/app/shared/data-services/service-action-helper.service.ts
+++ b/src/frontend/app/shared/data-services/service-action-helper.service.ts
@@ -8,7 +8,7 @@ import { DeleteServiceBinding } from '../../store/actions/service-bindings.actio
 import { DeleteServiceInstance } from '../../store/actions/service-instances.actions';
 import { IServiceBinding } from '../../core/cf-api-svc.types';
 import { APIResource } from '../../store/types/api.types';
-import { RouterNav } from '../../store/actions/router.actions';
+import { RouterNav, RouterQueryParams } from '../../store/actions/router.actions';
 
 @Injectable()
 export class ServiceActionHelperService {
@@ -64,6 +64,6 @@ export class ServiceActionHelperService {
   }
 
 
-  editServiceBinding = (guid: string, endpointGuid: string) =>
-    this.store.dispatch(new RouterNav({ path: ['/services', endpointGuid, guid, 'edit'] }))
+  editServiceBinding = (guid: string, endpointGuid: string, query: RouterQueryParams = {}) =>
+    this.store.dispatch(new RouterNav({ path: ['/services', endpointGuid, guid, 'edit'], query: query }))
 }

--- a/src/frontend/app/store/actions/router.actions.ts
+++ b/src/frontend/app/store/actions/router.actions.ts
@@ -8,15 +8,16 @@ export const RouterActions = {
   GO: '[Router] Go To',
 };
 
+export interface RouterQueryParams {
+  [key: string]: any;
+}
 export class RouterNav implements Action, LoggerAction {
   public logLevel: LogLevel.INFO;
   public message: string;
   type = RouterActions.GO;
   constructor(public payload: {
     path: string[] | string;
-    query?: {
-      [key: string]: any
-    };
+    query?: RouterQueryParams;
     extras?: NavigationExtras;
   }, public redirect?: RouterRedirect) {
     const path = payload.path as string[];


### PR DESCRIPTION
1. Refactors out cancel URL code from stepper component to service.
2. Add `Edit Service Instance` action to service-binding card in App Services.
3. Fixed https://github.com/cloudfoundry-incubator/stratos/issues/2359 