### PR TITLE
Api Effect: Don't validate when there are no results

### DIFF
--- a/src/frontend/app/store/effects/api.effects.ts
+++ b/src/frontend/app/store/effects/api.effects.ts
@@ -18,7 +18,13 @@ import { selectPaginationState } from '../selectors/pagination.selectors';
 import { EndpointModel } from '../types/endpoint.types';
 import { InternalEventSeverity } from '../types/internal-events.types';
 import { PaginatedAction, PaginationEntityState, PaginationParam } from '../types/pagination.types';
-import { APISuccessOrFailedAction, ICFAction, IRequestAction, RequestEntityLocation, WrapperRequestActionSuccess } from '../types/request.types';
+import {
+  APISuccessOrFailedAction,
+  ICFAction,
+  IRequestAction,
+  RequestEntityLocation,
+  WrapperRequestActionSuccess
+} from '../types/request.types';
 import { environment } from './../../../environments/environment';
 import { ApiActionTypes, ValidateEntitiesStart } from './../actions/request.actions';
 import { AppState, IRequestEntityTypeState } from './../app-state';


### PR DESCRIPTION
Fixes #2682

Although this fixes the issue I think there may be issues within the validation.

@richard-cox why does the validation, when given an empty array for an entity list, not fill out the page of the pagination?

## Example

### Api Response

```
{
...
resources: []
total_pages: 1,
total_results: 1
}
```

### What ends up in the store pagination section:

```
{
...
ids: {}
...
}
```

### Expected:

```
{
...
ids: { 1: [] }
...
}
```