### PR TITLE
Change shell in git-metadata

### DIFF
--- a/build/store-git-metadata.sh
+++ b/build/store-git-metadata.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Store the git metadata - only dependency is the git binary
 


### PR DESCRIPTION
This fixes the git metadata script. As it uses BASH features, it should set the shell to `bash`.
The corresponding changes in the docker-image-resource are in https://github.com/irfanhabib/docker-image-resource/commit/ed654765ae844a5da0e237111e116fb4b6d8990f