### PR TITLE
Fix a few UX issues

### DIFF
--- a/src/frontend/app/shared/components/cards/card-cf-org-user-details/card-cf-org-user-details.component.html
+++ b/src/frontend/app/shared/components/cards/card-cf-org-user-details/card-cf-org-user-details.component.html
@@ -11,6 +11,6 @@
   </app-meta-card-item>
   <app-meta-card-item>
     <app-meta-card-key>Org Status</app-meta-card-key>
-    <app-meta-card-value>{{ (cfOrgService.org$ | async)?.entity?.entity?.status }}</app-meta-card-value>
+    <app-meta-card-value>{{ ((cfOrgService.org$ | async)?.entity?.entity?.status) | capitalizeFirst}}</app-meta-card-value>
   </app-meta-card-item>
 </app-meta-card>

--- a/src/frontend/app/shared/components/cards/card-cf-org-user-details/card-cf-org-user-details.component.spec.ts
+++ b/src/frontend/app/shared/components/cards/card-cf-org-user-details/card-cf-org-user-details.component.spec.ts
@@ -15,6 +15,7 @@ import { CfUserService } from '../../../data-services/cf-user.service';
 import { EntityMonitorFactory } from '../../../monitors/entity-monitor.factory.service';
 import { PaginationMonitorFactory } from '../../../monitors/pagination-monitor.factory';
 import { CardCfOrgUserDetailsComponent } from './card-cf-org-user-details.component';
+import { CapitalizeFirstPipe } from '../../../pipes/capitalizeFirstLetter.pipe';
 
 describe('CardCfOrgUserDetailsComponent', () => {
   let component: CardCfOrgUserDetailsComponent;
@@ -22,7 +23,7 @@ describe('CardCfOrgUserDetailsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [CardCfOrgUserDetailsComponent, ...MetadataCardTestComponents],
+      declarations: [CardCfOrgUserDetailsComponent, ...MetadataCardTestComponents, CapitalizeFirstPipe],
       imports: [...BaseTestModulesNoShared],
       providers: [
         CfUserService,

--- a/src/frontend/app/shared/components/cards/card-number-metric/card-number-metric.component.scss
+++ b/src/frontend/app/shared/components/cards/card-number-metric/card-number-metric.component.scss
@@ -7,25 +7,25 @@
     align-items: center;
     display: flex;
     flex-direction: row;
-    padding: 12px 24px;
+    padding: 12px;
     > div {
       flex: 1;
     }
   }
   &__icon {
-    flex: 0 0 42px;
-    font-size: 42px;
-    height: 42px;
+    flex: 0 0 40px;
+    font-size: 40px;
+    height: 40px;
     margin-right: 12px;
-    width: 42px;
+    width: 40px;
   }
   &__label {
-    font-size: 16px;
+    font-size: 15px;
   }
   &__value {
-    font-size: 24px;
+    font-size: 23px;
   }
   &__limit {
-    font-size: 20px;
+    font-size: 18px;
   }
 }

--- a/src/frontend/app/shared/components/list/list-table/table-row/table-row.component.scss
+++ b/src/frontend/app/shared/components/list/list-table/table-row/table-row.component.scss
@@ -21,7 +21,7 @@
     border-left-style: solid;
     border-left-width: 4px;
     .table-row__inner {
-      padding-left: 20px; // Cancel out highlighted padding (border left in theme)
+      margin-left: -4px; // Cancel out highlighted padding (border left in theme)
     }
   }
 }
@@ -57,5 +57,6 @@
   &__inner {
     display: flex;
     flex: 1;
+    width: 100%;
   }
 }

--- a/src/frontend/app/shared/components/list/list-types/app/card/card-app.component.html
+++ b/src/frontend/app/shared/components/list/list-types/app/card/card-app.component.html
@@ -14,15 +14,15 @@
     </app-meta-card-value>
   </app-meta-card-item>
   <app-meta-card-item>
-    <app-meta-card-key>Created</app-meta-card-key>
-    <app-meta-card-value>
-      {{ row.metadata.created_at | date:'medium' }}
-    </app-meta-card-value>
-  </app-meta-card-item>
-  <app-meta-card-item>
     <app-meta-card-key>Org/Space</app-meta-card-key>
     <app-meta-card-value>
       {{ row.entity.space.entity.organization.entity.name }}/{{ row.entity.space.entity.name }}
+    </app-meta-card-value>
+  </app-meta-card-item>
+  <app-meta-card-item>
+    <app-meta-card-key>Created</app-meta-card-key>
+    <app-meta-card-value>
+      {{ row.metadata.created_at | date:'medium' }}
     </app-meta-card-value>
   </app-meta-card-item>
 </app-meta-card>

--- a/src/frontend/app/shared/components/stepper/steppers/steppers.component.html
+++ b/src/frontend/app/shared/components/stepper/steppers/steppers.component.html
@@ -2,7 +2,7 @@
   <div class="steppers" *ngIf="steps && steps.length">
     <div class="steppers__inner">
       <div class="steppers__headers" *ngIf="steps.length > 1">
-        <div *ngFor="let step of steps; let i = index" [ngClass]="{'steppers__header--active': step.active || step.complete}" class="steppers__header">
+        <div *ngFor="let step of steps; let i = index" [ngClass]="{'steppers__header--active': step.active}" class="steppers__header">
           <div class="steppers__header-inner" *ngIf="steps.length !== 1">
             <!-- Blocked -->
             <mat-spinner *ngIf="step.blocked; else notBlocked" diameter="20"></mat-spinner>

--- a/src/frontend/app/shared/components/stepper/steppers/steppers.component.scss
+++ b/src/frontend/app/shared/components/stepper/steppers/steppers.component.scss
@@ -61,10 +61,9 @@
     display: flex;
     flex: 1;
     height: 0;
-    margin: 12px 36px;
+    padding: 12px 36px;
     min-height: 160px;
     overflow-y: auto;
-    padding: 0 2px; // Some cards/tables/etc will be clipped without this padding
   }
   &__wrapper {
     display: flex;

--- a/src/frontend/app/shared/components/stepper/steppers/steppers.component.scss
+++ b/src/frontend/app/shared/components/stepper/steppers/steppers.component.scss
@@ -61,9 +61,9 @@
     display: flex;
     flex: 1;
     height: 0;
-    padding: 12px 36px;
     min-height: 160px;
     overflow-y: auto;
+    padding: 12px 36px;
   }
   &__wrapper {
     display: flex;

--- a/src/frontend/app/shared/pipes/capitalizeFirstLetter.pipe.ts
+++ b/src/frontend/app/shared/pipes/capitalizeFirstLetter.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+/*
+ * Capitalize the first letter of the string
+*/
+@Pipe({
+  name: 'capitalizeFirst'
+})
+export class CapitalizeFirstPipe implements PipeTransform {
+  transform(text: string): string {
+    if (text === null) {
+      return text;
+    }
+    return text.charAt(0).toUpperCase() + text.slice(1);
+  }
+}

--- a/src/frontend/app/shared/shared.module.ts
+++ b/src/frontend/app/shared/shared.module.ts
@@ -130,6 +130,7 @@ import { UptimePipe } from './pipes/uptime.pipe';
 import { UsageBytesPipe } from './pipes/usage-bytes.pipe';
 import { ValuesPipe } from './pipes/values.pipe';
 import { UserPermissionDirective } from './user-permission.directive';
+import { CapitalizeFirstPipe } from './pipes/capitalizeFirstLetter.pipe';
 
 @NgModule({
   imports: [
@@ -230,6 +231,7 @@ import { UserPermissionDirective } from './user-permission.directive';
     NoServicePlansComponent,
     CreateApplicationStep1Component,
     BindAppsStepComponent,
+    CapitalizeFirstPipe,
   ],
   exports: [
     FormsModule,
@@ -315,7 +317,8 @@ import { UserPermissionDirective } from './user-permission.directive';
     SelectPlanStepComponent,
     SelectServiceComponent,
     CreateApplicationStep1Component,
-    BindAppsStepComponent
+    BindAppsStepComponent,
+    CapitalizeFirstPipe,
   ],
   entryComponents: [
     AppEventDetailDialogComponentComponent,


### PR DESCRIPTION
This PR fixes #2344:

- Changes the spacing on the stepper to use padding rather than margin, so that checkboxes don't have their ripple effect cropped
- Tweaks down the padding and font sizes on the small card
- Adds a capitalize first pipe and uses this on the org card so that the status reads Active and not active
- Fixed the highlighted table row so that it is not indented
- Fixed an overflow issue with table rows, where longs rows - such as the STRATOS_PROJECT value on the env vars table does not cause the table to overflow off the screen
- Swapped the org/space with the created field on the app card
- Changed stepper style so that only the active step is marked in bold and not the previous compelted steps