### PR TITLE
Diagnostics: Add git and build date metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ src/backend/app-core/load_plugins.go
 secrets.yaml
 build/dev_config.json
 e2e-reports/
+.stratos-git-metadata.json
 
 # Customisations
 
@@ -103,3 +104,4 @@ src/frontend/app/custom.module.ts
 src/frontend/app/custom
 src/frontend/assets/custom
 src/frontend/sass/custom
+src/frontend/index.html

--- a/build/customize-build.js
+++ b/build/customize-build.js
@@ -10,27 +10,49 @@
   var path = require('path');
   var fs = require('fs-extra');
   var yaml = require('js-yaml');
+  var replace = require('replace-in-file');
+  var execSync = require('child_process').execSync;
 
   const CUSTOM_YAML_MANIFEST = path.resolve(__dirname, '../src/frontend/misc/custom/custom.yaml');
+
+  const INDEX_TEMPLATE = path.resolve(__dirname, '../src/frontend/misc/custom/index.html');
+  const INDEX_HTML = path.resolve(__dirname, '../src/frontend/index.html');
+
+  const CUSTOM_METADATA = path.resolve(__dirname, '../custom-src/stratos.yaml');
+
+  const GIT_FOLDER = path.resolve(__dirname, '../.git');
+
+  const GIT_METADATA = path.resolve(__dirname, '../.stratos-git-metadata.json');
+
 
   // Apply any customizations
   // Symlink customizations of the default resources for Stratos
   gulp.task('customize', function (cb) {
     doCustomize(false);
+    doGenerateIndexHtml(true);
     cb();
   });
 
   // Apply defaults instead of any customizations that are available in custom-src
   gulp.task('customize-default', function (cb) {
     doCustomize(true);
+    doGenerateIndexHtml(false);
     cb();
   });
 
   // Remove all customizations (removes all symlinks as if customize had not been run)
   gulp.task('customize-reset', function (cb) {
     doCustomize(true, true);
+    doGenerateIndexHtml(false);
     cb();
   });
+
+  // Store git metadata so we have it when we are running the the non-git world (Docker)
+  gulp.task('store-git-metadata', function (cb) {
+    storeGitRepositoryMetadata();
+    cb();
+  });
+
 
   function doCustomize(forceDefaults, reset) {
     var msg = !forceDefaults ? 'Checking for and applying customizations' : 'Removing customizations and applying defaults';
@@ -105,6 +127,9 @@
     // Symlink custom backend plugin folders if they are present
     // Get all of the sub-folders in the custom-src/backend folder and symlink
 
+    // Upda the git metadata if we can
+    storeGitRepositoryMetadata();
+
     // Remove all existing symlinks first
     var existing = fs.readdirSync(baseFolder);
     existing.forEach(file => {
@@ -138,6 +163,73 @@
         fs.symlinkSync(srcFolder, destFolder);
       }
     })
+  }
+
+  // Generate index.html from template
+  function doGenerateIndexHtml(customize) {
+    // Copy the default
+    fs.copySync(INDEX_TEMPLATE, INDEX_HTML);
+
+    // Read custom metadata if we are customizing and the file is present 
+    var metadata = {};
+    if (customize && fs.existsSync(CUSTOM_METADATA)) {
+      try {
+        metadata = yaml.safeLoad(fs.readFileSync(CUSTOM_METADATA, 'utf8'));
+      } catch (e) {
+        console.log('Could not read stratos.yaml file');
+        console.log(e);
+        process.exit(1);
+      }
+    }
+
+    // Patch different page title if there is one
+    var title = metadata.title || 'Stratos';
+    replace.sync({ files: INDEX_HTML, from: /@@TITLE@@/g, to: title });
+
+    // Read in the stored Git metadata if it is there, default to empty metadata
+    var gitMetadata = {
+      project: '',
+      branch: '',
+      commit: ''
+    };
+
+    if (fs.existsSync(GIT_METADATA)) {
+      gitMetadata = JSON.parse(fs.readFileSync(GIT_METADATA));
+    }
+
+    // Git Information
+    replace.sync({ files: INDEX_HTML, from: '@@stratos_git_project@@', to: gitMetadata.project });
+    replace.sync({ files: INDEX_HTML, from: '@@stratos_git_branch@@', to: gitMetadata.branch });
+    replace.sync({ files: INDEX_HTML, from: '@@stratos_git_commit@@', to: gitMetadata.commit });
+
+    // Date and Time that the build was made (approximately => it is when this script is run)
+    replace.sync({ files: INDEX_HTML, from: '@@stratos_build_date@@', to: new Date() });
+  }
+
+  // We can only do this if we have a git repository checkout
+  // We'll store this in a file which we will then use - when in environments like Docker, we will run this
+  // in the host environment so that we can pick it up when we're running in the Docker world
+  function storeGitRepositoryMetadata() {
+    // Do we have a git folder?
+    if (!fs.existsSync(GIT_FOLDER)) {
+      return;
+    }
+    var gitMetadata = {
+      project: execGit('git config --get remote.origin.url'),
+      branch: execGit('git rev-parse --abbrev-ref HEAD'),
+      commit: execGit('git rev-parse HEAD')
+    };
+
+    fs.writeFileSync(GIT_METADATA, JSON.stringify(gitMetadata, null, 2));
+  }
+
+  function execGit(cmd) {
+    try {
+      var response = execSync(cmd + ' 2> /dev/null');
+      return response.toString().trim();
+    } catch (e) {
+      return '';
+    }
   }
 
 })();

--- a/build/customize-build.js
+++ b/build/customize-build.js
@@ -14,16 +14,11 @@
   var execSync = require('child_process').execSync;
 
   const CUSTOM_YAML_MANIFEST = path.resolve(__dirname, '../src/frontend/misc/custom/custom.yaml');
-
   const INDEX_TEMPLATE = path.resolve(__dirname, '../src/frontend/misc/custom/index.html');
   const INDEX_HTML = path.resolve(__dirname, '../src/frontend/index.html');
-
   const CUSTOM_METADATA = path.resolve(__dirname, '../custom-src/stratos.yaml');
-
   const GIT_FOLDER = path.resolve(__dirname, '../.git');
-
   const GIT_METADATA = path.resolve(__dirname, '../.stratos-git-metadata.json');
-
 
   // Apply any customizations
   // Symlink customizations of the default resources for Stratos

--- a/build/customize-build.js
+++ b/build/customize-build.js
@@ -122,7 +122,7 @@
     // Symlink custom backend plugin folders if they are present
     // Get all of the sub-folders in the custom-src/backend folder and symlink
 
-    // Upda the git metadata if we can
+    // Update the git metadata if we can
     storeGitRepositoryMetadata();
 
     // Remove all existing symlinks first

--- a/build/store-git-metadata.sh
+++ b/build/store-git-metadata.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Store the git metadata - only dependency is the git binary
+
+DIRPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GIT_METADATA_FILE=${DIRPATH}/../.stratos-git-metadata.json
+
+GIT_PROJECT=$(git config --get remote.origin.url)
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+GIT_COMMIT=$(git rev-parse HEAD)
+
+echo "{" > ${GIT_METADATA_FILE}
+echo "  \"project\": \"${GIT_PROJECT}\"," >> ${GIT_METADATA_FILE}
+echo "  \"branch\": \"${GIT_BRANCH}\"," >> ${GIT_METADATA_FILE}
+echo "  \"commit\": \"${GIT_COMMIT}\"" >> ${GIT_METADATA_FILE}
+echo "}" >> ${GIT_METADATA_FILE}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "customize": "gulp customize",
     "customize-default": "gulp customize-default",
     "customize-reset": "gulp customize-reset",
+    "store-git-metadata": "gulp store-git-metadata",
     "postinstall": "npm run customize"
   },
   "author": "",
@@ -109,6 +110,7 @@
     "protractor": "^5.3.2",
     "stratos-protractor-reporter": "^1.2.3",
     "q": "^1.4.1",
+    "replace-in-file": "^3.4.0",
     "request-promise-native": "^1.0.5",
     "rxjs-tslint": "^0.1.4",
     "sass-lint": "^1.12.1",

--- a/src/frontend/misc/custom/index.html
+++ b/src/frontend/misc/custom/index.html
@@ -3,10 +3,14 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Stratos</title>
+  <title>@@TITLE@@</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="stratos_git_project" content="@@stratos_git_project@@">
+  <meta name="stratos_git_branch" content="@@stratos_git_branch@@">
+  <meta name="stratos_git_commit" content="@@stratos_git_commit@@">  
+  <meta name="stratos_build_date" content="@@stratos_build_date@@">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <noscript>
     <style>
@@ -31,6 +35,7 @@
       .title {
         font-size: 36px;
         font-weight: bold;
+        text-transform: uppercase;
       }
     </style>
   </noscript>
@@ -41,7 +46,7 @@
   <app-root></app-root>
   <noscript>
     <div class="no-javascript">
-      <div class="message title">STRATOS</div>
+      <div class="message title">@@TITLE@@</div>
       <div class="message">Javascript is required to run Stratos</div>
       <div class="message">Please enable Javascript in your browser and refresh this page</div>
     </div>


### PR DESCRIPTION
This PR adds diagnostics into the HTML page.
- It also allows the page title to be configured.
- The HTML page is now a template and the customize task will now render the template to the correct location, adding in the git repo, branch, commit and build date.
- A script and npm target can be run to output the git metadata to a file (.stratos-git-metadata.json) which is used by the customize target - this is useful in docker cases where the git metadata is not available - we can run this task in a git environment to generate a file and use that file within a docker context later.
