### PR TITLE
Clear service instances pagination after disconnecting an endpoint

### DIFF
--- a/src/frontend/app/features/service-catalog/service-catalog-page/service-catalog-page.component.ts
+++ b/src/frontend/app/features/service-catalog/service-catalog-page/service-catalog-page.component.ts
@@ -2,13 +2,11 @@ import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { ListDataSource } from '../../../shared/components/list/data-sources-controllers/list-data-source';
 import {
   CfServicesListConfigService,
 } from '../../../shared/components/list/list-types/cf-services/cf-services-list-config.service';
 import { ListConfig } from '../../../shared/components/list/list.component.types';
 import { CloudFoundryService } from '../../../shared/data-services/cloud-foundry.service';
-import { APIResource } from '../../../store/types/api.types';
 import { getActiveRouteCfOrgSpaceProvider } from '../../cloud-foundry/cf.helpers';
 
 @Component({
@@ -29,7 +27,10 @@ export class ServiceCatalogPageComponent {
 
   constructor(public cloudFoundryService: CloudFoundryService) {
     this.cfIds$ = cloudFoundryService.cFEndpoints$.pipe(
-      map(endpoints => endpoints.map(endpoint => endpoint.guid))
+      map(endpoints => endpoints
+        .filter(endpoint => endpoint.connectionStatus === 'connected')
+        .map(endpoint => endpoint.guid)
+      )
     );
   }
 }

--- a/src/frontend/app/features/services/services-wall/services-wall.component.ts
+++ b/src/frontend/app/features/services/services-wall/services-wall.component.ts
@@ -12,7 +12,6 @@ import { CfOrgSpaceDataService, initCfOrgSpaceService } from '../../../shared/da
 import { CloudFoundryService } from '../../../shared/data-services/cloud-foundry.service';
 import { AppState } from '../../../store/app-state';
 import { serviceInstancesSchemaKey } from '../../../store/helpers/entity-factory';
-import { endpointsRegisteredCFEntitiesSelector } from '../../../store/selectors/endpoint.selectors';
 
 @Component({
   selector: 'app-services-wall',

--- a/src/frontend/app/features/services/services-wall/services-wall.component.ts
+++ b/src/frontend/app/features/services/services-wall/services-wall.component.ts
@@ -12,6 +12,7 @@ import { CfOrgSpaceDataService, initCfOrgSpaceService } from '../../../shared/da
 import { CloudFoundryService } from '../../../shared/data-services/cloud-foundry.service';
 import { AppState } from '../../../store/app-state';
 import { serviceInstancesSchemaKey } from '../../../store/helpers/entity-factory';
+import { endpointsRegisteredCFEntitiesSelector } from '../../../store/selectors/endpoint.selectors';
 
 @Component({
   selector: 'app-services-wall',
@@ -36,7 +37,10 @@ export class ServicesWallComponent implements OnDestroy {
 
     this.canCreateServiceInstance = CurrentUserPermissions.SERVICE_INSTANCE_CREATE;
     this.cfIds$ = cloudFoundryService.cFEndpoints$.pipe(
-      map(endpoints => endpoints.map(endpoint => endpoint.guid))
+      map(endpoints => endpoints
+        .filter(endpoint => endpoint.connectionStatus === 'connected')
+        .map(endpoint => endpoint.guid)
+      )
     );
 
     this.initCfOrgSpaceService = initCfOrgSpaceService(this.store,

--- a/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-clear-pagination-type.ts
+++ b/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-clear-pagination-type.ts
@@ -5,6 +5,7 @@ import {
   organizationSchemaKey,
   serviceSchemaKey,
   spaceSchemaKey,
+  serviceInstancesSchemaKey,
 } from '../../helpers/entity-factory';
 import { PaginationState } from '../../types/pagination.types';
 
@@ -29,6 +30,7 @@ export function clearEndpointEntities(state: PaginationState, action: EndpointAc
     newState = paginationClearType(newState, organizationSchemaKey, defaultPaginationEntityState);
     newState = paginationClearType(newState, serviceSchemaKey, defaultPaginationEntityState);
     newState = paginationClearType(newState, cfUserSchemaKey, defaultPaginationEntityState);
+    newState = paginationClearType(newState, serviceInstancesSchemaKey, defaultPaginationEntityState);
     return newState;
   }
   return state;


### PR DESCRIPTION
Fixes https://github.com/cloudfoundry-incubator/stratos/issues/2582

Fixes two issues:
1. Follow the steps outlines in https://github.com/cloudfoundry-incubator/stratos/issues/2582, two exception occur in the services-wall
1.1 Because service instance pagination hasn't been cleared we attempt to fetch entities from the disconnected endpoint.
1.2 Services wall passes  all endpoints (rather than connected endpoints) to the app page header, leading to a red-bar.