### PR TITLE
Fix list state (deleting/etc)

### DIFF
--- a/src/frontend/app/shared/components/list/data-sources-controllers/list-data-source-config.ts
+++ b/src/frontend/app/shared/components/list/data-sources-controllers/list-data-source-config.ts
@@ -1,11 +1,11 @@
 import { Store } from '@ngrx/store';
 import { schema } from 'normalizr';
-import { OperatorFunction ,  Observable } from 'rxjs';
+import { OperatorFunction, Observable } from 'rxjs';
 
 import { AppState } from '../../../../store/app-state';
 import { PaginatedAction } from '../../../../store/types/pagination.types';
 import { DataFunction, DataFunctionDefinition } from './list-data-source';
-import { getRowUniqueId, RowsState } from './list-data-source-types';
+import { getRowUniqueId, RowsState, RowState } from './list-data-source-types';
 import { IListConfig } from '../list.component.types';
 
 export interface IListDataSourceConfig<A, T> {
@@ -28,7 +28,7 @@ export interface IListDataSourceConfig<A, T> {
    */
   paginationKey: string;
   /**
-   * The state of each row/entity
+   * An observable containing each row's state
    */
   rowsState?: Observable<RowsState>;
   /**
@@ -60,4 +60,9 @@ export interface IListDataSourceConfig<A, T> {
   destroy?: () => void;
 
   refresh?: () => void;
+  /**
+   * A function which fetches an observable containing a specific row's state
+   *
+   */
+  getRowState?(row: T): Observable<RowState>;
 }

--- a/src/frontend/app/shared/components/list/data-sources-controllers/list-data-source.ts
+++ b/src/frontend/app/shared/components/list/data-sources-controllers/list-data-source.ts
@@ -12,7 +12,7 @@ import { getPaginationObservables } from '../../../../store/reducers/pagination-
 import { PaginatedAction, PaginationEntityState } from '../../../../store/types/pagination.types';
 import { PaginationMonitor } from '../../../monitors/pagination-monitor';
 import { IListDataSourceConfig } from './list-data-source-config';
-import { getDefaultRowState, getRowUniqueId, IListDataSource, RowsState } from './list-data-source-types';
+import { getDefaultRowState, getRowUniqueId, IListDataSource, RowsState, RowState } from './list-data-source-types';
 import { getDataFunctionList } from './local-filtering-sorting';
 import { LocalListController } from './local-list-controller';
 import { tag } from 'rxjs-spy/operators';
@@ -68,6 +68,8 @@ export abstract class ListDataSource<T, A = T> extends DataSource<T> implements 
 
   // Misc
   public isLoadingPage$: Observable<boolean> = observableOf(false);
+  public rowsState: Observable<RowsState>;
+  public getRowState: (row: T) => Observable<RowState> = null;
 
   // ------------- Private
   private entities$: Observable<T>;
@@ -83,7 +85,6 @@ export abstract class ListDataSource<T, A = T> extends DataSource<T> implements 
   private transformEntity: OperatorFunction<A[], T[]> = null;
   public isLocal = false;
   public transformEntities?: (DataFunction<T> | DataFunctionDefinition)[];
-  public rowsState?: Observable<RowsState>;
 
   private pageSubscription: Subscription;
   private transformedEntitiesSubscription: Subscription;
@@ -159,6 +160,7 @@ export abstract class ListDataSource<T, A = T> extends DataSource<T> implements 
     this.isLocal = config.isLocal || false;
     this.transformEntities = config.transformEntities;
     this.rowsState = config.rowsState;
+    this.getRowState = config.getRowState;
     this.externalDestroy = config.destroy || (() => { });
     this.addItem = this.getEmptyType();
     this.entityKey = this.sourceScheme.key;

--- a/src/frontend/app/shared/components/list/list-table/table-row/table-row.component.html
+++ b/src/frontend/app/shared/components/list/list-table/table-row/table-row.component.html
@@ -2,7 +2,7 @@
   <div *ngIf="isDeleting$ | async" class="table-row__deletion-bar-wrapper">
     <div class="table-row__deletion-bar-inner">
       <div class="table-row__deletion-bar-text">Deleting</div>
-      <mat-progress-bar class="table-row__deletion-bar"  mode="indeterminate"></mat-progress-bar>
+      <mat-progress-bar class="table-row__deletion-bar" mode="indeterminate"></mat-progress-bar>
     </div>
   </div>
   <div role="row" class="table-row">

--- a/src/frontend/app/shared/components/list/list-types/cf-space-routes/cf-space-route-row-state.helper.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-space-routes/cf-space-route-row-state.helper.ts
@@ -44,10 +44,11 @@ export class SpaceRouteDataSourceHelper {
           const request$ = entityMonitor.entityRequest$.pipe(
             tap(request => {
               const unmapping = request.updating['unmapping'] || { busy: false };
-              const blocked = request.deleting.busy;
               const busy = unmapping.busy;
               rowStateManager.setRowState(route.metadata.guid, {
-                blocked,
+                deleting: request.deleting.busy,
+                error: request.deleting.error,
+                blocked: unmapping.busy,
                 busy
               });
             })

--- a/src/frontend/app/shared/components/list/list-types/cf-space-routes/cf-space-routes-data-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-space-routes/cf-space-routes-data-source.ts
@@ -6,10 +6,10 @@ import { GetSpaceRoutes } from '../../../../../store/actions/space.actions';
 import { AppState } from '../../../../../store/app-state';
 import {
   applicationSchemaKey,
+  domainSchemaKey,
   entityFactory,
   routeSchemaKey,
   spaceSchemaKey,
-  domainSchemaKey,
 } from '../../../../../store/helpers/entity-factory';
 import {
   createEntityRelationKey,

--- a/src/frontend/app/shared/components/list/list-types/github-commits/github-commits-data-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/github-commits/github-commits-data-source.ts
@@ -1,21 +1,18 @@
-
-import {of as observableOf,  Observable } from 'rxjs';
 import { Store } from '@ngrx/store';
+import { of as observableOf } from 'rxjs';
 
-import { GetAllEndpoints } from '../../../../../store/actions/endpoint.actions';
-import { CreatePagination } from '../../../../../store/actions/pagination.actions';
+import { FetchCommits } from '../../../../../store/actions/deploy-applications.actions';
 import { AppState } from '../../../../../store/app-state';
-import { entityFactory, EntitySchema, githubCommitSchemaKey } from '../../../../../store/helpers/entity-factory';
-import { endpointSchemaKey } from '../../../../../store/helpers/entity-factory';
-import { EndpointModel } from '../../../../../store/types/endpoint.types';
+import { EntitySchema, githubCommitSchemaKey } from '../../../../../store/helpers/entity-factory';
+import { APIResource } from '../../../../../store/types/api.types';
+import { GithubCommit } from '../../../../../store/types/github.types';
 import { ListDataSource } from '../../data-sources-controllers/list-data-source';
 import { IListConfig } from '../../list.component.types';
-import { GithubCommit } from '../../../../../store/types/github.types';
-import { FetchCommits } from '../../../../../store/actions/deploy-applications.actions';
-import { APIResource } from '../../../../../store/types/api.types';
+
 
 export class GithubCommitsDataSource extends ListDataSource<APIResource<GithubCommit>> {
   store: Store<AppState>;
+
   /**
    * Creates an instance of GithubCommitsDataSource.
    * @param {Store<AppState>} store

--- a/src/frontend/app/shared/components/list/list.component.ts
+++ b/src/frontend/app/shared/components/list/list.component.ts
@@ -1,20 +1,3 @@
-
-import { of as observableOf, BehaviorSubject, Observable, combineLatest as observableCombineLatest, Subscription } from 'rxjs';
-
-import {
-  debounceTime,
-  distinctUntilChanged,
-  filter,
-  first,
-  map,
-  pairwise,
-  publishReplay,
-  refCount,
-  startWith,
-  takeWhile,
-  tap,
-  withLatestFrom,
-} from 'rxjs/operators';
 import { animate, style, transition, trigger } from '@angular/animations';
 import {
   AfterViewInit,
@@ -29,12 +12,36 @@ import {
 import { NgForm, NgModel } from '@angular/forms';
 import { MatPaginator, PageEvent, SortDirection } from '@angular/material';
 import { Store } from '@ngrx/store';
+import { schema } from 'normalizr';
+import {
+  BehaviorSubject,
+  combineLatest as observableCombineLatest,
+  Observable,
+  of as observableOf,
+  Subscription,
+} from 'rxjs';
+import {
+  debounceTime,
+  distinctUntilChanged,
+  filter,
+  first,
+  map,
+  pairwise,
+  publishReplay,
+  refCount,
+  startWith,
+  takeWhile,
+  tap,
+  withLatestFrom,
+} from 'rxjs/operators';
 
 import { ListFilter, ListPagination, ListSort, SetListViewAction } from '../../../store/actions/list.actions';
 import { AppState } from '../../../store/app-state';
+import { entityFactory } from '../../../store/helpers/entity-factory';
 import { getListStateObservables } from '../../../store/reducers/list.reducer';
+import { EntityMonitor } from '../../monitors/entity-monitor';
 import { ListView } from './../../../store/actions/list.actions';
-import { IListDataSource, RowsState, RowState, getDefaultRowState } from './data-sources-controllers/list-data-source-types';
+import { getDefaultRowState, IListDataSource, RowsState, RowState } from './data-sources-controllers/list-data-source-types';
 import { IListPaginationController, ListPaginationController } from './data-sources-controllers/list-pagination-controller';
 import { ITableColumn } from './list-table/table.types';
 import {
@@ -45,13 +52,10 @@ import {
   IListConfig,
   IListMultiFilterConfig,
   IMultiListAction,
+  IOptionalAction,
   ListConfig,
   ListViewTypes,
-  IOptionalAction,
 } from './list.component.types';
-import { entityFactory } from '../../../store/helpers/entity-factory';
-import { EntityMonitor } from '../../monitors/entity-monitor';
-import { schema } from 'normalizr';
 
 
 @Component({
@@ -217,7 +221,9 @@ export class ListComponent<T> implements OnInit, OnDestroy, AfterViewInit {
     this.singleActions = this.config.getSingleActions();
     this.columns = this.config.getColumns();
     this.dataSource = this.config.getDataSource();
-    if (!this.dataSource.getRowState) {
+    if (this.dataSource.rowsState) {
+      this.dataSource.getRowState = this.getRowStateFromRowsState;
+    } else if (!this.dataSource.getRowState) {
       const schema = entityFactory(this.dataSource.entityKey);
       this.dataSource.getRowState = this.getRowStateGeneratorFromEntityMonitor(schema, this.dataSource);
     }
@@ -547,12 +553,16 @@ export class ListComponent<T> implements OnInit, OnDestroy, AfterViewInit {
       const entityMonitor = new EntityMonitor(this.store, dataSource.getRowUniqueId(row), dataSource.entityKey, entitySchema);
       return entityMonitor.entityRequest$.pipe(
         distinctUntilChanged(),
-        map(requestInfor => ({
-          deleting: requestInfor.deleting.busy,
-          error: requestInfor.deleting.error,
-          message: requestInfor.deleting.error ? `Sorry, deletion failed` : null
+        map(requestInfo => ({
+          deleting: requestInfo.deleting.busy,
+          error: requestInfo.deleting.error,
+          message: requestInfo.deleting.error ? `Sorry, deletion failed` : null
         }))
       );
     };
   }
+
+  private getRowStateFromRowsState = (row: T): Observable<RowState> =>
+    this.dataSource.rowsState.pipe(map(state => state[this.dataSource.getRowUniqueId(row)] || getDefaultRowState()))
+
 }


### PR DESCRIPTION
- This fixes the following list states
  - Endpoints table endpoint warning state
  - Space routes table unbind state
  - app github tabs commit table highlighting
- By..
  - If we have a `rowsState` use it before falling back to `getRowState`
  - Both `rowsState` and `getRowState` are plumbed in to data source config (tidying up)
