### PR TITLE
Fixed exception after unmapping routes

### DIFF
--- a/src/frontend/app/features/applications/application.service.ts
+++ b/src/frontend/app/features/applications/application.service.ts
@@ -294,7 +294,7 @@ export class ApplicationService {
         }
         return null;
       }),
-      filter(entRoute => entRoute.entity && entRoute.entity.domain),
+      filter(entRoute => !!entRoute && !!entRoute.entity && !!entRoute.entity.domain),
       map(entRoute => getRoute(entRoute, true, false, {
         entityRequestInfo: undefined,
         entity: entRoute.entity.domain


### PR DESCRIPTION
After routes are unmapped from an app, the `routes` property contains an empty array, therefore, a `null` value is emitted by the map operator.

Fixes #2475