### PR TITLE
Fix redirect with SSO and Fix bug caused by extra slash in AutoRegUrl

### DIFF
--- a/src/backend/app-core/auth.go
+++ b/src/backend/app-core/auth.go
@@ -92,7 +92,11 @@ func (p *portalProxy) initSSOlogin(c echo.Context) error {
 }
 
 func getSSORedirectUri(state string) string {
-	return fmt.Sprintf("%s/pp/v1/auth/sso_login_callback?state=%s", state, url.QueryEscape(state))
+	baseURL, _ := url.Parse(state)
+	baseURL.Path = ""
+	baseURL.RawQuery = ""
+	baseURLString := strings.TrimRight(baseURL.String(), "?")
+	return fmt.Sprintf("%s/pp/v1/auth/sso_login_callback?state=%s", baseURLString, url.QueryEscape(state))
 }
 
 func (p *portalProxy) loginToUAA(c echo.Context) error {
@@ -398,6 +402,7 @@ func (p *portalProxy) logoutOfCNSI(c echo.Context) error {
 	}
 
 	// If cnsi is cf AND cf is auto-register only clear the entry
+	p.Config.AutoRegisterCFUrl = strings.TrimRight(p.Config.AutoRegisterCFUrl, "/")
 	if cnsiRecord.CNSIType == "cf" && p.GetConfig().AutoRegisterCFUrl == cnsiRecord.APIEndpoint.String() {
 		log.Debug("Setting token record as disconnected")
 

--- a/src/backend/cloudfoundry/main.go
+++ b/src/backend/cloudfoundry/main.go
@@ -147,6 +147,7 @@ func (c *CloudFoundrySpecification) cfLoginHook(context echo.Context) error {
 
 func (c *CloudFoundrySpecification) fetchAutoRegisterEndpoint() (string, interfaces.CNSIRecord, error) {
 	cfAPI := c.portalProxy.GetConfig().AutoRegisterCFUrl
+	cfAPI = strings.TrimRight(cfAPI, "/")
 
 	if cfAPI == "" {
 		return "", interfaces.CNSIRecord{}, nil

--- a/src/frontend/app/features/login/login-page/login-page.component.ts
+++ b/src/frontend/app/features/login/login-page/login-page.component.ts
@@ -77,8 +77,11 @@ export class LoginPageComponent implements OnInit, OnDestroy {
 
   login() {
     if (this.ssoLogin) {
-      const returnUrl = encodeURI(window.location.protocol + '//' + window.location.hostname +
-        (window.location.port ? ':' + window.location.port : ''));
+      const returnUrl = encodeURIComponent(window.location.protocol + '//' + window.location.hostname +
+        (window.location.port ? ':' + window.location.port : '') +
+          (this.redirect ? this.redirect.path + '?' +
+              Object.keys(this.redirect.queryParams).map(k => k + '=' + this.redirect.queryParams[k]).join('&') : '/')
+      );
       window.open('/pp/v1/auth/sso_login?state=' + returnUrl, '_self');
       this.busy$ = new Observable<boolean>((observer) => {
         observer.next(true);

--- a/src/frontend/app/features/login/login-page/login-page.component.ts
+++ b/src/frontend/app/features/login/login-page/login-page.component.ts
@@ -75,13 +75,18 @@ export class LoginPageComponent implements OnInit, OnDestroy {
     this.subscription.unsubscribe();
   }
 
+  formSSOredirectURL() {
+      const queryKeys = this.redirect ? Object.keys(this.redirect.queryParams) : undefined;
+      return window.location.protocol + '//' + window.location.hostname +
+      (window.location.port ? ':' + window.location.port : '') +
+      (this.redirect ?
+          this.redirect.path +
+          (queryKeys.length > 0 ? '?' + queryKeys.map(k => k + '=' + this.redirect.queryParams[k]).join('&') : '') : '/');
+  }
+
   login() {
     if (this.ssoLogin) {
-      const returnUrl = encodeURIComponent(window.location.protocol + '//' + window.location.hostname +
-        (window.location.port ? ':' + window.location.port : '') +
-          (this.redirect ? this.redirect.path + '?' +
-              Object.keys(this.redirect.queryParams).map(k => k + '=' + this.redirect.queryParams[k]).join('&') : '/')
-      );
+      const returnUrl = encodeURIComponent(this.formSSOredirectURL());
       window.open('/pp/v1/auth/sso_login?state=' + returnUrl, '_self');
       this.busy$ = new Observable<boolean>((observer) => {
         observer.next(true);


### PR DESCRIPTION
This PR allows Stratos to redirect back to original URL after an SSO login. It works by passing the path and query params to the state when initiating the SSO flow.

It also fixes a bug that caused the console to attempt to register endpoint twice when the AUTO_REG_CF_URL was set with an ending slash.

https://github.com/cloudfoundry-incubator/stratos/issues/2712