### PR TITLE
Update to newer UAA version for test/dev

### DIFF
--- a/deploy/uaa/Dockerfile.dev
+++ b/deploy/uaa/Dockerfile.dev
@@ -25,10 +25,10 @@ RUN rm -rf /tomcat/webapps/*
 
 #ADD https://github.com/sequenceiq/uaa/releases/download/3.9.3/cloudfoundry-identity-uaa-3.9.3.war /tomcat/webapps/
 
-COPY ./tmp/cloudfoundry-identity-uaa-3.9.3.war /tomcat/webapps/cloudfoundry-identity-uaa-3.9.3.war
+COPY ./tmp/cloudfoundry-identity-uaa-4.19.0.war /tomcat/webapps/cloudfoundry-identity-uaa-4.19.0.war
 
 
-RUN mv /tomcat/webapps/cloudfoundry-identity-uaa-3.9.3.war /tomcat/webapps/ROOT.war
+RUN mv /tomcat/webapps/cloudfoundry-identity-uaa-4.19.0.war /tomcat/webapps/ROOT.war
 
 EXPOSE 8080
 

--- a/deploy/uaa/prepare.sh
+++ b/deploy/uaa/prepare.sh
@@ -11,7 +11,11 @@ echo "Cacheing UAA resources to: ${DOWNLOAD_FOLDER}"
 mkdir -p ${DOWNLOAD_FOLDER}
 
 TOMCAT_FILE=${DOWNLOAD_FOLDER}/apache-tomcat-8.0.28.tar.gz
-UAA_FILE=${DOWNLOAD_FOLDER}/cloudfoundry-identity-uaa-3.9.3.war
+
+# Get war directly from Maven repository
+UAA_VERSION=4.19.0
+UAA_FILE=${DOWNLOAD_FOLDER}/cloudfoundry-identity-uaa-${UAA_VERSION}.war
+URL_URL=http://central.maven.org/maven2/org/cloudfoundry/identity/cloudfoundry-identity-uaa/${UAA_VERSION}/cloudfoundry-identity-uaa-${UAA_VERSION}.war
 
 if [ ! -f ${TOMCAT_FILE} ]; then
   echo "Dowloading Apache Tomcat package"
@@ -20,5 +24,5 @@ fi
 
 if [ ! -f ${UAA_FILE} ]; then
   echo "Dowloading Cloud Foundry UAA package"
-  curl -L -o ${UAA_FILE} https://github.com/sequenceiq/uaa/releases/download/3.9.3/cloudfoundry-identity-uaa-3.9.3.war
+  curl -L -o ${UAA_FILE} ${URL_URL}
 fi

--- a/deploy/uaa/uaa.yml
+++ b/deploy/uaa/uaa.yml
@@ -49,14 +49,16 @@ oauth:
       authorities: clients.read,clients.write,clients.secret,uaa.admin,scim.read,scim.write,password.write,zone.admin,stratos.admin,stratos.user,stratos.publisher
       access-token-validity: 3600
       refresh-token-validity: 2592000
+      redirect-uri: https://127.0.0.1:4200/pp/v1/auth/**
     console:
       id: console
       override: true
-      authorized-grant-types: client_credentials,implicit,password,refresh_token
+      authorized-grant-types: client_credentials,implicit,password,refresh_token,authorization_code
       scope: scim.me,stratos.user,openid,profile,roles,notification_preferences.read user_attributes,uaa.user,notification_preferences.write,stratos.publisher,cloud_controller.read,password.write,approvals.me,cloud_controller.write,cloud_controller_service_permissions.read,stratos.admin,oauth.approvals
       authorities: clients.read,clients.write,clients.secret,uaa.admin,scim.read,scim.write,password.write,zone.admin,stratos.admin,stratos.user,stratos.publisher
       access-token-validity: 3600
       refresh-token-validity: 2592000
+      redirect-uri: https://127.0.0.1:4200/pp/v1/auth/**
 login:
   serviceProviderKey: |
     -----BEGIN RSA PRIVATE KEY-----
@@ -110,6 +112,12 @@ zones:
     hostnames:
       - localhost
 #      - 10.4.21.242
+
+encryption:
+  active_key_label: stratos-uaa-key
+  encryption_keys:
+  - label: stratos-uaa-key
+    passphrase: changeme
 
 #The secret that an external login server will use to authenticate to the uaa using the id `login`
 LOGIN_SECRET: secret


### PR DESCRIPTION
This PR:

- Updates the UAA to a newer 4.19.0 version
- Adds in the necessary extra config that this version requires
- Adds in authorization grant type for console client

This is needed to test SSO against the test UAA Stratos uses for test/dev.