### PR TITLE
Fix assign role for non-admin connected user

### DIFF
--- a/src/frontend/app/shared/components/list/list-types/cf-users/cf-space-permission-cell/cf-space-permission-cell.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-users/cf-space-permission-cell/cf-space-permission-cell.component.ts
@@ -118,7 +118,8 @@ export class CfSpacePermissionCellComponent extends CfPermissionCell<SpaceUserRo
       cellPermission.guid,
       cellPermission.key,
       true,
-      updateConnectedUser
+      updateConnectedUser,
+      cellPermission.orgGuid
     ));
   }
 

--- a/src/frontend/app/store/actions/users.actions.ts
+++ b/src/frontend/app/store/actions/users.actions.ts
@@ -1,19 +1,22 @@
-import { RequestOptions, RequestMethod } from '@angular/http';
+import { RequestOptions } from '@angular/http';
 
 import {
   cfUserSchemaKey,
+  endpointSchemaKey,
   entityFactory,
   EntitySchema,
   organizationSchemaKey,
   spaceSchemaKey,
-  endpointSchemaKey,
 } from '../helpers/entity-factory';
-import { createEntityRelationKey, EntityInlineParentAction, createEntityRelationPaginationKey } from '../helpers/entity-relations.types';
-import { PaginatedAction, PaginationParam } from '../types/pagination.types';
-import { CFStartAction, IRequestAction, RequestEntityLocation } from '../types/request.types';
-import { getActions } from './action.helper';
+import {
+  createEntityRelationKey,
+  createEntityRelationPaginationKey,
+  EntityInlineParentAction,
+} from '../helpers/entity-relations.types';
+import { PaginatedAction } from '../types/pagination.types';
+import { CFStartAction, IRequestAction } from '../types/request.types';
 import { OrgUserRoleNames, SpaceUserRoleNames } from '../types/user.types';
-import { Action } from '@ngrx/store';
+import { getActions } from './action.helper';
 
 export const GET_ALL = '[Users] Get all';
 export const GET_ALL_SUCCESS = '[Users] Get all success';
@@ -110,7 +113,8 @@ export class ChangeUserRole extends CFStartAction implements IRequestAction {
     public permissionTypeKey: OrgUserRoleNames | SpaceUserRoleNames,
     public entityGuid: string,
     public isSpace = false,
-    public updateConnectedUser = false
+    public updateConnectedUser = false,
+    public orgGuid?: string
   ) {
     super();
     this.guid = entityGuid;
@@ -140,7 +144,8 @@ export class AddUserRole extends ChangeUserRole {
     entityGuid: string,
     permissionTypeKey: OrgUserRoleNames | SpaceUserRoleNames,
     isSpace = false,
-    updateConnectedUser = false
+    updateConnectedUser = false,
+    orgGuid?: string
   ) {
     super(
       endpointGuid,
@@ -151,6 +156,7 @@ export class AddUserRole extends ChangeUserRole {
       entityGuid,
       isSpace,
       updateConnectedUser,
+      orgGuid
     );
   }
 }
@@ -162,7 +168,8 @@ export class RemoveUserRole extends ChangeUserRole {
     entityGuid: string,
     permissionTypeKey: OrgUserRoleNames | SpaceUserRoleNames,
     isSpace = false,
-    updateConnectedUser = false
+    updateConnectedUser = false,
+    orgGuid?: string
   ) {
     super(
       endpointGuid,
@@ -172,7 +179,8 @@ export class RemoveUserRole extends ChangeUserRole {
       permissionTypeKey,
       entityGuid,
       isSpace,
-      updateConnectedUser
+      updateConnectedUser,
+      orgGuid
     );
   }
 }

--- a/src/frontend/app/store/effects/users-roles.effects.ts
+++ b/src/frontend/app/store/effects/users-roles.effects.ts
@@ -114,8 +114,8 @@ export class UsersRolesEffects {
     const isSpace = !!change.spaceGuid;
     const entityGuid = isSpace ? change.spaceGuid : change.orgGuid;
     return change.add ?
-      new AddUserRole(cfGuid, change.userGuid, entityGuid, change.role, isSpace, updateConnectedUser) :
-      new RemoveUserRole(cfGuid, change.userGuid, entityGuid, change.role, isSpace, updateConnectedUser);
+      new AddUserRole(cfGuid, change.userGuid, entityGuid, change.role, isSpace, updateConnectedUser, change.orgGuid) :
+      new RemoveUserRole(cfGuid, change.userGuid, entityGuid, change.role, isSpace, updateConnectedUser, change.orgGuid);
   }
 
   private createActionObs(action: ChangeUserRole): Observable<boolean> {

--- a/src/frontend/app/store/reducers/current-user-roles-reducer/current-user-roles-changed.reducers.ts
+++ b/src/frontend/app/store/reducers/current-user-roles-reducer/current-user-roles-changed.reducers.ts
@@ -1,8 +1,10 @@
 import { PermissionStrings } from '../../../core/current-user-permissions.config';
 import { ChangeUserRole } from '../../actions/users.actions';
-import { ICfRolesState, ICurrentUserRolesState } from '../../types/current-user-roles.types';
+import { ICfRolesState, ICurrentUserRolesState, ISpaceRoleState } from '../../types/current-user-roles.types';
 import { APISuccessOrFailedAction } from '../../types/request.types';
 import { OrgUserRoleNames, SpaceUserRoleNames } from '../../types/user.types';
+import { defaultUserOrgRoleState } from './current-user-roles-org.reducer';
+import { defaultUserSpaceRoleState } from './current-user-roles-space.reducer';
 
 export function updateAfterRoleChange(
   state: ICurrentUserRolesState,
@@ -17,12 +19,18 @@ export function updateAfterRoleChange(
   const entityType = changePerm.isSpace ? 'spaces' : 'organizations';
 
   const cf = state.cf[changePerm.endpointGuid];
-  const entity = cf[entityType][changePerm.entityGuid];
-
+  let entity = cf[entityType][changePerm.entityGuid];
   const permissionType = userRoleNameToPermissionName(changePerm.permissionTypeKey);
-  const currentValue = entity[permissionType];
 
-  if (currentValue === isAdd) {
+  if (!entity) {
+    // New org/space or one that does not yet contain any roles
+    entity = changePerm.isSpace ? {
+      ...defaultUserSpaceRoleState,
+      orgId: changePerm.orgGuid
+    } : {
+        ...defaultUserOrgRoleState,
+      };
+  } else if (entity[permissionType] === isAdd) {
     // No change, just return the state. Unlikely to happen
     return state;
   }

--- a/src/frontend/app/store/reducers/current-user-roles-reducer/current-user-roles-org.reducer.ts
+++ b/src/frontend/app/store/reducers/current-user-roles-reducer/current-user-roles-org.reducer.ts
@@ -1,7 +1,7 @@
 import { UserRelationTypes } from '../../actions/permissions.actions';
 import { IOrgRoleState } from '../../types/current-user-roles.types';
 
-const defaultOrgRoleStateState = {
+export const defaultUserOrgRoleState = {
   isManager: false,
   isAuditor: false,
   isBillingManager: false,
@@ -10,9 +10,9 @@ const defaultOrgRoleStateState = {
 };
 
 export const createOrgRoleStateState = () => ({
-  ...defaultOrgRoleStateState,
+  ...defaultUserOrgRoleState,
   spaceGuids: [
-    ...defaultOrgRoleStateState.spaceGuids
+    ...defaultUserOrgRoleState.spaceGuids
   ]
 });
 

--- a/src/frontend/app/store/reducers/current-user-roles-reducer/current-user-roles-space.reducer.ts
+++ b/src/frontend/app/store/reducers/current-user-roles-reducer/current-user-roles-space.reducer.ts
@@ -1,9 +1,9 @@
-import { GetCurrentUserRelationsComplete, UserRelationTypes } from '../../actions/permissions.actions';
-import { ISpaceRoleState } from '../../types/current-user-roles.types';
-import { APIResource } from '../../types/api.types';
 import { ISpace } from '../../../core/cf-api.types';
+import { UserRelationTypes } from '../../actions/permissions.actions';
+import { APIResource } from '../../types/api.types';
+import { ISpaceRoleState } from '../../types/current-user-roles.types';
 
-const defaultState = {
+export const defaultUserSpaceRoleState = {
   orgId: null,
   isManager: false,
   isAuditor: false,
@@ -11,7 +11,7 @@ const defaultState = {
 };
 
 export function currentUserSpaceRoleReducer(
-  state: ISpaceRoleState = defaultState,
+  state: ISpaceRoleState = defaultUserSpaceRoleState,
   relationType: UserRelationTypes,
   userHasRelation: boolean,
   space: APIResource<ISpace>
@@ -28,7 +28,7 @@ export function currentUserSpaceRoleReducer(
 }
 
 function addId(
-  state: ISpaceRoleState = defaultState,
+  state: ISpaceRoleState = defaultUserSpaceRoleState,
   space: APIResource<ISpace>
 ) {
   if (!state.orgId) {


### PR DESCRIPTION
Bug
- CF non-admin
- Assign a role to the connected user to a space without any existing roles
- CF permissions section in store did not have this section so exception was thrown when accessing it
- This would affect users who create a space and then try to assign themselves the dev role to create an app.

Fix
- Ensure we fall back to an empty space or org when we attempt to change the store permissions on user role change.
- In theory there should always be an org entity for non admins, as they will have to be the 'org user' to see it, but covered case.
- Code also covers path when a user removes a role, however code should never be hit (permissions exist to remove).
