### PR TITLE
Add x-frame header to static file servers

### DIFF
--- a/deploy/containers/nginx/conf/nginx.dev.conf
+++ b/deploy/containers/nginx/conf/nginx.dev.conf
@@ -13,8 +13,6 @@ http {
         keepalive                   32;
     }
 
-    add_header                      X-Frame-Options DENY;
-
     include                         mime.types;
     default_type                    application/octet-stream;
     keepalive_timeout               70;
@@ -70,6 +68,7 @@ http {
         location / {
             root                    /usr/share/nginx/html;
             add_header Cache-Control no-cache;
+            add_header X-Frame-Options DENY;
             try_files $uri$args $uri$args/ /index.html /building.html;
         }
     }

--- a/deploy/containers/nginx/conf/nginx.k8s.conf
+++ b/deploy/containers/nginx/conf/nginx.k8s.conf
@@ -13,8 +13,6 @@ http {
         keepalive                   32;
     }
 
-    add_header                      X-Frame-Options DENY;
-
     include                         mime.types;
     default_type                    application/octet-stream;
     keepalive_timeout               70;
@@ -70,6 +68,7 @@ http {
         location / {
             root                    /usr/share/nginx/html;
             add_header Cache-Control no-cache;
+            add_header X-Frame-Options DENY;
             try_files $uri$args $uri$args/ /index.html;
         }
     }

--- a/deploy/stratos-ui-release/jobs/frontend/templates/nginx.conf.erb
+++ b/deploy/stratos-ui-release/jobs/frontend/templates/nginx.conf.erb
@@ -13,8 +13,6 @@ http {
         keepalive                   32;
     }
 
-    add_header                      X-Frame-Options DENY;
-
     include                         /var/vcap/packages/nginx/conf/mime.types;
     default_type                    application/octet-stream;
     keepalive_timeout               70;
@@ -69,6 +67,7 @@ http {
 
         location / {
             root                    /var/vcap/packages/frontend;
+            add_header X-Frame-Options DENY;
             add_header Cache-Control no-cache;
         }
     }

--- a/src/backend/app-core/main.go
+++ b/src/backend/app-core/main.go
@@ -537,7 +537,7 @@ func start(config interfaces.PortalConfig, p *portalProxy, addSetupMiddleware *s
 		AllowCredentials: true,
 	}))
 	e.Use(middleware.SecureWithConfig(middleware.SecureConfig{
-		XFrameOptions: "SAMEORIGIN",
+		XFrameOptions: "DENY",
 	}))
 
 	if !isUpgrade {

--- a/src/backend/app-core/main.go
+++ b/src/backend/app-core/main.go
@@ -536,6 +536,9 @@ func start(config interfaces.PortalConfig, p *portalProxy, addSetupMiddleware *s
 		AllowMethods:     []string{echo.GET, echo.PUT, echo.POST, echo.DELETE},
 		AllowCredentials: true,
 	}))
+	e.Use(middleware.SecureWithConfig(middleware.SecureConfig{
+		XFrameOptions: "SAMEORIGIN",
+	}))
 
 	if !isUpgrade {
 		e.Use(errorLoggingMiddleware)


### PR DESCRIPTION
Fixes #2785
- Add to echo middleware (AIO, cf push)
- Update nginx config (docker-compose, k8+helm)
- Notes - header added twice for jetstream requests where nginx is used.