### PR TITLE
Fix issue where circular reference failed to denormalize an app's space

### DIFF
--- a/src/frontend/app/store/helpers/entity-factory.ts
+++ b/src/frontend/app/store/helpers/entity-factory.ts
@@ -293,6 +293,7 @@ const ApplicationEntitySchema = new EntitySchema(
         entity: {
           ...coreSpaceSchemaParams,
           routes: [RouteNoAppsSchema],
+          service_instances: [ServiceInstancesWithNoBindingsSchema],
           organization: OrganizationsWithoutSpaces,
         }
       }, { idAttribute: getAPIResourceGuid }),


### PR DESCRIPTION
- Exception thrown in template due to missing org in an app's space
- To reproduce...
  - Connect to scf, no other endpoint (bug is app specific)
  - Fresh load on CF page
  - Click Services nav item
  - Click Applications nav item
  - apps in third column did not denormalize their space entity, causing undefined error
- Caused by app's space's service instances containing app bindings