### PR TITLE
Two loading changes

### DIFF
--- a/src/frontend/app/shared/components/loading-page/loading-page.component.ts
+++ b/src/frontend/app/shared/components/loading-page/loading-page.component.ts
@@ -1,11 +1,12 @@
-
-import { of as observableOf, Observable, combineLatest } from 'rxjs';
 import { animate, style, transition, trigger } from '@angular/animations';
 import { Component, Input, OnInit } from '@angular/core';
-import { filter, first, startWith, map } from 'rxjs/operators';
-import { EntityMonitorFactory } from '../../monitors/entity-monitor.factory.service';
 import { schema } from 'normalizr';
+import { combineLatest, Observable, of as observableOf } from 'rxjs';
+import { filter, first, map, startWith, debounceTime } from 'rxjs/operators';
+
 import { EntityMonitor } from '../../monitors/entity-monitor';
+import { EntityMonitorFactory } from '../../monitors/entity-monitor.factory.service';
+
 
 @Component({
   selector: 'app-loading-page',
@@ -23,7 +24,6 @@ import { EntityMonitor } from '../../monitors/entity-monitor';
   ]
 })
 export class LoadingPageComponent implements OnInit {
-
 
   constructor(private entityMonitorFactory: EntityMonitorFactory) { }
 
@@ -78,7 +78,20 @@ export class LoadingPageComponent implements OnInit {
   }
 
   private buildFromMonitor(monitor: EntityMonitor) {
-    this.isLoading = monitor.isFetchingEntity$;
     this.isDeleting = monitor.isDeletingEntity$;
+    this.isLoading = combineLatest(
+      monitor.isFetchingEntity$.pipe(
+        // There's a brief amount of time between the monitor returning an initial 'false' value before the validation code kicks
+        // in and marks as 'updating' (true + false --> false + false --> false --> true). Add some artificial lag here until we find a
+        // better solution.. see #2779
+        debounceTime(50)
+      ),
+      monitor.updatingSection$
+    ).pipe(
+      map(([fetching, updating]) => {
+        return fetching || updating._root_.busy;
+      }),
+      startWith(true),
+    );
   }
 }

--- a/src/frontend/app/shared/user-permission.directive.ts
+++ b/src/frontend/app/shared/user-permission.directive.ts
@@ -1,8 +1,11 @@
 import { Directive, Input, OnDestroy, OnInit, TemplateRef, ViewContainerRef } from '@angular/core';
-import { Subscription } from 'rxjs';
-
+import { Subscription, Observable, of as observableOf } from 'rxjs';
+import { Store } from '@ngrx/store';
+import { switchMap } from 'rxjs/operators';
 import { CurrentUserPermissions } from '../core/current-user-permissions.config';
 import { CurrentUserPermissionsService } from '../core/current-user-permissions.service';
+import { AppState } from '../store/app-state';
+import { waitForCFPermissions } from '../features/cloud-foundry/cf.helpers';
 
 @Directive({
   selector: '[appUserPermission]'
@@ -24,17 +27,20 @@ export class UserPermissionDirective implements OnDestroy, OnInit {
   private canSub: Subscription;
 
   constructor(
+    private store: Store<AppState>,
     private templateRef: TemplateRef<any>,
     private viewContainer: ViewContainerRef,
     private currentUserPermissionsService: CurrentUserPermissionsService,
   ) { }
 
   public ngOnInit() {
-    this.canSub = this.currentUserPermissionsService.can(
-      this.appUserPermission,
-      this.appUserPermissionEndpointGuid,
-      this.getOrgOrSpaceGuid(),
-      this.getSpaceGuid()
+    this.canSub = this.waitForEndpointPermissions(this.appUserPermissionEndpointGuid).pipe(
+      switchMap(() => this.currentUserPermissionsService.can(
+        this.appUserPermission,
+        this.appUserPermissionEndpointGuid,
+        this.getOrgOrSpaceGuid(),
+        this.getSpaceGuid()
+      ))
     ).subscribe(
       can => {
         if (can) {
@@ -44,6 +50,10 @@ export class UserPermissionDirective implements OnDestroy, OnInit {
         }
       }
     );
+  }
+
+  private waitForEndpointPermissions(endpointGuid: string): Observable<any> {
+    return endpointGuid && endpointGuid.length > 0 ? waitForCFPermissions(this.store, endpointGuid) : observableOf(true);
   }
 
   public ngOnDestroy() {


### PR DESCRIPTION
- Show app-loading indicator when entity is 'updating'. This catches case when we have an entity but it's missing inline params. See #2779 for further work
- Before checking if we have permissions in a cf ensure we have fetched permissions for that cf. This avoids some null issues in selectors
