### PR TITLE
Fix App Chips not collapsing long lists

### DIFF
--- a/src/frontend/app/shared/components/chips/chips.component.html
+++ b/src/frontend/app/shared/components/chips/chips.component.html
@@ -6,8 +6,8 @@
       <mat-spinner *ngIf="chip.busy && (chip.busy | async)" diameter="15" class="app-chip__busy-spinner"></mat-spinner>
     </ng-container>
   </mat-chip>
-  <a class="app-chips__limit" *ngIf="chips.length > lowerLimit" (click)="toggleLimit()" appClickStopPropagation>
+  <button mat-button class="app-chips__limit" *ngIf="chips.length > lowerLimit" (click)="toggleLimit()" appClickStopPropagation>
     <span *ngIf="atLowerLimit">+{{ chips.length - limit }}</span>
     <span *ngIf="!atLowerLimit">Show less</span>
-    </a>
+  </button>
 </mat-chip-list>

--- a/src/frontend/app/shared/components/chips/chips.component.html
+++ b/src/frontend/app/shared/components/chips/chips.component.html
@@ -6,7 +6,7 @@
       <mat-spinner *ngIf="chip.busy && (chip.busy | async)" diameter="15" class="app-chip__busy-spinner"></mat-spinner>
     </ng-container>
   </mat-chip>
-  <button mat-button class="app-chips__limit" *ngIf="chips.length > lowerLimit" (click)="toggleLimit()" appClickStopPropagation>
+  <button mat-button color="primary" class="app-chips__limit" *ngIf="chips.length > lowerLimit" (click)="toggleLimit()" appClickStopPropagation>
     <span *ngIf="atLowerLimit">+{{ chips.length - limit }}</span>
     <span *ngIf="!atLowerLimit">Show less</span>
   </button>

--- a/src/frontend/app/shared/components/chips/chips.component.scss
+++ b/src/frontend/app/shared/components/chips/chips.component.scss
@@ -18,6 +18,7 @@
   &__limit {
     cursor: pointer;
     padding: 0 5px;
+    font-weight: unset;
   }
 }
 

--- a/src/frontend/app/shared/components/chips/chips.component.scss
+++ b/src/frontend/app/shared/components/chips/chips.component.scss
@@ -16,9 +16,10 @@
   display: block;
   margin: 5px 0;
   &__limit {
-    cursor: pointer;
     padding: 0 5px;
-    font-weight: unset;
+    cursor: pointer;
+    font-weight: 300;
+    min-width: 0;
   }
 }
 

--- a/src/frontend/app/shared/components/chips/chips.component.scss
+++ b/src/frontend/app/shared/components/chips/chips.component.scss
@@ -16,10 +16,10 @@
   display: block;
   margin: 5px 0;
   &__limit {
-    padding: 0 5px;
     cursor: pointer;
     font-weight: 300;
     min-width: 0;
+    padding: 0 5px;
   }
 }
 


### PR DESCRIPTION
Fixes #2461

Switching `<a>` to a proper `<button>` fixes the issue of click handler not registering if content expansion causes a scroll bar to appear.