### PR TITLE
Fix layout on summary pages

### DIFF
--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-summary-tab/cloud-foundry-summary-tab.component.scss
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-summary-tab/cloud-foundry-summary-tab.component.scss
@@ -1,5 +1,5 @@
 .summary {
   display: flex;
-  height: 100%;
+  min-height: 100%;
   width: 100%;
 }


### PR DESCRIPTION
On screens with smaller height, the cf summary pages collapses and cards overlaps.