### PR TITLE
Fix invalid status code when backend fails to retrieve appropriate CNSI token record

### DIFF
--- a/src/backend/app-core/passthrough.go
+++ b/src/backend/app-core/passthrough.go
@@ -356,6 +356,8 @@ func (p *portalProxy) doRequest(cnsiRequest *interfaces.CNSIRequest, done chan<-
 	if err != nil {
 		cnsiRequest.Error = err
 		if done != nil {
+			cnsiRequest.StatusCode = 400
+			cnsiRequest.Status = "Unable to retrieve CNSI token record"
 			done <- cnsiRequest
 		}
 		return


### PR DESCRIPTION
Fixes #2774 