### PR TITLE
Fix issue timing issue resulting in  invalid Space Service request

### DIFF
--- a/src/frontend/app/shared/components/add-service-instance/add-service-instance/add-service-instance.component.html
+++ b/src/frontend/app/shared/components/add-service-instance/add-service-instance/add-service-instance.component.html
@@ -3,7 +3,7 @@
 </app-page-header>
 <div class="add-service-instance">
   <app-steppers [cancel]="modeService.cancelUrl">
-    <app-step *ngIf="modeService.viewDetail.showSelectCf && !isSpaceScoped()" title="Cloud Foundry" [valid]="selectCF.validate | async" [onNext]="onNext" [blocked]="cfOrgSpaceService.isLoading$ | async">
+    <app-step *ngIf="modeService.viewDetail.showSelectCf && !isSpaceScoped()" title="Cloud Foundry" [onEnter]="resetStoreData" [valid]="selectCF.validate | async" [onNext]="onNext" [blocked]="cfOrgSpaceService.isLoading$ | async">
       <app-create-application-step1 [stepperText]="stepperText" [isMarketplaceMode]="inMarketplaceMode" #selectCF></app-create-application-step1>
     </app-step>
     <app-step title="Select Service" *ngIf="modeService.viewDetail.showSelectService" [valid]="selectService.validate | async" [onNext]="selectService.onNext">

--- a/src/frontend/app/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
+++ b/src/frontend/app/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
@@ -124,6 +124,10 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
     return observableOf({ success: true });
   }
 
+  resetStoreData = () => {
+    this.store.dispatch(new ResetCreateServiceInstanceState());
+  }
+
   private getIdsFromRoute() {
     const serviceId = getIdFromRoute(this.activatedRoute, 'serviceId');
     const cfId = getIdFromRoute(this.activatedRoute, 'cfId');

--- a/src/frontend/app/shared/components/add-service-instance/select-service/select-service.component.ts
+++ b/src/frontend/app/shared/components/add-service-instance/select-service/select-service.component.ts
@@ -50,6 +50,8 @@ export class SelectServiceComponent implements OnDestroy, AfterContentInit {
       combineLatest(
         this.store.select(selectCreateServiceInstanceCfGuid),
         this.store.select(selectCreateServiceInstanceSpaceGuid)
+      ).pipe(
+       filter(([p, q]) => !!p && !!q)
       );
     const schema = entityFactory(serviceSchemaKey);
     this.isFetching$ = cfSpaceGuid$.pipe(

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/cf-spaces-service-instances-data-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/cf-spaces-service-instances-data-source.ts
@@ -24,13 +24,14 @@ import { GetServiceInstancesForSpace } from '../../../../../store/actions/space.
 export class CfSpacesServiceInstancesDataSource extends ListDataSource<APIResource> {
   constructor(cfGuid: string, spaceGuid: string, store: Store<AppState>, listConfig?: IListConfig<APIResource>) {
     const paginationKey = createEntityRelationPaginationKey(spaceSchemaKey, spaceGuid);
-    const action = new GetServiceInstancesForSpace(spaceGuid, cfGuid , paginationKey, null, [
+    const action = new GetServiceInstancesForSpace(spaceGuid, cfGuid, paginationKey, null, [
       createEntityRelationKey(serviceInstancesSchemaKey, serviceBindingSchemaKey),
       createEntityRelationKey(serviceInstancesSchemaKey, serviceSchemaKey),
       createEntityRelationKey(serviceInstancesSchemaKey, servicePlanSchemaKey),
       createEntityRelationKey(serviceInstancesSchemaKey, spaceSchemaKey),
       createEntityRelationKey(serviceBindingSchemaKey, applicationSchemaKey),
     ], true, false);
+    action.entity = [entityFactory(serviceInstancesWithSpaceSchemaKey)];
     super({
       store,
       action,

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/cf-spaces-service-instances-data-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/cf-spaces-service-instances-data-source.ts
@@ -24,7 +24,7 @@ import { GetServiceInstancesForSpace } from '../../../../../store/actions/space.
 export class CfSpacesServiceInstancesDataSource extends ListDataSource<APIResource> {
   constructor(cfGuid: string, spaceGuid: string, store: Store<AppState>, listConfig?: IListConfig<APIResource>) {
     const paginationKey = createEntityRelationPaginationKey(spaceSchemaKey, spaceGuid);
-    const action = new GetServiceInstancesForSpace(spaceGuid, cfGuid , paginationKey, null,[
+    const action = new GetServiceInstancesForSpace(spaceGuid, cfGuid , paginationKey, null, [
       createEntityRelationKey(serviceInstancesSchemaKey, serviceBindingSchemaKey),
       createEntityRelationKey(serviceInstancesSchemaKey, serviceSchemaKey),
       createEntityRelationKey(serviceInstancesSchemaKey, servicePlanSchemaKey),

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/cf-spaces-service-instances-data-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/cf-spaces-service-instances-data-source.ts
@@ -1,7 +1,6 @@
 import { Store } from '@ngrx/store';
 
 import { getRowMetadata } from '../../../../../features/cloud-foundry/cf.helpers';
-import { GetServicesInstancesInSpace } from '../../../../../store/actions/service-instances.actions';
 import { AppState } from '../../../../../store/app-state';
 import {
   applicationSchemaKey,
@@ -20,11 +19,12 @@ import {
 import { APIResource } from '../../../../../store/types/api.types';
 import { ListDataSource } from '../../data-sources-controllers/list-data-source';
 import { IListConfig } from '../../list.component.types';
+import { GetServiceInstancesForSpace } from '../../../../../store/actions/space.actions';
 
 export class CfSpacesServiceInstancesDataSource extends ListDataSource<APIResource> {
   constructor(cfGuid: string, spaceGuid: string, store: Store<AppState>, listConfig?: IListConfig<APIResource>) {
     const paginationKey = createEntityRelationPaginationKey(spaceSchemaKey, spaceGuid);
-    const action = new GetServicesInstancesInSpace(cfGuid, spaceGuid, paginationKey, [
+    const action = new GetServiceInstancesForSpace(spaceGuid, cfGuid , paginationKey, null,[
       createEntityRelationKey(serviceInstancesSchemaKey, serviceBindingSchemaKey),
       createEntityRelationKey(serviceInstancesSchemaKey, serviceSchemaKey),
       createEntityRelationKey(serviceInstancesSchemaKey, servicePlanSchemaKey),

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-instance-tags/table-cell-service-instance-tags.component.spec.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-instance-tags/table-cell-service-instance-tags.component.spec.ts
@@ -3,6 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TableCellServiceInstanceTagsComponent } from './table-cell-service-instance-tags.component';
 import { BaseTestModulesNoShared } from '../../../../../../test-framework/cloud-foundry-endpoint-service.helper';
 import { AppChipsComponent } from '../../../../chips/chips.component';
+import { EntityMonitorFactory } from '../../../../../monitors/entity-monitor.factory.service';
 
 describe('TableCellServiceInstanceTagsComponent', () => {
   let component: TableCellServiceInstanceTagsComponent<any>;
@@ -11,7 +12,8 @@ describe('TableCellServiceInstanceTagsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [TableCellServiceInstanceTagsComponent, AppChipsComponent],
-      imports: [...BaseTestModulesNoShared]
+      imports: [...BaseTestModulesNoShared],
+      providers: [EntityMonitorFactory]
 
     })
       .compileComponents();

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-name/table-cell-service-name.component.spec.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-name/table-cell-service-name.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TableCellServiceNameComponent } from './table-cell-service-name.component';
 import { BaseTestModulesNoShared } from '../../../../../../test-framework/cloud-foundry-endpoint-service.helper';
+import { EntityMonitorFactory } from '../../../../../monitors/entity-monitor.factory.service';
 
 describe('TableCellServiceNameComponent', () => {
   let component: TableCellServiceNameComponent<any>;
@@ -10,7 +11,8 @@ describe('TableCellServiceNameComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [TableCellServiceNameComponent],
-      imports: [...BaseTestModulesNoShared]
+      imports: [...BaseTestModulesNoShared],
+      providers: [EntityMonitorFactory]
     })
       .compileComponents();
   }));

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-name/table-cell-service-name.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-name/table-cell-service-name.component.ts
@@ -4,8 +4,10 @@ import { Observable } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
 import { IService, IServiceExtra } from '../../../../../../core/cf-api-svc.types';
+import { EntityServiceFactory } from '../../../../../../core/entity-service-factory.service';
+import { GetService } from '../../../../../../store/actions/service.actions';
 import { AppState } from '../../../../../../store/app-state';
-import { selectEntity } from '../../../../../../store/selectors/api.selectors';
+import { entityFactory, serviceSchemaKey } from '../../../../../../store/helpers/entity-factory';
 import { APIResource } from '../../../../../../store/types/api.types';
 import { TableCellCustom } from '../../../list.types';
 
@@ -18,20 +20,25 @@ export class TableCellServiceNameComponent<T> extends TableCellCustom<T> impleme
 
   serviceName$: Observable<string>;
   @Input('row') row;
-  constructor(private store: Store<AppState>) {
+  constructor(private store: Store<AppState>, private entityServiceFactory: EntityServiceFactory) {
     super();
   }
 
   ngOnInit() {
-    this.serviceName$ = this.store.select(selectEntity<APIResource<IService>>('service', this.row.entity.service_guid))
-      .pipe(
+    this.serviceName$ = this.entityServiceFactory.create<APIResource<IService>>(
+      serviceSchemaKey,
+      entityFactory(serviceSchemaKey),
+      this.row.entity.service_guid,
+      new GetService(this.row.entity.service_guid, this.row.entity.cfGuid),
+      false
+    ).entityObs$.pipe(
       filter(s => !!s),
       map(s => {
-        let serviceLabel = s.entity.label;
+        let serviceLabel = s.entity.entity.label;
         try {
-          const extraInfo: IServiceExtra = s.entity.extra ? JSON.parse(s.entity.extra) : null;
+          const extraInfo: IServiceExtra = s.entity.entity.extra ? JSON.parse(s.entity.entity.extra) : null;
           serviceLabel = extraInfo && extraInfo.displayName ? extraInfo.displayName : serviceLabel;
-        }catch (e) {}
+        } catch (e) { }
         return serviceLabel;
       })
     );

--- a/src/frontend/app/store/actions/service-instances.actions.ts
+++ b/src/frontend/app/store/actions/service-instances.actions.ts
@@ -24,40 +24,6 @@ import { getActions } from './action.helper';
 export const DELETE_SERVICE_BINDING = '[Service Instances] Delete service binding';
 export const UPDATE_SERVICE_INSTANCE_SUCCESS = getActions('Service Instances', 'Update Service Instance')[1];
 
-export class GetServicesInstancesInSpace
-  extends CFStartAction implements PaginationAction, EntityInlineParentAction, EntityInlineChildAction {
-  constructor(
-    public endpointGuid: string,
-    public spaceGuid: string,
-    public paginationKey: string,
-    public includeRelations: string[] = [
-      createEntityRelationKey(serviceInstancesSchemaKey, serviceBindingSchemaKey),
-      createEntityRelationKey(serviceInstancesSchemaKey, servicePlanSchemaKey)
-    ],
-    public populateMissing = true,
-    public flattenPagination = true
-  ) {
-    super();
-    this.options = new RequestOptions();
-    this.options.url = `spaces/${spaceGuid}/service_instances`;
-    this.options.method = 'get';
-    this.options.params = new URLSearchParams();
-    this.parentGuid = spaceGuid;
-  }
-  actions = getActions('Service Instances', 'Get all in Space');
-  entity = [entityFactory(serviceInstancesWithSpaceSchemaKey)];
-  entityKey = serviceInstancesSchemaKey;
-  options: RequestOptions;
-  initialParams = {
-    page: 1,
-    'results-per-page': 100,
-    'order-direction': 'desc',
-    'order-direction-field': 'creation',
-  };
-  parentGuid: string;
-  parentEntitySchema = entityFactory(spaceSchemaKey);
-}
-
 export class GetServiceInstances
   extends CFStartAction implements PaginationAction, EntityInlineParentAction {
   constructor(

--- a/src/frontend/app/store/actions/space.actions.ts
+++ b/src/frontend/app/store/actions/space.actions.ts
@@ -260,7 +260,7 @@ export class GetAllServicesForSpace extends CFStartAction implements PaginationA
 
 
 export class GetServiceInstancesForSpace
-  extends CFStartAction implements PaginationAction, EntityInlineParentAction {
+  extends CFStartAction implements PaginationAction, EntityInlineParentAction, EntityInlineChildAction {
   constructor(
     public spaceGuid: string,
     public endpointGuid: string,
@@ -285,6 +285,7 @@ export class GetServiceInstancesForSpace
     if (q) {
       this.initialParams['q'] = q;
     }
+    this.parentGuid = spaceGuid;
   }
   actions = getActions('Space', 'Get all service instances');
   entity = [entityFactory(serviceInstancesSchemaKey)];
@@ -296,7 +297,8 @@ export class GetServiceInstancesForSpace
     'order-direction': 'desc',
     'order-direction-field': 'creation',
   };
-
+  parentGuid: string;
+  parentEntitySchema = entityFactory(spaceSchemaKey);
 }
 
 export class GetServicesForSpace

--- a/src/frontend/app/store/actions/space.actions.ts
+++ b/src/frontend/app/store/actions/space.actions.ts
@@ -274,7 +274,8 @@ export class GetServiceInstancesForSpace
       createEntityRelationKey(servicePlanSchemaKey, serviceSchemaKey),
       createEntityRelationKey(serviceBindingSchemaKey, applicationSchemaKey)
     ],
-    public populateMissing = true
+    public populateMissing = true,
+    public flattenPagination = true
   ) {
     super();
     this.options = new RequestOptions();
@@ -295,7 +296,7 @@ export class GetServiceInstancesForSpace
     'order-direction': 'desc',
     'order-direction-field': 'creation',
   };
-  flattenPagination = true;
+
 }
 
 export class GetServicesForSpace


### PR DESCRIPTION
Fixes #2468.

Was able to reproduce this issue, and it appeared to be a timing issue.

When creating a service instance: once a CF/Org/Space are selected the user proceeds to the next page. In the next page services available in the space are fetched. If one value (i.e CF) has been updated in the store, but Space hasn't, invalid values propagate in the observable chain.

+ Removed a duplicate action.
