### PR TITLE
Use different env var for test checker. Remove fdescribe

### DIFF
--- a/build/karma.test.reporter.js
+++ b/build/karma.test.reporter.js
@@ -17,7 +17,7 @@
     };
 
     this.onRunComplete = function (browser, result) {
-      if (process.env['CI_ENV'] === 'true' && this.skipped !== 0) {
+      if (process.env['CHECK_TESTS'] === 'true' && this.skipped !== 0) {
         result.exitCode = 1;
         console.log('\x1b[41m\x1b[97m\x1b[1m');
         console.log('');

--- a/src/frontend/app/shared/components/list/list-table/table.component.spec.ts
+++ b/src/frontend/app/shared/components/list/list-table/table.component.spec.ts
@@ -13,7 +13,7 @@ import { IListPaginationController } from '../data-sources-controllers/list-pagi
 import { ITableColumn } from './table.types';
 import { TableComponent } from './table.component';
 
-fdescribe('TableComponent', () => {
+describe('TableComponent', () => {
 
   const column1Id = '123123';
   const column2Id = 'dsftq34ge';


### PR DESCRIPTION
Use a different env var for checking for skipped tests.

Remove fdescribe in table tests.