### PR TITLE
Fix three issues around 100+ roles

### DIFF
--- a/src/frontend/app/shared/components/list/list-types/cf-users/cf-space-permission-cell/cf-space-permission-cell.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-users/cf-space-permission-cell/cf-space-permission-cell.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { combineLatest, of as observableOf } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { map, switchMap, first, filter } from 'rxjs/operators';
 
 import { IOrganization, ISpace } from '../../../../../../core/cf-api.types';
 import { CurrentUserPermissions } from '../../../../../../core/current-user-permissions.config';
@@ -55,6 +55,8 @@ export class CfSpacePermissionCellComponent extends CfPermissionCell<SpaceUserRo
     const orgNames$ = combineLatest(
       orgGuids.map(orgGuid => this.store.select<APIResource<IOrganization>>(selectEntity(organizationSchemaKey, orgGuid)))
     ).pipe(
+      filter(org => !!org),
+      first(),
       map((orgs: APIResource<IOrganization>[]) => {
         const orgNames: { [orgGuid: string]: string } = {};
         orgs.forEach(org => {

--- a/src/frontend/app/shared/data-services/cf-user.service.ts
+++ b/src/frontend/app/shared/data-services/cf-user.service.ts
@@ -159,44 +159,31 @@ export class CfUserService {
     return res;
   }
 
+  private populatedArray(array?: Array<any>): boolean {
+    return array && !!array.length;
+  }
+
   /**
    * Helper to determine if user has roles other than Org User
    */
   hasRolesInOrg(user: CfUser, orgGuid: string, excludeOrgUser = true): boolean {
 
-    const orgRoles = this.getOrgRolesFromUser(user).filter(o => o.orgGuid === orgGuid);
-    const spaceRoles = this.getSpaceRolesFromUser(user).filter(o => o.orgGuid === orgGuid);
-
-    for (const roleKey in orgRoles) {
-      if (!orgRoles.hasOwnProperty(roleKey)) {
-        continue;
-      }
-
-      const permissions = orgRoles[roleKey].permissions;
-      if (
-        permissions[OrgUserRoleNames.MANAGER] ||
-        permissions[OrgUserRoleNames.BILLING_MANAGERS] ||
-        permissions[OrgUserRoleNames.AUDITOR]
-      ) {
-        return true;
-      }
-      if (!excludeOrgUser && permissions[OrgUserRoleNames.USER]) {
-        return true;
-      }
+    // Check org roles
+    if (this.populatedArray(user.audited_organizations) ||
+      this.populatedArray(user.billing_managed_organizations) ||
+      this.populatedArray(user.managed_organizations) ||
+      (!excludeOrgUser && this.populatedArray(user.organizations))) {
+      return true;
     }
 
-    for (const roleKey in spaceRoles) {
-      if (!spaceRoles.hasOwnProperty(roleKey)) {
-        continue;
-      }
-
-      const permissions = spaceRoles[roleKey].permissions;
-      if (permissions[SpaceUserRoleNames.MANAGER] ||
-        permissions[SpaceUserRoleNames.AUDITOR] ||
-        permissions[SpaceUserRoleNames.DEVELOPER]) {
-        return true;
-      }
+    // Check space roles
+    if (this.populatedArray(user.audited_spaces) ||
+      this.populatedArray(user.managed_spaces) ||
+      this.populatedArray(user.spaces)) {
+      return true;
     }
+
+    return false;
   }
 
   getUserRoleInOrg = (

--- a/src/frontend/app/store/helpers/entity-factory.ts
+++ b/src/frontend/app/store/helpers/entity-factory.ts
@@ -58,7 +58,8 @@ export class EntitySchema extends schema.Entity {
    * @param {string} entityKey As per schema.Entity ctor
    * @param {Schema} [definition] As per schema.Entity ctor
    * @param {schema.EntityOptions} [options] As per schema.Entity ctor
-   * @param {string} [relationKey] Allows multiple children of the same type within a single parent entity
+   * @param {string} [relationKey] Allows multiple children of the same type within a single parent entity. For instance user with developer
+   * spaces, manager spaces, auditor space, etc
    * @memberof EntitySchema
    */
   constructor(
@@ -339,14 +340,14 @@ const orgUserEntity = {
   }
 };
 const OrganizationUserSchema = new EntitySchema(
-  organizationSchemaKey, orgUserEntity, { idAttribute: getAPIResourceGuid }, 'users_organizations');
+  organizationSchemaKey, orgUserEntity, { idAttribute: getAPIResourceGuid }, 'organizations');
 const OrganizationAuditedSchema = new EntitySchema(
   organizationSchemaKey, orgUserEntity, { idAttribute: getAPIResourceGuid }, 'audited_organizations');
 const OrganizationManagedSchema = new EntitySchema(
   organizationSchemaKey, orgUserEntity, { idAttribute: getAPIResourceGuid }, 'managed_organizations');
 const OrganizationBillingSchema = new EntitySchema(
   organizationSchemaKey, orgUserEntity, { idAttribute: getAPIResourceGuid }, 'billing_managed_organizations');
-const SpaceUserSchema = new EntitySchema(spaceSchemaKey, {}, { idAttribute: getAPIResourceGuid }, 'users_spaces');
+const SpaceUserSchema = new EntitySchema(spaceSchemaKey, {}, { idAttribute: getAPIResourceGuid }, 'spaces');
 const SpaceManagedSchema = new EntitySchema(spaceSchemaKey, {}, { idAttribute: getAPIResourceGuid }, 'managed_spaces');
 const SpaceAuditedSchema = new EntitySchema(spaceSchemaKey, {}, { idAttribute: getAPIResourceGuid }, 'audited_spaces');
 

--- a/src/frontend/app/store/reducers/api-request-data-reducer/request-data-reducer.factory.ts
+++ b/src/frontend/app/store/reducers/api-request-data-reducer/request-data-reducer.factory.ts
@@ -89,7 +89,9 @@ function populateParentEntity(state, successAction) {
 
   const action: EntityInlineChildAction = successAction.apiAction as EntityInlineChildAction;
   const response = successAction.response;
-  const entities = pathGet(`entities.${successAction.apiAction.entityKey}`, response) || {};
+  const entityKey = successAction.apiAction.entityKey;
+  const entity = successAction.apiAction.entity;
+  const entities = pathGet(`entities.${entityKey}`, response) || {};
   if (!Object.values(entities)) {
     return;
   }
@@ -103,10 +105,12 @@ function populateParentEntity(state, successAction) {
     type: '',
     entity: action.parentEntitySchema,
     entityKey: parentEntityKey,
-    includeRelations: [createEntityRelationKey(parentEntityKey, successAction.apiAction.entityKey)],
+    includeRelations: [createEntityRelationKey(parentEntityKey, entityKey)],
     populateMissing: null,
   });
-  const childRelation = parentEntityTree.rootRelation.childRelations.find(rel => rel.entityKey === successAction.apiAction.entityKey);
+  const relationKey = entity.length ? entity[0].relationKey : entity.relationKey;
+  const childRelation = parentEntityTree.rootRelation.childRelations.find(rel =>
+    relationKey ? rel.paramName === relationKey : rel.entityKey === entityKey);
   const entityParamName = childRelation.paramName;
 
   let newParentEntity = pathGet(`${parentEntityKey}.${parentGuid}`, state);

--- a/src/frontend/app/test-framework/cloud-foundry-organization.service.mock.ts
+++ b/src/frontend/app/test-framework/cloud-foundry-organization.service.mock.ts
@@ -1,6 +1,21 @@
+import { Observable, of as observableOf } from 'rxjs';
+
 import { GetAllOrgUsers } from '../store/actions/organization.actions';
+import { getDefaultRequestState } from '../store/reducers/api-request-reducer/types';
+import { APIResource, EntityInfo } from '../store/types/api.types';
 
 export class CloudFoundryOrganizationServiceMock {
+  org$: Observable<EntityInfo<APIResource<any>>> = observableOf(
+    {
+      entity: {
+        entity: {
+          spaces: [],
+          status: ''
+        },
+        metadata: null
+      },
+      entityRequestInfo: getDefaultRequestState()
+    });
   allOrgUsersAction = new GetAllOrgUsers('guid', 'guid-key', 'guid');
   allOrgUsers = {};
 }

--- a/src/frontend/app/test-framework/cloud-foundry-space.service.mock.ts
+++ b/src/frontend/app/test-framework/cloud-foundry-space.service.mock.ts
@@ -1,7 +1,5 @@
+import { Observable, of as observableOf } from 'rxjs';
 
-import {of as observableOf,  Observable } from 'rxjs';
-import { APIResource, EntityInfo } from '../store/types/api.types';
-import { ISpace } from '../core/cf-api.types';
 import { GetAllSpaceUsers } from '../store/actions/space.actions';
 
 export class CloudFoundrySpaceServiceMock {


### PR DESCRIPTION
For testing would advice using `deploy/tools/populate-cf/create-many-spaces.sh`

Ensure users with 100+ roles are stored correctly -  changes to `entity-factory.ts` + `request-data-reducer.factory.ts`
- admin with 100+ manager and dev space roles
- we notice that the user is missing the manager and space properties and go out and fetch
- previously we then stored the users managed spaces in the `spaces` property instead of `managed_spaces`

Improve efficiency when calculating user other roles -  changes to `cf-user.service.ts`
- Need to determine if a user has roles other than org user (to determine if we show the 'cross' on org user pill)
- This happens per org user cell per user quite a lot of times
- Previously this recalculated roles for each space and org. these could be 100s * above
- Now we just check the user's arrays

Ensure we don't show incorrect space roles in org users list - changes to `cf-user-list-config.service.ts`
- When there are many space roles we have to fetch them asyncronously
- Previously the org users list would briefly show all space roles (even those for spaces not in org) before showing correct list
- We now block until we have that space list
- CF user and space user lists should remain unaffected