### PR TITLE
Update release pipeline

### DIFF
--- a/deploy/ci/console-dev-releases.yml
+++ b/deploy/ci/console-dev-releases.yml
@@ -15,11 +15,11 @@ resources:
     branch: ((stratos-branch))
     private_key: ((github-private-key))
     tag_filter: "2*"
-- name: stratos-master
+- name: helm-repo
   type: git
   source:
-    uri: git@github.com:((github-organization))/((github-repository))
-    branch: master
+    uri: git@github.com:((helm-repo.github-organization))/((helm-repo.github-repository))
+    branch: ((helm-repo.branch))
     private_key: ((github-private-key))
 # Docker Images
 - name: jetstream-image
@@ -126,7 +126,7 @@ jobs:
   - get: stratos
     passed: [build-images]
     trigger: true
-  - get: stratos-master
+  - get: helm-repo
   - get: image-tag
     passed: [build-images]
     params:
@@ -144,6 +144,7 @@ jobs:
         GIT_PRIVATE_KEY: ((github-private-key))
         DOCKER_ORG: ((artifact-docker-organization))
         DOCKER_REGISTRY: ((artifact-docker-registry))
+        HELM_REPO_PATH: ((helm-repo.path))
     - put: helm-chart-tarball
       params:
        file: helm-chart/*.tgz
@@ -166,8 +167,8 @@ jobs:
       file: stratos/deploy/ci/tasks/dev-releases/update-gh-release.yml
       params:
         GITHUB_TOKEN: ((github-access-token))
-        GITHUB_USER: ((github-organization))
-        GITHUB_REPO: ((github-repository))
+        GITHUB_USER: ((github-artifact.organization))
+        GITHUB_REPO: ((github-artifact.repository))
         GIT_USER: ((concourse-user))
         GIT_EMAIL: ((concourse-email))
         GIT_PRIVATE_KEY: ((github-private-key))

--- a/deploy/ci/console-dev-releases.yml
+++ b/deploy/ci/console-dev-releases.yml
@@ -18,8 +18,8 @@ resources:
 - name: helm-repo
   type: git
   source:
-    uri: git@github.com:((helm-repo.github-organization))/((helm-repo.github-repository))
-    branch: ((helm-repo.branch))
+    uri: git@github.com:((helm-repo-github-organization))/((helm-repo-github-repository))
+    branch: ((helm-repo-branch))
     private_key: ((github-private-key))
 # Docker Images
 - name: jetstream-image
@@ -144,7 +144,7 @@ jobs:
         GIT_PRIVATE_KEY: ((github-private-key))
         DOCKER_ORG: ((artifact-docker-organization))
         DOCKER_REGISTRY: ((artifact-docker-registry))
-        HELM_REPO_PATH: ((helm-repo.path))
+        HELM_REPO_PATH: ((helm-repo-path))
     - put: helm-chart-tarball
       params:
        file: helm-chart/*.tgz
@@ -167,8 +167,8 @@ jobs:
       file: stratos/deploy/ci/tasks/dev-releases/update-gh-release.yml
       params:
         GITHUB_TOKEN: ((github-access-token))
-        GITHUB_USER: ((github-artifact.organization))
-        GITHUB_REPO: ((github-artifact.repository))
+        GITHUB_USER: ((helm-repo-github-organization))
+        GITHUB_REPO: ((helm-repo-github-repository))
         GIT_USER: ((concourse-user))
         GIT_EMAIL: ((concourse-email))
         GIT_PRIVATE_KEY: ((github-private-key))

--- a/deploy/ci/tasks/dev-releases/create-chart.yml
+++ b/deploy/ci/tasks/dev-releases/create-chart.yml
@@ -3,7 +3,7 @@ platform: linux
 inputs:
 - name: stratos
 - name: image-tag
-- name: stratos-master
+- name: helm-repo
 outputs:
 - name: helm-chart
 image_resource:
@@ -23,7 +23,7 @@ run:
       ROOT_DIR=$PWD
       STRATOS=${ROOT_DIR}/stratos
       source ${STRATOS}/deploy/ci/tasks/dev-releases/create-chart-helper.sh
-      STRATOS_MASTER=${ROOT_DIR}/stratos-master
+      HELM_REPO=${ROOT_DIR}/helm-repo/${HELM_REPO_PATH}
       GIT_TAG=$(cat image-tag/v2-alpha-tag)
       cd ${STRATOS}/deploy/kubernetes/
       patchHelmChart ${GIT_TAG} ${DOCKER_ORG} ${DOCKER_REGISTRY} ./console
@@ -32,13 +32,13 @@ run:
       helm package console
       cp console*.tgz ${ROOT_DIR}/helm-chart/console-helm-chart-${GIT_TAG}.tgz
       cd ${ROOT_DIR}/helm-chart/
-      if [ -f ${STRATOS_MASTER}/index.yaml ]; then
-        cp ${STRATOS_MASTER}/index.yaml ${ROOT_DIR}/helm-chart/
+      if [ -f ${HELM_REPO}/index.yaml ]; then
+        cp ${HELM_REPO}/index.yaml ${ROOT_DIR}/helm-chart/
         MERGE_INDEX="--merge index.yaml"
       fi
 
       # Update Helm Repository
       helm repo index ./ ${MERGE_INDEX} --url https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download/${GIT_TAG}/
-      cp index.yaml ${STRATOS_MASTER}
-      cd ${STRATOS_MASTER}
+      cp index.yaml ${HELM_REPO}
+      cd ${HELM_REPO}
       setupAndPushChange


### PR DESCRIPTION
1. Allows helm chart repo to be different than Stratos/master
2. Helm repository index.yaml can live outside root of repo