### PR TITLE
Fail requests to fetch arbitrary files

### DIFF
--- a/src/backend/app-core/main.go
+++ b/src/backend/app-core/main.go
@@ -729,6 +729,8 @@ func (p *portalProxy) registerRoutes(e *echo.Echo, addSetupMiddleware *setupMidd
 
 	// Serve up static resources
 	if err == nil {
+		log.Debug("Add URL Check Middleware")
+		e.Use(p.urlCheckMiddleware)
 		e.Static("/", staticDir)
 		e.SetHTTPErrorHandler(getUICustomHTTPErrorHandler(staticDir, e.DefaultHTTPErrorHandler))
 		log.Info("Serving static UI resources")

--- a/src/backend/app-core/middleware.go
+++ b/src/backend/app-core/middleware.go
@@ -123,7 +123,7 @@ func (p *portalProxy) urlCheckMiddleware(h echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		log.Debug("urlCheckMiddleware")
 		requestPath := c.Request().URL().Path()
-		if strings.HasPrefix(requestPath, "/../") || strings.HasPrefix(requestPath, "/./..") {
+		if strings.Contains(requestPath, "../") {
 			err := "Invalid path"
 			return interfaces.NewHTTPShadowError(
 				http.StatusBadRequest,

--- a/src/backend/app-core/middleware.go
+++ b/src/backend/app-core/middleware.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/engine/standard"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/SUSE/stratos-ui/config"
 	"github.com/SUSE/stratos-ui/repository/interfaces"
@@ -115,6 +115,23 @@ func sessionCleanupMiddleware(h echo.HandlerFunc) echo.HandlerFunc {
 		context.Clear(req)
 
 		return err
+	}
+}
+
+// This middleware is not required if Echo is upgraded to v3
+func (p *portalProxy) urlCheckMiddleware(h echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		log.Debug("urlCheckMiddleware")
+		requestPath := c.Request().URL().Path()
+		if strings.HasPrefix(requestPath, "/../") || strings.HasPrefix(requestPath, "/./..") {
+			err := "Invalid path"
+			return interfaces.NewHTTPShadowError(
+				http.StatusBadRequest,
+				err,
+				err,
+			)
+		}
+		return h(c)
 	}
 }
 


### PR DESCRIPTION
Fixes #2783 

Issue only occurs when the backend is serving static content (when deployed as CF push or All in one).
Its a bug in the Echo v2 Static middleware, which has been fixed in v3. Currently the Stratos backend uses v2.