### PR TITLE
Fix Postgres to use same value as detected by VCAP_SERVICES

### DIFF
--- a/src/backend/app-core/migrator.go
+++ b/src/backend/app-core/migrator.go
@@ -229,7 +229,7 @@ func exportDatabaseConfig(dbConfig datastore.DatabaseConfig) {
 	exportString(DB_PASSWORD, dbConfig.Password)
 	exportString(DB_DATABASE_NAME, dbConfig.Database)
 
-	if dbConfig.DatabaseProvider == "psql" {
+	if dbConfig.DatabaseProvider == "pgsql" {
 		exportString(DB_TYPE, TYPE_POSTGRES)
 	} else if dbConfig.DatabaseProvider == "mysql" {
 		exportString(DB_TYPE, TYPE_MYSQL)


### PR DESCRIPTION
## Description

Fix migration to actually run when Postgres is detected.

ie compare against the value that is set in `src/backend/app-core/datastore/datastore.go`

## Motivation and Context

Prior to this change, we'd see this in the logs:

```
Discovered Cloud Foundry postgres service and applied config 
No DB Environment detected - skipping migrations 
```

## How Has This Been Tested?

Applied change, app now attempts migration (and fails for other reasons, that I'll look into next).

## Types of changes

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ? ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

It's unclear if this is breaking or not. For CF users, it isn't - I'm not sure if the env variable is specifically set by others or not, as I can find no reference to it any any documentation.

## Checklist:

- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message