### PR TITLE
Postflight script times out if it can not connect

### DIFF
--- a/deploy/db/scripts/run-postflight-job.k8s.sh
+++ b/deploy/db/scripts/run-postflight-job.k8s.sh
@@ -1,7 +1,22 @@
 #!/bin/bash
-set -e
+echo "=== Stratos Postlight Job ==="
 echo "Running postflight job"
-MYSQL_CMD="mysql -u $DB_ADMIN_USER -h $DB_HOST -P $DB_PORT -p$DB_ADMIN_PASSWORD -e"
+
+# mysql commands will timeout after 5 seconds
+MYSQL_CMD="mysql -u $DB_ADMIN_USER -h $DB_HOST -P $DB_PORT -p$DB_ADMIN_PASSWORD --connect_timeout 5 -e"
+
+echo "Checking if DB Server is ready"
+dbServerVersion=$(${MYSQL_CMD} "SELECT VERSION();" --skip-column-names)
+if [ $? -eq 1 ]; then
+  echo "Failed to connect to database server - it is not ready yet .. bailing for now..."
+  exit 1
+fi
+
+echo "Database Server is ready"
+echo $dbServerVersion
+
+set -e
+
 echo "Checking if DB exists..."
 stratosDbExists=$(${MYSQL_CMD}  "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '$DB_DATABASE_NAME';")
 DBCONF_KEY=mariadb-k8s


### PR DESCRIPTION
Fixes #2546.

There is a race-condition with the Helm deployment - if the postflight job runs just before the DB Server is ready, it will sit for a long time trying to connect to it to determine if the db schema exists. You'll get the upgrade notice in the UI and it will take longer for Stratos to be available.

This PR fixes this and does a check with a lower timeout (5 seconds). If it can not connect in that time, it bails. Kubernetes will reschedule the post-flight job.. and it will then succeed (maybe after more retries).. but it will do so quickly.