### PR TITLE
Service Catalog UI Tweaks

### DIFF
--- a/src/frontend/app/shared/components/boolean-indicator/boolean-indicator.component.html
+++ b/src/frontend/app/shared/components/boolean-indicator/boolean-indicator.component.html
@@ -1,10 +1,10 @@
 <div class="boolean-indicator">
   <div class="boolean-indicator__container" *ngIf="isTrue">
-    <mat-icon class="boolean-indicator__container__icon-true">{{ getIcon() }}</mat-icon>
+    <mat-icon [ngClass]="{'boolean-indicator__container__icon-subtle': subtle}" class="boolean-indicator__container__icon-true">{{ getIcon() }}</mat-icon>
     <div>{{ getText() }}</div>
   </div>
   <div class="boolean-indicator__container" *ngIf="!isTrue">
-    <mat-icon class="boolean-indicator__container__icon-false">{{ getIcon() }}</mat-icon>
+    <mat-icon [ngClass]="{'boolean-indicator__container__icon-subtle': subtle}" class="boolean-indicator__container__icon-false">{{ getIcon() }}</mat-icon>
     <div>{{ getText() }}</div>
   </div>
 </div>

--- a/src/frontend/app/shared/components/boolean-indicator/boolean-indicator.component.theme.scss
+++ b/src/frontend/app/shared/components/boolean-indicator/boolean-indicator.component.theme.scss
@@ -1,13 +1,20 @@
 @import '~@angular/material/theming';
 @mixin app-boolean-indicator-theme($theme, $app-theme) {
+  $primary: map-get($theme, primary);
   $status: map-get($app-theme, status);
   .boolean-indicator {
     &__container {
       &__icon-true {
         color: map-get($status, success);
+        &.boolean-indicator__container__icon-subtle {
+          color: mat-color($primary)
+        }
       }
       &__icon-false {
         color: map-get($status, danger);
+        &.boolean-indicator__container__icon-subtle {
+          color: map-get($status, tentative);
+        }
       }
     }
   }

--- a/src/frontend/app/shared/components/boolean-indicator/boolean-indicator.component.theme.scss
+++ b/src/frontend/app/shared/components/boolean-indicator/boolean-indicator.component.theme.scss
@@ -7,7 +7,7 @@
       &__icon-true {
         color: map-get($status, success);
         &.boolean-indicator__container__icon-subtle {
-          color: mat-color($primary)
+          color: mat-color($primary);
         }
       }
       &__icon-false {

--- a/src/frontend/app/shared/components/boolean-indicator/boolean-indicator.component.ts
+++ b/src/frontend/app/shared/components/boolean-indicator/boolean-indicator.component.ts
@@ -6,7 +6,6 @@ export enum BooleanIndicatorType {
   lockedUnlocked = 'locked-unlocked',
   unlockedLocked = 'unlocked-locked',
   yesNo = 'yes-no',
-  yesNoSubtlt = 'yes-no',
   trueFalse = 'true-false'
 }
 

--- a/src/frontend/app/shared/components/boolean-indicator/boolean-indicator.component.ts
+++ b/src/frontend/app/shared/components/boolean-indicator/boolean-indicator.component.ts
@@ -6,6 +6,7 @@ export enum BooleanIndicatorType {
   lockedUnlocked = 'locked-unlocked',
   unlockedLocked = 'unlocked-locked',
   yesNo = 'yes-no',
+  yesNoSubtlt = 'yes-no',
   trueFalse = 'true-false'
 }
 
@@ -19,6 +20,9 @@ export class BooleanIndicatorComponent implements OnInit {
 
   @Input('isTrue') isTrue: boolean;
   @Input('type') type: BooleanIndicatorType;
+
+  // Should we use a subtle display - this won't show the No option as dandger (typically red)
+  @Input('subtle') subtle: boolean;
 
   private icons = {
     Yes: 'check_circle',

--- a/src/frontend/app/shared/components/cards/service-summary-card/service-summary-card.component.html
+++ b/src/frontend/app/shared/components/cards/service-summary-card/service-summary-card.component.html
@@ -8,20 +8,22 @@
   <app-meta-card-item customStyle="long-text">
     <app-meta-card-key></app-meta-card-key>
     <app-meta-card-value>
-      {{ servicesService.getServiceDescription() | async }}
+      <span class="service-summary__description">
+        {{ servicesService.getServiceDescription() | async }}
+      </span>
     </app-meta-card-value>
   </app-meta-card-item>
   <app-meta-card-item>
     <app-meta-card-key>Active</app-meta-card-key>
     <app-meta-card-value>
-      <app-boolean-indicator [isTrue]="(service$ | async)?.entity.active" type="yes-no">
+      <app-boolean-indicator [isTrue]="(service$ | async)?.entity.active" type="yes-no" subtle="true">
       </app-boolean-indicator>
     </app-meta-card-value>
   </app-meta-card-item>
   <app-meta-card-item>
     <app-meta-card-key>Bindable</app-meta-card-key>
     <app-meta-card-value>
-      <app-boolean-indicator [isTrue]="(service$ | async)?.entity.bindable" type="yes-no">
+      <app-boolean-indicator [isTrue]="(service$ | async)?.entity.bindable" type="yes-no" subtle="true">
       </app-boolean-indicator>
     </app-meta-card-value>
   </app-meta-card-item>

--- a/src/frontend/app/shared/components/cards/service-summary-card/service-summary-card.component.scss
+++ b/src/frontend/app/shared/components/cards/service-summary-card/service-summary-card.component.scss
@@ -4,4 +4,7 @@
     flex-direction: row;
     justify-content: space-between;
   }
+  &__description {
+    line-height: 1.5em;
+  }
 }

--- a/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-item/meta-card-item.component.scss
+++ b/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-item/meta-card-item.component.scss
@@ -49,7 +49,7 @@
   .meta-card-item__value {
     height: 3.6em;
     position: relative;
-    &:after {
+    &::after {
       background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 75%);
       bottom: 0;
       content: '';

--- a/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-item/meta-card-item.component.scss
+++ b/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-item/meta-card-item.component.scss
@@ -31,7 +31,7 @@
   padding-top: 10px;
 }
 
-.meta-card-item-long-text {
+.meta-card-item-long-text, .meta-card-item-long-text-fixed {
   padding-top: 10px;
   .meta-card-item__value {
     padding-bottom: 10px;
@@ -41,5 +41,22 @@
   }
   .meta-card-item__key {
     display: none;
+  }
+}
+
+.meta-card-item-long-text-fixed {
+  .meta-card-item__value {
+    height: 3.6em;
+    position: relative;
+    &:after {
+      content: "";
+      text-align: right;
+      position: absolute;
+      bottom: 0;
+      right: 0;
+      width: 25%;
+      height: 1.2em;
+      background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 75%);
+    }
   }
 }

--- a/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-item/meta-card-item.component.scss
+++ b/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-item/meta-card-item.component.scss
@@ -47,7 +47,8 @@
 
 .meta-card-item-long-text-fixed {
   .meta-card-item__value {
-    height: 3.6em;
+    height: 54px;
+    line-height: 18px;
     position: relative;
     &::after {
       background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 75%);

--- a/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-item/meta-card-item.component.scss
+++ b/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-item/meta-card-item.component.scss
@@ -31,7 +31,8 @@
   padding-top: 10px;
 }
 
-.meta-card-item-long-text, .meta-card-item-long-text-fixed {
+.meta-card-item-long-text,
+.meta-card-item-long-text-fixed {
   padding-top: 10px;
   .meta-card-item__value {
     padding-bottom: 10px;
@@ -49,14 +50,14 @@
     height: 3.6em;
     position: relative;
     &:after {
-      content: "";
-      text-align: right;
-      position: absolute;
-      bottom: 0;
-      right: 0;
-      width: 25%;
-      height: 1.2em;
       background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 75%);
+      bottom: 0;
+      content: '';
+      height: 1.2em;
+      position: absolute;
+      right: 0;
+      text-align: right;
+      width: 25%;
     }
   }
 }

--- a/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-item/meta-card-item.component.ts
+++ b/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-item/meta-card-item.component.ts
@@ -15,7 +15,8 @@ export class MetaCardItemComponent implements OnInit {
     'row': 'meta-card-item-row',
     'row-top': 'meta-card-item-row-top',
     'column': 'meta-card-item-column',
-    'long-text': 'meta-card-item-long-text'
+    'long-text': 'meta-card-item-long-text',
+    'long-text-fixed': 'meta-card-item-long-text-fixed',
   };
   itemStyle = 'meta-card-item-row';
   @ContentChild(MetaCardKeyComponent)

--- a/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-title/meta-card-title.component.html
+++ b/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-title/meta-card-title.component.html
@@ -1,5 +1,5 @@
 <ng-template>
-  <div class="meta-card__title">
+  <div class="meta-card__title" [ngClass]="{'meta-card__title-nomargin': !!noMargin}">
     <ng-content></ng-content>
   </div>
 </ng-template>

--- a/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-title/meta-card-title.component.scss
+++ b/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-title/meta-card-title.component.scss
@@ -3,5 +3,8 @@
     flex: 1;
     font-weight: 500;
     margin-bottom: 16px;
+    &.meta-card__title-nomargin {
+      margin-bottom: 0;
+    }
   }
 }

--- a/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-title/meta-card-title.component.ts
+++ b/src/frontend/app/shared/components/list/list-cards/meta-card/meta-card-title/meta-card-title.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, Input, TemplateRef, ViewChild } from '@angular/core';
 
 @Component({
   selector: 'app-meta-card-title',
@@ -10,6 +10,8 @@ export class MetaCardTitleComponent implements OnInit {
 
   @ViewChild(TemplateRef)
   content: TemplateRef<any>;
+
+  @Input('noMargin') noMargin;
 
   constructor() { }
 

--- a/src/frontend/app/shared/components/list/list-types/cf-endpoints/cf-endpoint-card/endpoint-card.component.html
+++ b/src/frontend/app/shared/components/list/list-types/cf-endpoints/cf-endpoint-card/endpoint-card.component.html
@@ -8,10 +8,10 @@
     <app-meta-card-key>Account Username</app-meta-card-key>
     <app-meta-card-value>{{ row.user.name }}</app-meta-card-value>
   </app-meta-card-item>
-  <app-meta-card-item *ngIf="row.user.admin === true">
+  <app-meta-card-item>
     <app-meta-card-key>Administrator</app-meta-card-key>
     <app-meta-card-value>
-      <app-boolean-indicator [isTrue]="row.user.admin" type="yes-no"></app-boolean-indicator>
+      <app-boolean-indicator [isTrue]="row.user.admin" type="yes-no" subtle="true"></app-boolean-indicator>
     </app-meta-card-value>
   </app-meta-card-item>
 </app-meta-card>

--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.html
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.html
@@ -1,50 +1,54 @@
 <app-meta-card class="service-card" [clickAction]="goToServiceInstances">
-  <app-meta-card-title>
+  <app-meta-card-title noMargin="true">
     <div class="service-card__title">
       <div class="service-card__title__link">{{ getDisplayName() }}</div>
       <app-service-icon [service]="row"></app-service-icon>
     </div>
   </app-meta-card-title>
-  <app-meta-card-item customStyle="long-text">
+  <app-meta-card-item customStyle="long-text-fixed">
     <app-meta-card-key></app-meta-card-key>
     <app-meta-card-value>
       {{ row.entity.description}}
     </app-meta-card-value>
   </app-meta-card-item>
   <app-meta-card-item>
+      <app-meta-card-key>Service Plans</app-meta-card-key>
+      <app-meta-card-value>
+        {{ row.entity.service_plans.length }}
+      </app-meta-card-value>
+    </app-meta-card-item>
+  <app-meta-card-item>
     <app-meta-card-key>Active</app-meta-card-key>
     <app-meta-card-value>
-      <app-boolean-indicator [isTrue]="row.entity.active" type="yes-no">
+      <app-boolean-indicator [isTrue]="row.entity.active" type="yes-no" subtle="true">
       </app-boolean-indicator>
     </app-meta-card-value>
   </app-meta-card-item>
   <app-meta-card-item>
     <app-meta-card-key>Bindable</app-meta-card-key>
     <app-meta-card-value>
-      <app-boolean-indicator [isTrue]="row.entity.bindable" type="yes-no">
+      <app-boolean-indicator [isTrue]="row.entity.bindable" type="yes-no" subtle="true">
       </app-boolean-indicator>
     </app-meta-card-value>
   </app-meta-card-item>
-  <app-meta-card-item *ngIf="hasDocumentationUrl()">
-    <app-meta-card-key>Documentation Link</app-meta-card-key>
-    <app-meta-card-value>
-      <a [href]="getDocumentationUrl()" target="_blank" appClickStopPropagation>
-        <mat-icon>launch</mat-icon>
-      </a>
-    </app-meta-card-value>
-  </app-meta-card-item>
-  <app-meta-card-item *ngIf="hasSupportUrl()">
-    <app-meta-card-key>Support Link</app-meta-card-key>
-    <app-meta-card-value>
-      <a [href]="getSupportUrl()" target="_blank" appClickStopPropagation>
-        <mat-icon>launch</mat-icon>
-      </a>
-    </app-meta-card-value>
-  </app-meta-card-item>
   <app-meta-card-item>
-    <app-meta-card-key>Service Plans</app-meta-card-key>
+    <app-meta-card-key>References</app-meta-card-key>
     <app-meta-card-value>
-      {{ row.entity.service_plans.length }}
+      <div class="service-card__links">
+        <div class="service-card__link" *ngIf="hasDocumentationUrl()">
+          <a class="service-card__icon-link" [href]="getDocumentationUrl()" target="_blank" appClickStopPropagation>
+            <mat-icon>launch</mat-icon>
+          </a>
+          <a [href]="getDocumentationUrl()" target="_blank" appClickStopPropagation>Docs</a>
+        </div>
+        <div class="service-card__link" *ngIf="hasSupportUrl()">
+          <a class="service-card__icon-link" [href]="getSupportUrl()" target="_blank" appClickStopPropagation>
+            <mat-icon>launch</mat-icon>
+          </a>
+          <a [href]="getSupportUrl()" target="_blank" appClickStopPropagation>Support</a>
+        </div>
+      </div>
+      <div *ngIf="!hasDocumentationUrl() && !hasSupportUrl()">-</div>
     </app-meta-card-value>
   </app-meta-card-item>
   <app-meta-card-item customStyle="column">

--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.scss
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.scss
@@ -8,7 +8,7 @@
   &__links {
     display: flex;
     flex-wrap: wrap;
-    justify-content: flex-end;    
+    justify-content: flex-end;
   }
   &__link {
     display: flex;

--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.scss
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.scss
@@ -30,6 +30,8 @@
     }
   }
   &__icon-link {
+    align-items: center;
+    display: flex;
     text-decoration: none;
   }
 }

--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.scss
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.scss
@@ -23,7 +23,8 @@
       margin-right: 2px;
       text-decoration: none;
       width: 16px;
-      &:focus, &:active {
+      &:focus,
+      &:active {
         text-decoration: none;
       }
     }

--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.scss
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.scss
@@ -5,4 +5,30 @@
     justify-content: space-between;
     width: 100%;
   }
+  &__links {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;    
+  }
+  &__link {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    &:not(:first-child) {
+      margin-left: 6px;
+    }
+    mat-icon {
+      font-size: 16px;
+      height: 16px;
+      margin-right: 2px;
+      text-decoration: none;
+      width: 16px;
+      &:focus, &:active {
+        text-decoration: none;
+      }
+    }
+  }
+  &__icon-link {
+    text-decoration: none;
+  }
 }

--- a/src/frontend/app/shared/components/service-icon/service-icon.component.html
+++ b/src/frontend/app/shared/components/service-icon/service-icon.component.html
@@ -1,4 +1,4 @@
 <div class='service-icon' [ngClass]="{'service-icon__padding': addMenuPadding}">
-  <mat-icon *ngIf="!hasImage()">cloud_circle</mat-icon>
-  <img [src]="getImageUrl() | safeImg" *ngIf="hasImage()">
+  <mat-icon *ngIf="!image">cloud_circle</mat-icon>
+  <img [src]="image | safeImg" *ngIf="image" (error)="imageLoadError()">
 </div>

--- a/src/frontend/app/shared/components/service-icon/service-icon.component.ts
+++ b/src/frontend/app/shared/components/service-icon/service-icon.component.ts
@@ -9,6 +9,8 @@ import { IService, IServiceExtra } from '../../../core/cf-api-svc.types';
 })
 export class ServiceIconComponent implements OnInit {
 
+  image = '';
+
   extraInfo: IServiceExtra;
   @Input('service') service: APIResource<IService>;
 
@@ -18,19 +20,13 @@ export class ServiceIconComponent implements OnInit {
   ngOnInit() {
     if (this.service) {
       this.extraInfo = this.service.entity.extra ? JSON.parse(this.service.entity.extra) : null;
+      if (this.extraInfo && this.extraInfo.imageUrl) {
+        this.image = this.extraInfo.imageUrl;
+      }
     }
   }
 
-  hasImage() {
-    return !!(this.getImageUrl());
-  }
-
-  getImageUrl() {
-
-    let image = '';
-    if (this.extraInfo && this.extraInfo.imageUrl) {
-      image = this.extraInfo.imageUrl;
-    }
-    return image;
+  imageLoadError() {
+    this.image = '';
   }
 }


### PR DESCRIPTION
This PR:

- Adds a subtle flag to the boolean indicator that switches it to use subtler colours than red/green
- Updated service card to use this mode for bindable and active
- Clamped the description to 3 lines with fade for overflow so that all cards are aligned
- Moved service plan count up
- Combined the docs and support links and refined their display
- Improved the service card icon so that if the image fails to load we fall back to the default icon
- Changed line height to 1.5 on the description of the service detail page to make it easier to read

Also:

- Changed the CF Selector view to use the subtle mode and to always show if the user is an administrator of the given CF
