### PR TITLE
Fix errors when multiple cf's are connected as both admin and non-admin users

### DIFF
--- a/src/frontend/app/store/effects/permissions.effect.ts
+++ b/src/frontend/app/store/effects/permissions.effect.ts
@@ -129,7 +129,9 @@ export class PermissionsEffects {
     // Per endpoint fetch feature flags and user roles (unless admin, where we don't need to), then mark endpoint as initialised
     endpoints.forEach(endpoint => {
       if (endpoint.user.admin) {
+        // We don't need permissions for admin users (they can do everything)
         requests[endpoint.guid] = [observableOf(true)];
+        this.store.dispatch(new GetUserCfRelations(endpoint.guid, GET_CURRENT_USER_CF_RELATIONS_SUCCESS));
       } else {
         // START fetching cf roles for current user
         this.store.dispatch(new GetUserCfRelations(endpoint.guid, GET_CURRENT_USER_CF_RELATIONS));

--- a/src/frontend/app/store/effects/permissions.effect.ts
+++ b/src/frontend/app/store/effects/permissions.effect.ts
@@ -129,7 +129,7 @@ export class PermissionsEffects {
     // Per endpoint fetch feature flags and user roles (unless admin, where we don't need to), then mark endpoint as initialised
     endpoints.forEach(endpoint => {
       if (endpoint.user.admin) {
-        requests[endpoint.guid].push(observableOf(true));
+        requests[endpoint.guid] = [observableOf(true)];
       } else {
         // START fetching cf roles for current user
         this.store.dispatch(new GetUserCfRelations(endpoint.guid, GET_CURRENT_USER_CF_RELATIONS));


### PR DESCRIPTION
Connect two cloud foundry's, one as an admin and one as non-admin

Error 1 - fixes #2408
- Visit the endpoints (any?) page and exceptions shown in log 
- Caused by assigning to null

Error 2
- Visit cf that's connected as admin and no users are shown in user count or lists
- Caused by failing to set admin cf permissions as initialised

