### PR TITLE
Fixed application service instance creation

### DIFF
--- a/src/frontend/app/shared/components/add-service-instance/create-service-instance-helper.service.ts
+++ b/src/frontend/app/shared/components/add-service-instance/create-service-instance-helper.service.ts
@@ -213,7 +213,7 @@ export class CreateServiceInstanceHelperService {
     }
     return getPaginationObservables<APIResource<IServiceInstance>>({
       store: this.store,
-      action: action,
+      action,
       paginationMonitor: this.paginationMonitorFactory.create(
         paginationKey,
         entityFactory(serviceInstancesSchemaKey)

--- a/src/frontend/app/shared/components/list/list-types/services-wall/service-instance-card/service-instance-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/services-wall/service-instance-card/service-instance-card.component.ts
@@ -111,7 +111,7 @@ export class ServiceInstanceCardComponent extends CardCell<APIResource<IServiceI
     try {
       extraInfo = serviceEntity.entity.extra ? JSON.parse(serviceEntity.entity.extra) : null;
     } catch (e) { }
-    let displayName = serviceEntity.entity.label;
+    let displayName = serviceEntity.entity ? serviceEntity.entity.label : '';
     if (extraInfo && extraInfo.displayName) {
       displayName = extraInfo.displayName;
     }
@@ -121,13 +121,13 @@ export class ServiceInstanceCardComponent extends CardCell<APIResource<IServiceI
   getSpaceName = () => this.serviceInstanceEntity.entity.space.entity.name;
   getSpaceURL = () => [
     '/cloud-foundry',
-     this.serviceInstanceEntity.entity.cfGuid,
-     'organizations',
-     this.serviceInstanceEntity.entity.space.entity.organization_guid,
-     'spaces',
-     this.serviceInstanceEntity.entity.space_guid,
-     'summary'
-    ]
-    getSpaceBreadcrumbs = () => ({ 'breadcrumbs': 'services-wall'});
+    this.serviceInstanceEntity.entity.cfGuid,
+    'organizations',
+    this.serviceInstanceEntity.entity.space.entity.organization_guid,
+    'spaces',
+    this.serviceInstanceEntity.entity.space_guid,
+    'summary'
+  ]
+  getSpaceBreadcrumbs = () => ({ 'breadcrumbs': 'services-wall' });
 
 }

--- a/src/frontend/app/shared/monitors/pagination-monitor.ts
+++ b/src/frontend/app/shared/monitors/pagination-monitor.ts
@@ -1,7 +1,7 @@
 import { Store } from '@ngrx/store';
 import { denormalize, schema } from 'normalizr';
-import { Observable ,  combineLatest } from 'rxjs';
-import { filter, map, publishReplay, refCount, pairwise, tap, distinctUntilChanged, publish ,  withLatestFrom } from 'rxjs/operators';
+import { Observable, combineLatest } from 'rxjs';
+import { filter, map, publishReplay, refCount, pairwise, tap, distinctUntilChanged, publish, withLatestFrom } from 'rxjs/operators';
 
 import { getAPIRequestDataState, selectEntities } from '../../store/selectors/api.selectors';
 import { selectPaginationState } from '../../store/selectors/pagination.selectors';
@@ -108,7 +108,7 @@ export class PaginationMonitor<T = any> {
   ) {
     return combineLatest(
       pagination$,
-      this.store.select(selectEntities<T>(this.schema.key)),
+      this.store.select(selectEntities<T>(this.schema.key)).pipe(distinctUntilChanged()),
     ).pipe(
       filter(([pagination, entities]) => this.hasPage(pagination)),
       withLatestFrom(this.store.select(getAPIRequestDataState)),

--- a/src/frontend/app/store/actions/space.actions.ts
+++ b/src/frontend/app/store/actions/space.actions.ts
@@ -288,7 +288,7 @@ export class GetServiceInstancesForSpace
     this.parentGuid = spaceGuid;
   }
   actions = getActions('Space', 'Get all service instances');
-  entity = [entityFactory(serviceInstancesSchemaKey)];
+  entity = [entityFactory(serviceInstancesWithSpaceSchemaKey)];
   entityKey = serviceInstancesSchemaKey;
   options: RequestOptions;
   initialParams = {

--- a/src/frontend/app/store/effects/api.effects.ts
+++ b/src/frontend/app/store/effects/api.effects.ts
@@ -444,7 +444,9 @@ export class APIEffect {
 
   private addRelationParams(options, action: any) {
     if (isEntityInlineParentAction(action)) {
+      console.log(action);
       const relationInfo = listEntityRelations(action as EntityInlineParentAction);
+      console.log(relationInfo);
       options.params = options.params || new URLSearchParams();
       if (relationInfo.maxDepth > 0) {
         options.params.set('inline-relations-depth', relationInfo.maxDepth > 2 ? 2 : relationInfo.maxDepth);

--- a/src/frontend/app/store/effects/api.effects.ts
+++ b/src/frontend/app/store/effects/api.effects.ts
@@ -444,9 +444,7 @@ export class APIEffect {
 
   private addRelationParams(options, action: any) {
     if (isEntityInlineParentAction(action)) {
-      console.log(action);
       const relationInfo = listEntityRelations(action as EntityInlineParentAction);
-      console.log(relationInfo);
       options.params = options.params || new URLSearchParams();
       if (relationInfo.maxDepth > 0) {
         options.params.set('inline-relations-depth', relationInfo.maxDepth > 2 ? 2 : relationInfo.maxDepth);

--- a/src/frontend/app/store/helpers/entity-factory.ts
+++ b/src/frontend/app/store/helpers/entity-factory.ts
@@ -271,7 +271,8 @@ const ServiceInstancesWithSpaceSchema = new EntitySchema(serviceInstancesSchemaK
   entity: {
     service_plan: ServicePlanSchema,
     service_bindings: [ServiceBindingsSchema],
-    space: SpaceSchema.withEmptyDefinition()
+    space: SpaceSchema.withEmptyDefinition(),
+    service: ServiceSchema
   }
 }, { idAttribute: getAPIResourceGuid });
 entityCache[serviceInstancesWithSpaceSchemaKey] = ServiceInstancesWithSpaceSchema;


### PR DESCRIPTION
Fixes #2473 

The issue was twofold:

1) We were using the wrong schema when fetching service instances
2) The service instance entity we get from the create api is incomplete so we need to re-fetch the complete service instance (like we do when creating an app)