### PR TITLE
Add back in Cookie Domain support

### DIFF
--- a/deploy/kubernetes/console/templates/deployment.yaml
+++ b/deploy/kubernetes/console/templates/deployment.yaml
@@ -182,8 +182,7 @@ spec:
         - name: SKIP_SSL_VALIDATION 
           value: {{default "true" .Values.uaa.skipSSLValidation | quote}}
         {{- end }}
-        {{- if .Values.console.cookieDomain }}  
-        {{ if ne .Values.console.cookieDomain "-" }}
+        {{- if .Values.console.cookieDomain }}{{ if ne .Values.console.cookieDomain "-" }}
         - name: COOKIE_DOMAIN
           value: {{.Values.console.cookieDomain}}
         {{- end }}

--- a/deploy/kubernetes/console/templates/deployment.yaml
+++ b/deploy/kubernetes/console/templates/deployment.yaml
@@ -182,8 +182,13 @@ spec:
         - name: SKIP_SSL_VALIDATION 
           value: {{default "true" .Values.uaa.skipSSLValidation | quote}}
         {{- end }}
-        {{- if .Values.env.DOMAIN }}  
-        - name: X_COOKIE_DOMAIN
+        {{- if .Values.console.cookieDomain }}  
+        {{ if ne .Values.console.cookieDomain "-" }}
+        - name: COOKIE_DOMAIN
+          value: {{.Values.console.cookieDomain}}
+        {{- end }}
+        {{- else if .Values.env.DOMAIN }}  
+        - name: COOKIE_DOMAIN
           value: {{.Values.env.DOMAIN}}
         {{- end }}
         ports:

--- a/deploy/kubernetes/console/values.yaml
+++ b/deploy/kubernetes/console/values.yaml
@@ -13,6 +13,7 @@ dbProvider: mysql
 useLb: false
 console:
   port: 443
+  cookieDomain:
 # externalIP: 127.0.0.1
 images:
   console: stratos-console

--- a/src/backend/app-core/middleware.go
+++ b/src/backend/app-core/middleware.go
@@ -20,6 +20,8 @@ import (
 
 const cfSessionCookieName = "JSESSIONID"
 
+const StratosDomainHeader = "x-stratos-domain"
+
 func handleSessionError(err error, doNotLog bool) error {
 	if strings.Contains(err.Error(), "dial tcp") {
 		return interfaces.NewHTTPShadowError(
@@ -54,6 +56,10 @@ func (p *portalProxy) sessionMiddleware(h echo.HandlerFunc) echo.HandlerFunc {
 
 		// Don't log an error if we are verifying the session, as a failure is not an error
 		isVerify := strings.HasSuffix(c.Request().URI(), "/auth/session/verify")
+		if isVerify {
+			// Tell the frontend what the Cookie Domain is so it can check if sessions will work
+			c.Response().Header().Set(StratosDomainHeader, p.Config.CookieDomain)
+		}
 		return handleSessionError(err, isVerify)
 	}
 }

--- a/src/frontend/app/app.routing.ts
+++ b/src/frontend/app/app.routing.ts
@@ -11,11 +11,13 @@ import { ConsoleUaaWizardComponent } from './features/setup/uaa-wizard/console-u
 import { UpgradePageComponent } from './features/setup/upgrade-page/upgrade-page.component';
 import { SharedModule } from './shared/shared.module';
 import { PageNotFoundComponentComponent } from './core/page-not-found-component/page-not-found-component.component';
+import { DomainMismatchComponent } from './features/setup/domain-mismatch/domain-mismatch.component';
 
 const appRoutes: Routes = [
   { path: '', redirectTo: 'applications', pathMatch: 'full' },
   { path: 'uaa', component: ConsoleUaaWizardComponent },
   { path: 'upgrade', component: UpgradePageComponent },
+  { path: 'domainMismatch', component: DomainMismatchComponent },
   { path: 'login', loadChildren: 'app/features/login/login.module#LoginModule' },
   {
     path: '',

--- a/src/frontend/app/features/login/login-page/login-page.component.ts
+++ b/src/frontend/app/features/login/login-page/login-page.component.ts
@@ -107,6 +107,13 @@ export class LoginPageComponent implements OnInit, OnDestroy {
       return false;
     }
 
+    // Cookie domain mismatch (user won't be able to login)
+    if (auth.sessionData && auth.sessionData.domainMismatch) {
+      this.subscription.unsubscribe(); // Ensure to unsub otherwise GoToState gets caught in loop
+      this.store.dispatch(new RouterNav({ path: ['/domainMismatch'], extras: { skipLocationChange: true } }));
+      return false;
+    }
+
     // auth.sessionData will be populated if user has been redirected here after attempting to access a protected page without
     // a valid session
     this.error = auth.error && (!auth.sessionData || !auth.sessionData.valid);

--- a/src/frontend/app/features/setup/domain-mismatch/domain-mismatch.component.html
+++ b/src/frontend/app/features/setup/domain-mismatch/domain-mismatch.component.html
@@ -1,0 +1,13 @@
+<app-intro-screen>
+  <mat-card class="domain__card">
+    <app-stratos-title></app-stratos-title>
+    <div class="domain__message">
+      <mat-icon>warning</mat-icon>
+      <span>Domain mismatch</span>
+    </div>
+    <div class="domain__detail">
+      <p>The URL you are using to access Stratos does not match the configured domain</p>
+      <p>Please contact your system administrator</p>
+    </div>
+  </mat-card>
+</app-intro-screen>

--- a/src/frontend/app/features/setup/domain-mismatch/domain-mismatch.component.scss
+++ b/src/frontend/app/features/setup/domain-mismatch/domain-mismatch.component.scss
@@ -1,0 +1,23 @@
+.domain {
+  &__card {
+    margin: 12px;
+    padding: 24px 64px;
+  }
+  &__message {
+    align-items: center;
+    display: flex;
+    font-size: 18px;
+    font-weight: 600;
+    justify-content: center;
+    padding: 32px 48px 0;
+    text-align: center;
+    span {
+      margin-left: 12px;
+    }
+  }
+  &__detail {
+    font-size: 16px;
+    padding: 24px 0 32px;
+    text-align: center;
+  }
+}

--- a/src/frontend/app/features/setup/domain-mismatch/domain-mismatch.component.spec.ts
+++ b/src/frontend/app/features/setup/domain-mismatch/domain-mismatch.component.spec.ts
@@ -1,0 +1,31 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DomainMismatchComponent } from './domain-mismatch.component';
+import { MDAppModule } from '../../../core/md.module';
+import { IntroScreenComponent } from '../../../shared/components/intro-screen/intro-screen.component';
+import { StratosTitleComponent } from '../../../shared/components/stratos-title/stratos-title.component';
+
+describe('DomainMismatchComponent', () => {
+  let component: DomainMismatchComponent;
+  let fixture: ComponentFixture<DomainMismatchComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DomainMismatchComponent, IntroScreenComponent, StratosTitleComponent ],
+      imports: [
+        MDAppModule,
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DomainMismatchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/frontend/app/features/setup/domain-mismatch/domain-mismatch.component.ts
+++ b/src/frontend/app/features/setup/domain-mismatch/domain-mismatch.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-domain-mismatch',
+  templateUrl: './domain-mismatch.component.html',
+  styleUrls: ['./domain-mismatch.component.scss']
+})
+export class DomainMismatchComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/frontend/app/features/setup/setup.module.ts
+++ b/src/frontend/app/features/setup/setup.module.ts
@@ -4,6 +4,7 @@ import { CoreModule } from '../../core/core.module';
 import { SharedModule } from '../../shared/shared.module';
 import { ConsoleUaaWizardComponent } from './uaa-wizard/console-uaa-wizard.component';
 import { UpgradePageComponent } from './upgrade-page/upgrade-page.component';
+import { DomainMismatchComponent } from './domain-mismatch/domain-mismatch.component';
 
 
 @NgModule({
@@ -13,7 +14,8 @@ import { UpgradePageComponent } from './upgrade-page/upgrade-page.component';
   ],
   declarations: [
     ConsoleUaaWizardComponent,
-    UpgradePageComponent
+    UpgradePageComponent,
+    DomainMismatchComponent
   ]
 })
 export class SetupModule { }

--- a/src/frontend/app/store/actions/auth.actions.ts
+++ b/src/frontend/app/store/actions/auth.actions.ts
@@ -43,7 +43,7 @@ export class VerifiedSession implements Action {
 }
 
 export class InvalidSession implements Action {
-  constructor(public uaaError: boolean = false, public upgradeInProgress = false) { }
+  constructor(public uaaError: boolean = false, public upgradeInProgress = false, public domainMismatch = false) { }
   type = SESSION_INVALID;
 }
 

--- a/src/frontend/app/store/reducers/auth.reducer.ts
+++ b/src/frontend/app/store/reducers/auth.reducer.ts
@@ -69,7 +69,8 @@ export function authReducer(state: AuthState = defaultState, action): AuthState 
       const sessionInvalid: InvalidSession = action;
       return {
         ...state,
-        sessionData: { valid: false, uaaError: action.uaaError, upgradeInProgress: action.upgradeInProgress, sessionExpiresOn: null },
+        sessionData: { valid: false, uaaError: action.uaaError, upgradeInProgress: action.upgradeInProgress,
+          domainMismatch: action.domainMismatch, sessionExpiresOn: null },
         verifying: false
       };
     case RouterActions.GO:

--- a/src/frontend/app/store/types/auth.types.ts
+++ b/src/frontend/app/store/types/auth.types.ts
@@ -35,4 +35,5 @@ export interface SessionData {
   uaaError?: boolean;
   upgradeInProgress?: boolean;
   sessionExpiresOn: number;
+  domainMismatch?: boolean;
 }


### PR DESCRIPTION
Env var COOKIE_DOMAIN can restrict the domain used for the session cookie.

This PR:

- Adds back in the COOKIE_DOMAIN in the Helm chart
- Adds a new helm value console.cookieDomain that overrides env.DOMAIN
- Allows this new value to be set to "-" to say not to set it (event if env.DOMAIN is set)
- Adds a view that is shown if the configured Cookie Domain does not match that of the requesting URL - since the session cookie won't work and therefore the user can not login
 