### PR TITLE
Fix pagination of space level routes and service instance tables

### DIFF
--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-instances-list-config.base.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-instances-list-config.base.ts
@@ -13,7 +13,7 @@ import { AppState } from '../../../../../store/app-state';
 import { APIResource } from '../../../../../store/types/api.types';
 import { ServiceActionHelperService } from '../../../../data-services/service-action-helper.service';
 import { ITableColumn } from '../../list-table/table.types';
-import { IListAction, IListConfig, ListConfig, ListViewTypes } from '../../list.component.types';
+import { defaultPaginationPageSizeOptionsTable, IListAction, IListConfig, ListViewTypes } from '../../list.component.types';
 import {
   TableCellServiceInstanceAppsAttachedComponent,
 } from '../cf-spaces-service-instances/table-cell-service-instance-apps-attached/table-cell-service-instance-apps-attached.component';
@@ -26,16 +26,18 @@ import {
 import {
   TableCellServicePlanComponent,
 } from '../cf-spaces-service-instances/table-cell-service-plan/table-cell-service-plan.component';
-import { TableCellSpaceNameComponent } from '../cf-spaces-service-instances/table-cell-space-name/table-cell-space-name.component';
+import {
+  TableCellSpaceNameComponent,
+} from '../cf-spaces-service-instances/table-cell-space-name/table-cell-space-name.component';
 
 interface CanCache {
   [spaceGuid: string]: Observable<boolean>;
 }
 
 @Injectable()
-export class CfServiceInstancesListConfigBase extends ListConfig<APIResource<IServiceInstance>>
-  implements IListConfig<APIResource<IServiceInstance>>  {
+export class CfServiceInstancesListConfigBase implements IListConfig<APIResource<IServiceInstance>> {
   viewType = ListViewTypes.TABLE_ONLY;
+  pageSizeOptions = defaultPaginationPageSizeOptionsTable;
   dataSource: ListDataSource<APIResource>;
   defaultView = 'table' as ListView;
   text = {
@@ -153,7 +155,6 @@ export class CfServiceInstancesListConfigBase extends ListConfig<APIResource<ISe
     protected currentUserPermissionsService: CurrentUserPermissionsService,
     private serviceActionHelperService: ServiceActionHelperService
   ) {
-    super();
   }
 
   deleteServiceInstance = (serviceInstance: APIResource<IServiceInstance>) =>
@@ -172,5 +173,7 @@ export class CfServiceInstancesListConfigBase extends ListConfig<APIResource<ISe
   getMultiActions = () => [];
   getSingleActions = () => [this.listActionEdit, this.listActionDetach, this.listActionDelete];
   getMultiFiltersConfigs = () => [];
+  getColumns = () => this.serviceInstanceColumns;
+  getDataSource = () => null;
 
 }

--- a/src/frontend/app/shared/components/list/list-types/cf-space-routes/cf-space-routes-data-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-space-routes/cf-space-routes-data-source.ts
@@ -34,7 +34,7 @@ export class CfSpaceRoutesDataSource extends ListDataSource<APIResource> {
     const action = new GetSpaceRoutes(spaceGuid, cfGuid, paginationKey, [
       createEntityRelationKey(routeSchemaKey, applicationSchemaKey),
       createEntityRelationKey(routeSchemaKey, domainSchemaKey),
-    ]);
+    ], true, false);
     action.initialParams['order-direction-field'] = 'creation';
     const { rowStateManager, sub } = SpaceRouteDataSourceHelper.getRowStateManager(
       store,

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/cf-spaces-service-instances-data-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/cf-spaces-service-instances-data-source.ts
@@ -30,7 +30,7 @@ export class CfSpacesServiceInstancesDataSource extends ListDataSource<APIResour
       createEntityRelationKey(serviceInstancesSchemaKey, servicePlanSchemaKey),
       createEntityRelationKey(serviceInstancesSchemaKey, spaceSchemaKey),
       createEntityRelationKey(serviceBindingSchemaKey, applicationSchemaKey),
-    ]);
+    ], true, false);
     super({
       store,
       action,

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/cf-spaces-service-instances-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/cf-spaces-service-instances-list-config.service.ts
@@ -37,7 +37,6 @@ export class CfSpacesServiceInstancesListConfigService extends CfServiceInstance
     };
   }
 
-  getColumns = () => this.serviceInstanceColumns;
   getDataSource = () => this.dataSource;
 
 }

--- a/src/frontend/app/shared/components/list/list-types/service-instances/service-instances-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/service-instances/service-instances-list-config.service.ts
@@ -34,6 +34,5 @@ export class ServiceInstancesListConfigService extends CfServiceInstancesListCon
     };
   }
 
-  getColumns = () => this.serviceInstanceColumns;
   getDataSource = () => this.dataSource;
 }

--- a/src/frontend/app/shared/components/list/list-types/services-wall/service-instances-wall-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/services-wall/service-instances-wall-list-config.service.ts
@@ -7,7 +7,7 @@ import { ListView } from '../../../../../store/actions/list.actions';
 import { AppState } from '../../../../../store/app-state';
 import { CfOrgSpaceDataService } from '../../../../data-services/cf-org-space-service.service';
 import { ServiceActionHelperService } from '../../../../data-services/service-action-helper.service';
-import { ListViewTypes } from '../../list.component.types';
+import { defaultPaginationPageSizeOptionsCards, ListViewTypes } from '../../list.component.types';
 import { createListFilterConfig } from '../../list.helper';
 import { cfOrgSpaceFilter } from '../app/cf-apps-data-source';
 import { CfServiceInstancesListConfigBase } from '../cf-services/cf-service-instances-list-config.base';
@@ -33,6 +33,7 @@ export class ServiceInstancesWallListConfigService extends CfServiceInstancesLis
   defaultView = 'cards' as ListView;
   cardComponent = ServiceInstanceCardComponent;
   viewType = ListViewTypes.BOTH;
+  pageSizeOptions = defaultPaginationPageSizeOptionsCards;
 
   constructor(store: Store<AppState>,
     datePipe: DatePipe,
@@ -56,7 +57,6 @@ export class ServiceInstancesWallListConfigService extends CfServiceInstancesLis
     };
   }
 
-  getColumns = () => this.serviceInstanceColumns;
   getDataSource = () => this.dataSource;
 
 }

--- a/src/frontend/app/store/actions/service-instances.actions.ts
+++ b/src/frontend/app/store/actions/service-instances.actions.ts
@@ -34,7 +34,8 @@ export class GetServicesInstancesInSpace
       createEntityRelationKey(serviceInstancesSchemaKey, serviceBindingSchemaKey),
       createEntityRelationKey(serviceInstancesSchemaKey, servicePlanSchemaKey)
     ],
-    public populateMissing = true
+    public populateMissing = true,
+    public flattenPagination = true
   ) {
     super();
     this.options = new RequestOptions();
@@ -55,7 +56,6 @@ export class GetServicesInstancesInSpace
   };
   parentGuid: string;
   parentEntitySchema = entityFactory(spaceSchemaKey);
-  flattenPagination = true;
 }
 
 export class GetServiceInstances

--- a/src/frontend/app/store/actions/space.actions.ts
+++ b/src/frontend/app/store/actions/space.actions.ts
@@ -90,7 +90,8 @@ export class GetSpaceRoutes extends CFStartAction implements PaginatedAction, En
     public endpointGuid: string,
     public paginationKey: string,
     public includeRelations = [],
-    public populateMissing = true
+    public populateMissing = true,
+    public flattenPagination = true
   ) {
     super();
     this.options = new RequestOptions();
@@ -113,7 +114,6 @@ export class GetSpaceRoutes extends CFStartAction implements PaginatedAction, En
   entity = entityFactory(routeSchemaKey);
   entityKey = routeSchemaKey;
   options: RequestOptions;
-  flattenPagination = true;
   parentEntitySchema = entityFactory(spaceSchemaKey);
 }
 


### PR DESCRIPTION
- Actions were set to flattenPagination
- Ensure consistent page size between the two tables as well as other si tables
(5 for table only, otherwise 9)
- Fixes #1984 