### PR TITLE
Center align icon and align text to it

### DIFF
--- a/src/frontend/app/shared/components/list/list-table/table-row/table-row.component.scss
+++ b/src/frontend/app/shared/components/list/list-table/table-row/table-row.component.scss
@@ -66,7 +66,7 @@
       text-align: left;
     }
     &-icon {
-      padding-left: 18px;
+      padding-left: 24px;
     }
   }
   &__blocker {

--- a/src/frontend/app/shared/components/list/list-table/table-row/table-row.component.scss
+++ b/src/frontend/app/shared/components/list/list-table/table-row/table-row.component.scss
@@ -57,13 +57,13 @@
     }
   }
   &__error {
+    align-items: center;
     display: none;
-    justify-content: middle;
     &-message {
       flex: 1;
       line-height: 20px;
-      margin: 15px 20%;
-      text-align: center;
+      margin: 15px 36px;
+      text-align: left;
     }
     &-icon {
       padding-left: 18px;


### PR DESCRIPTION
Fixes #2457 - The vertical alignment of the icon in the error bar when in the table row - moved text to left align.