### PR TITLE
Allow e2e tests to be skipped based on secrets configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# compiled output
+, e2e.secrets.haveSingleCloudFoundryEndpointkip# compiled output
 /dist
 .dist
 /tmp
@@ -27,7 +27,7 @@
 # misc
 /.sass-cache
 /connect.lock
-/coverage
+/coverage, e2e.secrets.haveSingleCloudFoundryEndpoint
 /libpeerconnection.log
 npm-debug.log
 testem.log
@@ -35,7 +35,6 @@ testem.log
 yarn-error.log
 
 # e2e
-src/test-e2e/*.js
 src/test-e2e/*.map
 src/test-e2e/e2e.secrets.ts
 

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -7,6 +7,7 @@ const {
 
 const HtmlReporter = require('stratos-protractor-reporter');
 const moment = require('moment');
+const skipPlugin = require('./src/test-e2e/skip-plugin.js');
 
 var timestamp = moment().format('DD_MM_YYYY-hh.mm.ss');
 
@@ -57,6 +58,7 @@ exports.config = {
   },
   params: secrets,
   onPrepare() {
+    skipPlugin.install(jasmine);
     require('ts-node').register({
       project: 'src/test-e2e/tsconfig.e2e.json'
     });
@@ -68,12 +70,13 @@ exports.config = {
       logIgnore: [
         /\/auth\/session\/verify - Failed to load resource/g
       ]
-   }).getJasmine2Reporter());
+    }).getJasmine2Reporter());
     jasmine.getEnv().addReporter(new SpecReporter({
       spec: {
         displayStacktrace: true
       }
     }));
+    jasmine.getEnv().addReporter(skipPlugin.reporter());
   }
 };
 

--- a/src/test-e2e/cloud-foundry/endpoints-list-cf-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/endpoints-list-cf-e2e.spec.ts
@@ -52,7 +52,7 @@ describe('CF Endpoints Dashboard', () => {
     });
   });
 
-  describe('Multiple endpoints', () => {
+  describe('Multiple endpoints', e2e.secrets.haveSingleCloudFoundryEndpoint, () => {
     beforeAll(() => {
       e2e.setup(ConsoleUserType.admin)
         .clearAllEndpoints()

--- a/src/test-e2e/endpoints/endpoints-connect-e2e.spec.ts
+++ b/src/test-e2e/endpoints/endpoints-connect-e2e.spec.ts
@@ -142,7 +142,6 @@ describe('Endpoints', () => {
             const snackBar = new SnackBarComponent();
             snackBar.waitUntilShown();
             expect(endpointsPage.isNoneConnectedSnackBar(snackBar)).toBeTruthy();
-            
             endpointsPage.table.getEndpointDataForEndpoint(toDisconnect.name).then((data: EndpointMetadata) => {
               expect(data.connected).toBeFalsy();
             });

--- a/src/test-e2e/endpoints/endpoints-unregister-e2e.spec.ts
+++ b/src/test-e2e/endpoints/endpoints-unregister-e2e.spec.ts
@@ -41,8 +41,8 @@ describe('Endpoints', () => {
         });
       });
 
-      describe('Multiple endpoints -', () => {
-
+      // Skip test if we only have one Cloud Foundry endpoint
+      describe('Multiple endpoints -', e2e.secrets.haveSingleCloudFoundryEndpoint, () => {
         beforeAll(() => {
           // Ensure we have multiple endpoints registered
           e2e.setup(ConsoleUserType.admin)

--- a/src/test-e2e/helpers/secrets-helpers.ts
+++ b/src/test-e2e/helpers/secrets-helpers.ts
@@ -14,11 +14,11 @@ export class SecretsHelpers {
 
   constructor() { }
 
-  haveMultipleCloudFoundryEndpoints(): boolean {
+  haveMultipleCloudFoundryEndpoints = () => {
     return Object.keys(this.getCloudFoundryEndpoints()).length > 1;
   }
 
-  haveSingleCloudFoundryEndpoint(): boolean {
+  haveSingleCloudFoundryEndpoint = () => {
     return !this.haveMultipleCloudFoundryEndpoints();
   }
 

--- a/src/test-e2e/helpers/secrets-helpers.ts
+++ b/src/test-e2e/helpers/secrets-helpers.ts
@@ -14,6 +14,14 @@ export class SecretsHelpers {
 
   constructor() { }
 
+  haveMultipleCloudFoundryEndpoints(): boolean {
+    return Object.keys(this.getCloudFoundryEndpoints()).length > 1;
+  }
+
+  haveSingleCloudFoundryEndpoint(): boolean {
+    return !this.haveMultipleCloudFoundryEndpoints();
+  }
+
   getConsoleAdminUsername(): string {
     return this.secrets.consoleUsers.admin.username;
   }
@@ -31,7 +39,7 @@ export class SecretsHelpers {
   }
 
   getCloudFoundryEndpoints(): any {
-    throw new Error('Not implemented');
+    return this.secrets.endpoints.cf;
   }
 
   getConsoleCredentials(userType: ConsoleUserType): E2ECred {

--- a/src/test-e2e/skip-plugin.js
+++ b/src/test-e2e/skip-plugin.js
@@ -1,0 +1,102 @@
+/* eslint-disable angular/typecheck-function, angular/log, no-console */
+(function () {
+  'use strict';
+
+  module.exports.install = function (jasmine) {
+    const global = jasmine.getGlobal();
+    const _super = {
+      describe: global.describe,
+      fdescribe: global.fdescribe,
+      xdescribe: global.xdescribe
+    };
+
+    function checkSuiteSkipped(suite, skipFn) {
+      if (!skipFn) {
+        return;
+      }
+      // Add a method to the suite object to allow the suite to be skipped on a condition
+      function markDisabled(testSuite) {
+        if (testSuite && testSuite.children) {
+          for (let i = 0; i < testSuite.children.length; i++) {
+            const item = testSuite.children[i];
+            item.disabled = true;
+            markDisabled(item);
+          }
+        }
+      }
+      let skipped = false;
+      if (typeof skipFn === 'function') {
+        skipped = skipFn();
+        if (skipped) {
+          markDisabled(suite);
+        }
+      }
+      return suite;
+    }
+
+    global.describe = function (desc, skipWhen, specDefinition) {
+      let args = [desc, skipWhen];
+      if (skipWhen && specDefinition) {
+        args = [desc, specDefinition];
+      }
+      const suite = _super.describe.apply(this, args);
+      return checkSuiteSkipped(suite, (skipWhen && specDefinition) ? skipWhen : null);
+    };
+
+    global.fdescribe = function (desc, skipWhen, specDefinition) {
+      let args = [desc, skipWhen];
+      if (skipWhen && specDefinition) {
+        args = [desc, specDefinition];
+      }
+      const suite = _super.fdescribe.apply(this, args);
+      return checkSuiteSkipped(suite, (skipWhen && specDefinition) ? skipWhen : null);
+    };
+
+    global.xdescribe = function (desc, skipWhen, specDefinition) {
+      let args = [desc, skipWhen];
+      if (skipWhen && specDefinition) {
+        args = [desc, specDefinition];
+      }
+      const suite = _super.xdescribe.apply(this, args);
+      return checkSuiteSkipped(suite, (skipWhen && specDefinition) ? skipWhen : null);
+    };
+
+  };
+
+  // Custom reporter to summarize skipped tests
+  module.exports.reporter = function () {
+    var total = 0;
+    var skipped = 0;
+
+    const ansi = {
+      green: '\x1B[32m',
+      red: '\x1B[31m',
+      yellow: '\x1B[33m',
+      none: '\x1B[0m'
+    };
+
+    function colorize(color, str) {
+      return ansi[color] + str + ansi.none;
+    }
+
+    return {
+      jasmineStarted: function () {},
+      suiteStarted: function () {},
+      specStarted: function () {},
+      specDone: function (result) {
+        if (result.status === 'disabled') {
+          skipped++;
+        }
+        total++;
+      },
+      suiteDone: function () {},
+      jasmineDone: function () {
+        if (skipped > 0) {
+          console.log(colorize('yellow', '-------------------------------------------'));
+          console.log(colorize('yellow', 'WARNING: Some tests were skipped: ' + skipped + '/' + total));
+          console.log(colorize('yellow', '-------------------------------------------'));
+        }
+      }
+    };
+  };
+})();

--- a/src/test-e2e/types.d.ts
+++ b/src/test-e2e/types.d.ts
@@ -1,0 +1,5 @@
+// Add typings for overloads that take a skip function
+
+declare function describe(description: string, skipWhen: () => boolean, specDefinitions: () => void): any;
+declare function fdescribe(description: string, skipWhen: () => boolean, specDefinitions: () => void): any;
+declare function xdescribe(description: string, skipWhen: () => boolean, specDefinitions: () => void): any;


### PR DESCRIPTION
e.g. Skip tests that require multiple Cloud Foundries if there is only one.