### PR TITLE
Ensure lists with no entities populate pagination section correctly

### DIFF
--- a/src/frontend/app/store/helpers/entity-relations.ts
+++ b/src/frontend/app/store/helpers/entity-relations.ts
@@ -483,6 +483,7 @@ export function validateEntityRelations(config: ValidateEntityRelationsConfig): 
 
   if (!action.entity || !parentEntities || parentEntities.length === 0) {
     return {
+      apiResponse: config.apiResponse,
       started: false,
       completed: Promise.resolve([])
     };


### PR DESCRIPTION
- ids: { } => ids: { 1: [] }
- think this is a regression following the removal of partial entities
- Fixes #2682, #2684