### PR TITLE
Use correct log level when looking up Endpoints

### DIFF
--- a/src/backend/app-core/repository/tokens/pgsql_tokens.go
+++ b/src/backend/app-core/repository/tokens/pgsql_tokens.go
@@ -316,7 +316,11 @@ func (p *PgsqlTokenRepository) findCNSIToken(cnsiGUID string, userGUID string, e
 
 	if err != nil {
 		msg := "Unable to Find CNSI token: %v"
-		log.Errorf(msg, err)
+		if err == sql.ErrNoRows {
+			log.Debugf(msg, err)
+		} else {
+			log.Errorf(msg, err)
+		}
 		return interfaces.TokenRecord{}, fmt.Errorf(msg, err)
 	}
 


### PR DESCRIPTION
Fixes #2624 

We log at error level if we don't find any rows  - this is not an error - log this at debug and use error level for other errors.