### PR TITLE
Fix migrate script to work in Postgresql

### DIFF
--- a/src/backend/app-core/datastore/20170818120003_InitialSchema.go
+++ b/src/backend/app-core/datastore/20170818120003_InitialSchema.go
@@ -2,122 +2,81 @@ package datastore
 
 import (
 	"database/sql"
-	"fmt"
 	"strings"
 
 	"bitbucket.org/liamstask/goose/lib/goose"
 )
 
-// Up is executed when this migration is applied
-func (s *StratosMigrations) Up_20170818120003(txn *sql.Tx, conf *goose.DBConf) {
+func init() {
+	RegisterMigration(20170818120003, "InitialSchema", func(txn *sql.Tx, conf *goose.DBConf) error {
+		binaryDataType := "BYTEA"
+		if strings.Contains(conf.Driver.Name, "mysql") {
+			binaryDataType = "BLOB"
+		}
 
-	binaryDataType := "BYTEA"
-	if strings.Contains(conf.Driver.Name, "mysql") {
-		binaryDataType = "BLOB"
-	}
+		createTokens := "CREATE TABLE IF NOT EXISTS tokens ("
+		createTokens += "user_guid     VARCHAR(36) NOT NULL, "
+		createTokens += "cnsi_guid     VARCHAR(36), "
+		createTokens += "token_type    VARCHAR(4)  NOT NULL, "
+		createTokens += "auth_token    " + binaryDataType + "       NOT NULL, "
+		createTokens += "refresh_token " + binaryDataType + "       NOT NULL, "
+		createTokens += "token_expiry  BIGINT      NOT NULL, "
+		createTokens += "last_updated  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)"
 
-	createTokens := "CREATE TABLE IF NOT EXISTS tokens ("
-	createTokens += "user_guid     VARCHAR(36) NOT NULL, "
-	createTokens += "cnsi_guid     VARCHAR(36), "
-	createTokens += "token_type    VARCHAR(4)  NOT NULL, "
-	createTokens += "auth_token    " + binaryDataType + "       NOT NULL, "
-	createTokens += "refresh_token " + binaryDataType + "       NOT NULL, "
-	createTokens += "token_expiry  BIGINT      NOT NULL, "
-	createTokens += "last_updated  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)"
+		if strings.Contains(conf.Driver.Name, "postgres") {
+			createTokens += " WITH (OIDS=FALSE);"
+		} else {
+			createTokens += ";"
+		}
 
-	if strings.Contains(conf.Driver.Name, "postgres") {
-		createTokens += " WITH (OIDS=FALSE);"
-	} else {
-		createTokens += ";"
-	}
+		_, err := txn.Exec(createTokens)
+		if err != nil {
+			return err
+		}
 
-	_, err := txn.Exec(createTokens)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
+		createCnsisTable := "CREATE TABLE IF NOT EXISTS cnsis ("
+		createCnsisTable += "guid    VARCHAR(36)   NOT NULL UNIQUE,"
+		createCnsisTable += "name                      VARCHAR(255)  NOT NULL,"
+		createCnsisTable += "cnsi_type                 VARCHAR(3)    NOT NULL,"
+		createCnsisTable += "api_endpoint              VARCHAR(255)  NOT NULL,"
+		createCnsisTable += "auth_endpoint             VARCHAR(255)  NOT NULL,"
+		createCnsisTable += "token_endpoint            VARCHAR(255)  NOT NULL,"
+		createCnsisTable += "doppler_logging_endpoint  VARCHAR(255)  NOT NULL,"
+		createCnsisTable += "skip_ssl_validation       BOOLEAN       NOT NULL DEFAULT FALSE,"
+		createCnsisTable += "last_updated              TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+		createCnsisTable += "PRIMARY KEY (guid) );"
 
-	createCnsisTable := "CREATE TABLE IF NOT EXISTS cnsis ("
-	createCnsisTable += "guid    VARCHAR(36)   NOT NULL UNIQUE,"
-	createCnsisTable += "name                      VARCHAR(255)  NOT NULL,"
-	createCnsisTable += "cnsi_type                 VARCHAR(3)    NOT NULL,"
-	createCnsisTable += "api_endpoint              VARCHAR(255)  NOT NULL,"
-	createCnsisTable += "auth_endpoint             VARCHAR(255)  NOT NULL,"
-	createCnsisTable += "token_endpoint            VARCHAR(255)  NOT NULL,"
-	createCnsisTable += "doppler_logging_endpoint  VARCHAR(255)  NOT NULL,"
-	createCnsisTable += "skip_ssl_validation       BOOLEAN       NOT NULL DEFAULT FALSE,"
-	createCnsisTable += "last_updated              TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,"
-	createCnsisTable += "PRIMARY KEY (guid) );"
+		_, err = txn.Exec(createCnsisTable)
+		if err != nil {
+			return err
+		}
 
-	_, err = txn.Exec(createCnsisTable)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
+		createIndex := "CREATE INDEX tokens_user_guid ON tokens (user_guid);"
+		_, err = txn.Exec(createIndex)
+		if err != nil {
+			return err
+		}
+		createIndex = "CREATE INDEX tokens_cnsi_guid ON tokens (cnsi_guid);"
+		_, err = txn.Exec(createIndex)
+		if err != nil {
+			return err
+		}
+		createIndex = "CREATE INDEX tokens_token_type ON tokens (token_type);"
+		_, err = txn.Exec(createIndex)
+		if err != nil {
+			return err
+		}
+		createIndex = "CREATE INDEX cnsis_name ON cnsis (name);"
+		_, err = txn.Exec(createIndex)
+		if err != nil {
+			return err
+		}
+		createIndex = "CREATE INDEX cnsis_cnsi_type ON cnsis (cnsi_type);"
+		_, err = txn.Exec(createIndex)
+		if err != nil {
+			return err
+		}
 
-	createIndex := "CREATE INDEX tokens_user_guid ON tokens (user_guid);"
-	_, err = txn.Exec(createIndex)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-	createIndex = "CREATE INDEX tokens_cnsi_guid ON tokens (cnsi_guid);"
-	_, err = txn.Exec(createIndex)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-	createIndex = "CREATE INDEX tokens_token_type ON tokens (token_type);"
-	_, err = txn.Exec(createIndex)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-	createIndex = "CREATE INDEX cnsis_name ON cnsis (name);"
-	_, err = txn.Exec(createIndex)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-	createIndex = "CREATE INDEX cnsis_cnsi_type ON cnsis (cnsi_type);"
-	_, err = txn.Exec(createIndex)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-
-}
-
-// Down is executed when this migration is rolled back
-func Down_20170818120003(txn *sql.Tx) {
-
-	dropTables := "DROP  INDEX IF EXISTS tokens_token_type;"
-	_, err := txn.Exec(dropTables)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-	dropTables = "DROP  INDEX IF EXISTS tokens_cnsi_guid;"
-	_, err = txn.Exec(dropTables)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-	dropTables = "DROP  INDEX IF EXISTS tokens_user_guid;"
-	_, err = txn.Exec(dropTables)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-	dropTables = "DROP  TABLE IF EXISTS tokens;"
-	_, err = txn.Exec(dropTables)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-	dropTables = "DROP  INDEX IF EXISTS cnsis_cnsi_type;"
-	_, err = txn.Exec(dropTables)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-	dropTables = "DROP  INDEX IF EXISTS cnsis_name;"
-	_, err = txn.Exec(dropTables)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-	dropTables = "DROP  TABLE IF EXISTS cnsis;"
-	_, err = txn.Exec(dropTables)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-
+		return nil
+	})
 }

--- a/src/backend/app-core/datastore/20170818162837_SetupSchema.go
+++ b/src/backend/app-core/datastore/20170818162837_SetupSchema.go
@@ -2,51 +2,37 @@ package datastore
 
 import (
 	"database/sql"
-	"fmt"
 	"strings"
 
 	"bitbucket.org/liamstask/goose/lib/goose"
 )
 
-// Up is executed when this migration is applied
-func (s *StratosMigrations) Up_20170818162837(txn *sql.Tx, conf *goose.DBConf) {
+func init() {
+	RegisterMigration(20170818162837, "SetupSchema", func(txn *sql.Tx, conf *goose.DBConf) error {
+		consoleConfigTable := "CREATE TABLE IF NOT EXISTS console_config ("
+		consoleConfigTable += "  uaa_endpoint              VARCHAR(255)              NOT NULL, "
+		consoleConfigTable += "  console_admin_scope       VARCHAR(255)              NOT NULL,"
+		consoleConfigTable += "  console_client            VARCHAR(255)              NOT NULL,"
+		consoleConfigTable += "  console_client_secret     VARCHAR(255)              NOT NULL, "
+		consoleConfigTable += "  skip_ssl_validation       BOOLEAN                   NOT NULL DEFAULT FALSE,"
+		consoleConfigTable += "  is_setup_complete         BOOLEAN                   NOT NULL DEFAULT FALSE,"
+		consoleConfigTable += "  last_updated              TIMESTAMP                 NOT NULL DEFAULT CURRENT_TIMESTAMP);"
 
-	consoleConfigTable := "CREATE TABLE IF NOT EXISTS console_config ("
-	consoleConfigTable += "  uaa_endpoint              VARCHAR(255)              NOT NULL, "
-	consoleConfigTable += "  console_admin_scope       VARCHAR(255)              NOT NULL,"
-	consoleConfigTable += "  console_client            VARCHAR(255)              NOT NULL,"
-	consoleConfigTable += "  console_client_secret     VARCHAR(255)              NOT NULL, "
-	consoleConfigTable += "  skip_ssl_validation       BOOLEAN                   NOT NULL DEFAULT FALSE,"
-	consoleConfigTable += "  is_setup_complete         BOOLEAN                   NOT NULL DEFAULT FALSE,"
-	consoleConfigTable += "  last_updated              TIMESTAMP                 NOT NULL DEFAULT CURRENT_TIMESTAMP);"
-
-	_, err := txn.Exec(consoleConfigTable)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-
-	// Find a way to ensure this in Mysql
-	if strings.Contains(conf.Driver.Name, "postgres") {
-		createIndex := "CREATE UNIQUE INDEX console_config_one_row"
-		createIndex += "  ON console_config((uaa_endpoint IS NOT NULL));"
-		_, err = txn.Exec(createIndex)
+		_, err := txn.Exec(consoleConfigTable)
 		if err != nil {
-			fmt.Printf("Failed to migrate due to: %v", err)
+			return err
 		}
-	}
-}
 
-// Down is executed when this migration is rolled back
-func Down_20170818162837(txn *sql.Tx) {
-	dropTables := "DROP  TABLE IF EXISTS console_config;"
-	_, err := txn.Exec(dropTables)
-	if err != nil {
-		fmt.Printf("Failed ot migrate due to: %v", err)
-	}
-	dropTables = "DROP  INDEX IF EXISTS console_config_one_row;"
-	_, err = txn.Exec(dropTables)
-	if err != nil {
-		fmt.Printf("Failed ot migrate due to: %v", err)
-	}
+		// Find a way to ensure this in Mysql
+		if strings.Contains(conf.Driver.Name, "postgres") {
+			createIndex := "CREATE UNIQUE INDEX console_config_one_row"
+			createIndex += "  ON console_config((uaa_endpoint IS NOT NULL));"
+			_, err = txn.Exec(createIndex)
+			if err != nil {
+				return err
+			}
+		}
 
+		return nil
+	})
 }

--- a/src/backend/app-core/datastore/20170829154900_TokenDisconnected.go
+++ b/src/backend/app-core/datastore/20170829154900_TokenDisconnected.go
@@ -2,28 +2,19 @@ package datastore
 
 import (
 	"database/sql"
-	"fmt"
 
 	"bitbucket.org/liamstask/goose/lib/goose"
 )
 
-// Up is executed when this migration is applied
-func (s *StratosMigrations) Up_20170829154900(txn *sql.Tx, conf *goose.DBConf) {
+func init() {
+	RegisterMigration(20170829154900, "TokenDisconnected", func(txn *sql.Tx, conf *goose.DBConf) error {
+		alterTokens := "ALTER TABLE tokens ADD COLUMN disconnected boolean NOT NULL DEFAULT FALSE;"
 
-	alterTokens := "ALTER TABLE tokens ADD COLUMN disconnected boolean NOT NULL DEFAULT FALSE;"
+		_, err := txn.Exec(alterTokens)
+		if err != nil {
+			return err
+		}
 
-	_, err := txn.Exec(alterTokens)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-}
-
-// Down is executed when this migration is rolled back
-func Down_20170829154900(txn *sql.Tx) {
-	dropColumn := "ALTER TABLE \"table_name\" DROP COLUMN \"column_name\";"
-	_, err := txn.Exec(dropColumn)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-
+		return nil
+	})
 }

--- a/src/backend/app-core/datastore/20171108102900_AuthType.go
+++ b/src/backend/app-core/datastore/20171108102900_AuthType.go
@@ -2,35 +2,24 @@ package datastore
 
 import (
 	"database/sql"
-	"fmt"
 
 	"bitbucket.org/liamstask/goose/lib/goose"
 )
 
-func (s *StratosMigrations) Up_20171108102900(txn *sql.Tx, conf *goose.DBConf) {
+func init() {
+	RegisterMigration(20171108102900, "AuthType", func(txn *sql.Tx, conf *goose.DBConf) error {
+		createTokens := "ALTER TABLE tokens ADD auth_type VARCHAR(255) DEFAULT 'OAuth2'"
+		_, err := txn.Exec(createTokens)
+		if err != nil {
+			return err
+		}
 
-	createTokens := "ALTER TABLE tokens ADD auth_type VARCHAR(255) DEFAULT \"OAuth2\""
-	_, err := txn.Exec(createTokens)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
+		createTokens = "ALTER TABLE tokens ADD meta_data TEXT"
+		_, err = txn.Exec(createTokens)
+		if err != nil {
+			return err
+		}
 
-	createTokens = "ALTER TABLE tokens ADD meta_data TEXT"
-	_, err = txn.Exec(createTokens)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-}
-
-func Down_20171108102900(txn *sql.Tx) {
-	dropTables := "ALTER TABLE tokens DROP COLUMN auth_type"
-	_, err := txn.Exec(dropTables)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-	dropTables = "ALTER TABLE tokens DROP COLUMN meta_data"
-	_, err = txn.Exec(dropTables)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
+		return nil
+	})
 }

--- a/src/backend/app-core/datastore/20180627111300_UpdateMetadata.go
+++ b/src/backend/app-core/datastore/20180627111300_UpdateMetadata.go
@@ -2,35 +2,83 @@ package datastore
 
 import (
 	"database/sql"
-	"fmt"
+	"strings"
 
 	"bitbucket.org/liamstask/goose/lib/goose"
 )
 
-func (s *StratosMigrations) Up_20180627111300(txn *sql.Tx, conf *goose.DBConf) {
+func init() {
+	RegisterMigration(20180627111300, "UpdateMetadata", func(txn *sql.Tx, conf *goose.DBConf) error {
+		var statements []string
 
-	updateMetadata := "ALTER TABLE tokens modify meta_data TEXT DEFAULT ''"
-	_, err := txn.Exec(updateMetadata)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-	updateMetadata = "UPDATE tokens SET meta_data='' where meta_data is NULL"
-	_, err = txn.Exec(updateMetadata)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
+		switch {
+		case strings.Contains(conf.Driver.Name, "postgres"):
+			statements = append(statements,
+				"ALTER TABLE tokens ALTER COLUMN meta_data SET DEFAULT ''",
+				"UPDATE tokens SET meta_data='' where meta_data is NULL",
+			)
 
-}
+		case strings.Contains(conf.Driver.Name, "sqlite3"):
+			// sqllite cannot alter existing columns, so we need to rename the table, and copy the data into a new table
+			statements = append(statements,
+				"DROP INDEX tokens_user_guid",
+				"DROP INDEX tokens_cnsi_guid",
+				"DROP INDEX tokens_token_type",
+				"UPDATE tokens SET meta_data='' where meta_data is NULL",
+				"ALTER TABLE tokens RENAME TO _old_tokens",
+				`CREATE TABLE tokens (
+					user_guid     VARCHAR(36) NOT NULL,
+					cnsi_guid     VARCHAR(36),
+					token_type    VARCHAR(4)  NOT NULL,
+					auth_token    BYTEA       NOT NULL,
+					refresh_token BYTEA       NOT NULL,
+					token_expiry  BIGINT      NOT NULL,
+					last_updated  TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					disconnected boolean      NOT NULL DEFAULT FALSE,
+					auth_type VARCHAR(255)    DEFAULT 'OAuth2',
+					meta_data TEXT DEFAULT ''
+				)`,
+				`INSERT INTO tokens (
+						user_guid,
+						cnsi_guid,
+						token_type,
+						auth_token,
+						refresh_token,
+						token_expiry,
+						last_updated,
+						disconnected,
+						auth_type,
+						meta_data)
+					SELECT user_guid,
+						cnsi_guid,
+						token_type,
+						auth_token,
+						refresh_token,
+						token_expiry,
+						last_updated,
+						disconnected,
+						auth_type,
+						meta_data
+					FROM _old_tokens`,
+				"CREATE INDEX tokens_user_guid ON tokens (user_guid)",
+				"CREATE INDEX tokens_cnsi_guid ON tokens (cnsi_guid)",
+				"CREATE INDEX tokens_token_type ON tokens (token_type)",
+				"DROP TABLE _old_tokens",
+			)
+		default: // fallback to MySQL
+			statements = append(statements,
+				"ALTER TABLE tokens modify meta_data TEXT DEFAULT ''",
+				"UPDATE tokens SET meta_data='' where meta_data is NULL",
+			)
+		}
 
-func Down_20180627111300(txn *sql.Tx) {
-	dropTables := "ALTER TABLE tokens modify meta_data TEXT DEFAULT ''"
-	_, err := txn.Exec(dropTables)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
-	dropTables = "UPDATE tokens SET meta_data=NULL where meta_data is ''"
-	_, err = txn.Exec(dropTables)
-	if err != nil {
-		fmt.Printf("Failed to migrate due to: %v", err)
-	}
+		for _, st := range statements {
+			_, err := txn.Exec(st)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 }

--- a/src/backend/app-core/datastore/datastore.go
+++ b/src/backend/app-core/datastore/datastore.go
@@ -152,7 +152,7 @@ func GetSQLLiteConnection() (*sql.DB, error) {
 
 	db, err := sql.Open("sqlite3", SQLiteDatabaseFile)
 	if err != nil {
-		return db, err
+		return nil, err
 	}
 
 	// Create fake goose db conf object for SQLite
@@ -166,9 +166,12 @@ func GetSQLLiteConnection() (*sql.DB, error) {
 		Driver: d,
 	}
 
-	ApplyMigrations(conf, db)
+	err = ApplyMigrations(conf, db)
+	if err != nil {
+		return nil, err
+	}
 
-	return db, err
+	return db, nil
 }
 
 func buildConnectionString(dc DatabaseConfig) string {

--- a/src/backend/app-core/migrator.go
+++ b/src/backend/app-core/migrator.go
@@ -106,7 +106,7 @@ func upRun(args []string) {
 	}
 	defer db.Close()
 
-	datastore.ApplyMigrations(conf, db)
+	err = datastore.ApplyMigrations(conf, db)
 	if err != nil {
 		log.Fatal("Migration failed", err)
 	}


### PR DESCRIPTION
## Description

Migrate scripts don't work against Postgresql. This fixes the update scripts.

So far as I can tell the downgrade ones remain broken, however I'm surprised that functionality is supported at all?

## Motivation and Context

Postgres users are currently broken for new installs. This fixes that.

## How Has This Been Tested?

Application now starts on a fresh Postgres instance. No further testing done yet.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message