### PR TITLE
Restrict number of calls to app stats on app wall

### DIFF
--- a/src/frontend/app/core/dispatch-sequencer.ts
+++ b/src/frontend/app/core/dispatch-sequencer.ts
@@ -6,12 +6,12 @@ import { concatMap, delay, filter, map, tap } from 'rxjs/operators';
 import { AppState } from '../store/app-state';
 import { chunkArray } from './utils.service';
 
-export interface DispatchThrottlerAction {
+export interface DispatchSequencerAction {
   id: string;
   action: Action;
 }
 
-export class DispatchThrottler {
+export class DispatchSequencer {
 
   private dispatchRecord: {
     [id: string]: {
@@ -20,9 +20,19 @@ export class DispatchThrottler {
     }
   } = {};
 
-  constructor(private store: Store<AppState>, private chunkSize = 1, private debounceInMs = 5000) { }
+  /**
+   * @param {Store<AppState>} store
+   * @param {number} [batchSize=5]
+   * Multiple requests will be split up into batches of this size
+   * @param {number} [batchDelay=5000]
+   * Delay to apply between each batch
+   * @param {number} [debounceInMs=5000]
+   * Ignore repeat request made within this time period
+   * @memberof DispatchSequencer
+   */
+  constructor(private store: Store<AppState>, private batchSize = 5, private batchDelay = 5000, private debounceInMs = 5000) { }
 
-  private filterAndQueue(actions: DispatchThrottlerAction[]): DispatchThrottlerAction[] {
+  private filterAndQueue(actions: DispatchSequencerAction[]): DispatchSequencerAction[] {
     if (this.debounceInMs) {
       const now = new Date().getTime();
       actions = actions.filter(action => {
@@ -40,7 +50,7 @@ export class DispatchThrottler {
     return actions;
   }
 
-  private dispatch(actions: DispatchThrottlerAction[]) {
+  private dispatch(actions: DispatchSequencerAction[]) {
     actions.forEach(action => {
       this.dispatchRecord[action.id].time = new Date().getTime();
       this.dispatchRecord[action.id].queued = false;
@@ -48,17 +58,18 @@ export class DispatchThrottler {
     });
   }
 
-  public throttle(obs: Observable<DispatchThrottlerAction[]>) {
+  public sequence(obs: Observable<DispatchSequencerAction[]>) {
     return obs.pipe(
       filter(actions => !!actions.length),
       map(actions => this.filterAndQueue(actions)),
       filter(actions => !!actions.length),
       concatMap(filteredActions => {
-        const chunks = chunkArray(filteredActions, this.chunkSize);
+        const chunks = chunkArray(filteredActions, this.batchSize);
         this.dispatch(chunks.shift());
         return observableOf(...chunks);
       }),
-      concatMap(actions => observableOf(actions).pipe(delay(4000))), // TODO:  RC delay until last batch finished
+      // Could be improved by waiting on finish of previous batch
+      concatMap(actions => observableOf(actions).pipe(delay(4000))),
       tap(this.dispatch.bind(this)),
     );
   }

--- a/src/frontend/app/core/dispatch-throttler.ts
+++ b/src/frontend/app/core/dispatch-throttler.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Action, Store } from '@ngrx/store';
 import { interval, Observable, of as observableOf, Subject } from 'rxjs';
-import { delayWhen, filter, map, tap, concatMap, delay, throttleTime } from 'rxjs/operators';
+import { delayWhen, filter, map, tap, concatMap, delay, throttleTime, takeWhile, buffer } from 'rxjs/operators';
 
 import { AppState } from '../store/app-state';
 import { chunkArray } from './utils.service';
@@ -14,32 +14,39 @@ export interface DispatchThrottlerAction {
 @Injectable()
 export class DispatchThrottler {
 
-  private chunking = 10;
-  private ignoreWithinX: number;
+  // private chunking = 1;
+  // private ignoreWithinX: number;
   private dispatchRecord: {
     [id: string]: {
       time: number,
       queued: boolean
     }
   } = {};
-  private dispatched = new Subject();
+  // private dispatched = new Subject();
 
-  constructor(private store: Store<AppState>) {
-    this.dispatched.next(true);
-  }
-
-  setDispatchChunkSize(chunkSize: number) {
-    this.chunking = chunkSize;
+  constructor(private store: Store<AppState>, private chunkSize = 1, private debounceInMs = 5000) {
     // this.dispatched.next(true);
-    // this.dispatched.subscribe();
+
+
+    // this.dispatched.pipe(
+    //   tap(() => console.log('dispatched a')),
+    //   throttleTime(10000),
+    //   tap(() => console.log('dispatched b')),
+    // ).subscribe();
   }
 
-  setDispatchDebounceTime(time: number) {
-    this.ignoreWithinX = time;
-  }
+  // setDispatchChunkSize(chunkSize: number) {
+  //   this.chunking = chunkSize;
+  //   // this.dispatched.next(true);
+  //   // this.dispatched.subscribe();
+  // }
+
+  // setDispatchDebounceTime(time: number) {
+  //   this.ignoreWithinX = time;
+  // }
 
   private dispatch(filteredActions: DispatchThrottlerAction[]) {
-    this.dispatched.next(true);
+    // this.dispatched.next(true);
     filteredActions.forEach(action => {
       this.dispatchRecord[action.id].time = new Date().getTime();
       this.dispatchRecord[action.id].queued = false;
@@ -48,46 +55,142 @@ export class DispatchThrottler {
   }
 
   throttle(actions: DispatchThrottlerAction[]): Observable<any> {
-    // const filteredActions = ;
     return observableOf({ actions }).pipe(
       filter(({ actions }) => !!actions.length),
       map(({ actions }) => {
-        if (this.ignoreWithinX) {
+        if (this.debounceInMs) {
           const now = new Date().getTime();
-          return actions.filter(action => {
+          actions = actions.filter(action => {
             const record = this.dispatchRecord[action.id] || { time: 0, queued: false };
-            return !record.queued && now - record.time > this.ignoreWithinX;
+            // if (!record.queued && now - record.time > this.ignoreWithinX) {
+            //   console.log(action, record);
+            // }
+            return !record.queued && now - record.time > this.debounceInMs;
           });
         }
-        return actions;
-      }),
-      tap(filteredActions => {
-        filteredActions.forEach(action => {
+        actions.forEach(action => {
           if (!this.dispatchRecord[action.id]) {
             this.dispatchRecord[action.id] = { time: 0, queued: false };
           }
           const record = this.dispatchRecord[action.id];
           record.queued = true;
         });
+        // console.log(actions);
+        return actions;
       }),
-      // concatMap(filteredActions => {
-      //   const chunks = chunkArray(filteredActions, this.chunking);
-      //   this.dispatch(chunks[0]);
-      //   return observableOf([], ...chunks.splice(1, chunks.length));
-      // }), // TODO: dispatch first straight away?
+      filter(actions => !!actions.length),
       concatMap(filteredActions => {
-        return observableOf([], ...chunkArray(filteredActions, this.chunking));
+        const chunks = chunkArray(filteredActions, this.chunkSize);
+        this.dispatch(chunks.shift());
+        return observableOf(...chunks);
       }),
-      tap(a => console.log('a', a)),
-      // delayWhen(() => interval(Math.random() * 10000)),
-      delayWhen(() => this.dispatched.pipe(throttleTime(10000))),
-      // (Math.random() * 10000)),
-      // delay(10000),
-      // interval(Math.random() * 5000)
+      concatMap(actions => observableOf(actions).pipe(delay(4000))),
       tap(this.dispatch.bind(this)),
-      tap(a => console.log('b', a)),
+      tap(a => console.log('FINISHED', a))
+
+
+
 
     );
   }
 
+
+  // concatMap(actions => observableOf(...actions).pipe(buffer(interval(5000)))),
+  // concatMap(actions => observableOf(...actions)),
+  // buffer(interval(5000))),
+
+  //       const clicks = fromEvent(document, 'click');
+  // const interval = interval(1000);
+  // const buffered = interval.pipe(buffer(clicks));
+  // buffered.subscribe(x => console.log(x));
+  // concatMap(filteredActions => {
+  //   const chunks = chunkArray(filteredActions, this.chunking);
+  //   this.dispatch(chunks.shift());
+  //   // chunks.splice(1, chunks.length);
+  //   return interval(3000).pipe(
+  //     map(() => chunks.shift()),
+  //     takeWhile(chunk => !!chunk)
+  //   );
+  // }),
+  // // delayWhen(() => interval(10000)),
+  // tap(this.dispatch.bind(this)),
+
+  // throttle(actions: DispatchThrottlerAction[]): Observable<any> {
+  //   // const filteredActions = ;
+  //   return observableOf({ actions }).pipe(
+  //     filter(({ actions }) => !!actions.length),
+  //     map(({ actions }) => {
+
+  //       if (this.ignoreWithinX) {
+  //         const now = new Date().getTime();
+  //         actions = actions.filter(action => {
+  //           const record = this.dispatchRecord[action.id] || { time: 0, queued: false };
+  //           if (!record.queued && now - record.time > this.ignoreWithinX) {
+  //             console.log(action, record);
+  //           }
+  //           return !record.queued && now - record.time > this.ignoreWithinX;
+  //         });
+  //         // console.log(actions, a);
+  //         // return a;
+  //       }
+  //       actions.forEach(action => {
+  //         if (!this.dispatchRecord[action.id]) {
+  //           this.dispatchRecord[action.id] = { time: 0, queued: false };
+  //         }
+  //         const record = this.dispatchRecord[action.id];
+  //         record.queued = true;
+  //       });
+  //       // console.log(actions);
+  //       return actions;
+  //     }),
+  //     // tap(filteredActions => {
+  //     //   filteredActions.forEach(action => {
+  //     //     if (!this.dispatchRecord[action.id]) {
+  //     //       this.dispatchRecord[action.id] = { time: 0, queued: false };
+  //     //     }
+  //     //     const record = this.dispatchRecord[action.id];
+  //     //     record.queued = true;
+  //     //   });
+  //     // }),
+  //     filter(actions => !!actions.length),
+  //     concatMap(filteredActions => {
+  //       const chunks = chunkArray(filteredActions, this.chunking);
+  //       this.dispatch(chunks.shift());
+  //       // chunks.splice(1, chunks.length);
+  //       return interval(3000).pipe(
+  //         map(() => chunks.shift()),
+  //         takeWhile(chunk => !!chunk)
+  //       );
+  //     }),
+  //     // delayWhen(() => interval(10000)),
+  //     tap(this.dispatch.bind(this)),
+
+  //     tap(a => console.log('FINISHED', a)),
+
+  //   );
+  // }
+
 }
+        // return observableOf([], ...chunks.splice(1, chunks.length));
+        // .pipe(delay(10000))
+
+ // concatMap(filteredActions => {
+      //   return observableOf([], ...chunkArray(filteredActions, this.chunking));
+      // }),
+      // delay()
+      // tap(a => console.log('before delay', a)),
+      // // delayWhen(() => interval(Math.random() * 10000)),
+      // delayWhen(() => {
+      //   return interval(Math.random() * 10000).pipe(tap(() => console.log('interval fired')));
+
+      //   // return this.dispatched.pipe(
+      //   //   tap(() => console.log('dispatched a')),
+      //   //   throttleTime(10000),
+      //   //   tap(() => console.log('dispatched b')),
+      //   // );
+
+      // }),
+      // // (Math.random() * 10000)),
+      // // delay(10000),
+      // // interval(Math.random() * 5000)
+      // tap(this.dispatch.bind(this)),

--- a/src/frontend/app/core/dispatch-throttler.ts
+++ b/src/frontend/app/core/dispatch-throttler.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Action, Store } from '@ngrx/store';
-import { interval, Observable, of as observableOf, Subject } from 'rxjs';
-import { delayWhen, filter, map, tap, concatMap, delay, throttleTime, takeWhile, buffer } from 'rxjs/operators';
+import { Observable, of as observableOf } from 'rxjs';
+import { concatMap, delay, filter, map, tap } from 'rxjs/operators';
 
 import { AppState } from '../store/app-state';
 import { chunkArray } from './utils.service';
@@ -11,186 +11,55 @@ export interface DispatchThrottlerAction {
   action: Action;
 }
 
-@Injectable()
 export class DispatchThrottler {
 
-  // private chunking = 1;
-  // private ignoreWithinX: number;
   private dispatchRecord: {
     [id: string]: {
       time: number,
       queued: boolean
     }
   } = {};
-  // private dispatched = new Subject();
 
-  constructor(private store: Store<AppState>, private chunkSize = 1, private debounceInMs = 5000) {
-    // this.dispatched.next(true);
+  constructor(private store: Store<AppState>, private chunkSize = 1, private debounceInMs = 5000) { }
 
-
-    // this.dispatched.pipe(
-    //   tap(() => console.log('dispatched a')),
-    //   throttleTime(10000),
-    //   tap(() => console.log('dispatched b')),
-    // ).subscribe();
+  private filterAndQueue(actions: DispatchThrottlerAction[]): DispatchThrottlerAction[] {
+    if (this.debounceInMs) {
+      const now = new Date().getTime();
+      actions = actions.filter(action => {
+        const record = this.dispatchRecord[action.id] || { time: 0, queued: false };
+        return !record.queued && now - record.time > this.debounceInMs;
+      });
+    }
+    actions.forEach(action => {
+      if (!this.dispatchRecord[action.id]) {
+        this.dispatchRecord[action.id] = { time: 0, queued: false };
+      }
+      const record = this.dispatchRecord[action.id];
+      record.queued = true;
+    });
+    return actions;
   }
 
-  // setDispatchChunkSize(chunkSize: number) {
-  //   this.chunking = chunkSize;
-  //   // this.dispatched.next(true);
-  //   // this.dispatched.subscribe();
-  // }
-
-  // setDispatchDebounceTime(time: number) {
-  //   this.ignoreWithinX = time;
-  // }
-
-  private dispatch(filteredActions: DispatchThrottlerAction[]) {
-    // this.dispatched.next(true);
-    filteredActions.forEach(action => {
+  private dispatch(actions: DispatchThrottlerAction[]) {
+    actions.forEach(action => {
       this.dispatchRecord[action.id].time = new Date().getTime();
       this.dispatchRecord[action.id].queued = false;
       this.store.dispatch(action.action);
     });
   }
 
-  throttle(actions: DispatchThrottlerAction[]): Observable<any> {
-    return observableOf({ actions }).pipe(
-      filter(({ actions }) => !!actions.length),
-      map(({ actions }) => {
-        if (this.debounceInMs) {
-          const now = new Date().getTime();
-          actions = actions.filter(action => {
-            const record = this.dispatchRecord[action.id] || { time: 0, queued: false };
-            // if (!record.queued && now - record.time > this.ignoreWithinX) {
-            //   console.log(action, record);
-            // }
-            return !record.queued && now - record.time > this.debounceInMs;
-          });
-        }
-        actions.forEach(action => {
-          if (!this.dispatchRecord[action.id]) {
-            this.dispatchRecord[action.id] = { time: 0, queued: false };
-          }
-          const record = this.dispatchRecord[action.id];
-          record.queued = true;
-        });
-        // console.log(actions);
-        return actions;
-      }),
+  public throttle(obs: Observable<DispatchThrottlerAction[]>) {
+    return obs.pipe(
+      filter(actions => !!actions.length),
+      map(actions => this.filterAndQueue(actions)),
       filter(actions => !!actions.length),
       concatMap(filteredActions => {
         const chunks = chunkArray(filteredActions, this.chunkSize);
         this.dispatch(chunks.shift());
         return observableOf(...chunks);
       }),
-      concatMap(actions => observableOf(actions).pipe(delay(4000))),
+      concatMap(actions => observableOf(actions).pipe(delay(4000))), // TODO:  RC delay until last batch finished
       tap(this.dispatch.bind(this)),
-      tap(a => console.log('FINISHED', a))
-
-
-
-
     );
   }
-
-
-  // concatMap(actions => observableOf(...actions).pipe(buffer(interval(5000)))),
-  // concatMap(actions => observableOf(...actions)),
-  // buffer(interval(5000))),
-
-  //       const clicks = fromEvent(document, 'click');
-  // const interval = interval(1000);
-  // const buffered = interval.pipe(buffer(clicks));
-  // buffered.subscribe(x => console.log(x));
-  // concatMap(filteredActions => {
-  //   const chunks = chunkArray(filteredActions, this.chunking);
-  //   this.dispatch(chunks.shift());
-  //   // chunks.splice(1, chunks.length);
-  //   return interval(3000).pipe(
-  //     map(() => chunks.shift()),
-  //     takeWhile(chunk => !!chunk)
-  //   );
-  // }),
-  // // delayWhen(() => interval(10000)),
-  // tap(this.dispatch.bind(this)),
-
-  // throttle(actions: DispatchThrottlerAction[]): Observable<any> {
-  //   // const filteredActions = ;
-  //   return observableOf({ actions }).pipe(
-  //     filter(({ actions }) => !!actions.length),
-  //     map(({ actions }) => {
-
-  //       if (this.ignoreWithinX) {
-  //         const now = new Date().getTime();
-  //         actions = actions.filter(action => {
-  //           const record = this.dispatchRecord[action.id] || { time: 0, queued: false };
-  //           if (!record.queued && now - record.time > this.ignoreWithinX) {
-  //             console.log(action, record);
-  //           }
-  //           return !record.queued && now - record.time > this.ignoreWithinX;
-  //         });
-  //         // console.log(actions, a);
-  //         // return a;
-  //       }
-  //       actions.forEach(action => {
-  //         if (!this.dispatchRecord[action.id]) {
-  //           this.dispatchRecord[action.id] = { time: 0, queued: false };
-  //         }
-  //         const record = this.dispatchRecord[action.id];
-  //         record.queued = true;
-  //       });
-  //       // console.log(actions);
-  //       return actions;
-  //     }),
-  //     // tap(filteredActions => {
-  //     //   filteredActions.forEach(action => {
-  //     //     if (!this.dispatchRecord[action.id]) {
-  //     //       this.dispatchRecord[action.id] = { time: 0, queued: false };
-  //     //     }
-  //     //     const record = this.dispatchRecord[action.id];
-  //     //     record.queued = true;
-  //     //   });
-  //     // }),
-  //     filter(actions => !!actions.length),
-  //     concatMap(filteredActions => {
-  //       const chunks = chunkArray(filteredActions, this.chunking);
-  //       this.dispatch(chunks.shift());
-  //       // chunks.splice(1, chunks.length);
-  //       return interval(3000).pipe(
-  //         map(() => chunks.shift()),
-  //         takeWhile(chunk => !!chunk)
-  //       );
-  //     }),
-  //     // delayWhen(() => interval(10000)),
-  //     tap(this.dispatch.bind(this)),
-
-  //     tap(a => console.log('FINISHED', a)),
-
-  //   );
-  // }
-
 }
-        // return observableOf([], ...chunks.splice(1, chunks.length));
-        // .pipe(delay(10000))
-
- // concatMap(filteredActions => {
-      //   return observableOf([], ...chunkArray(filteredActions, this.chunking));
-      // }),
-      // delay()
-      // tap(a => console.log('before delay', a)),
-      // // delayWhen(() => interval(Math.random() * 10000)),
-      // delayWhen(() => {
-      //   return interval(Math.random() * 10000).pipe(tap(() => console.log('interval fired')));
-
-      //   // return this.dispatched.pipe(
-      //   //   tap(() => console.log('dispatched a')),
-      //   //   throttleTime(10000),
-      //   //   tap(() => console.log('dispatched b')),
-      //   // );
-
-      // }),
-      // // (Math.random() * 10000)),
-      // // delay(10000),
-      // // interval(Math.random() * 5000)
-      // tap(this.dispatch.bind(this)),

--- a/src/frontend/app/core/dispatch-throttler.ts
+++ b/src/frontend/app/core/dispatch-throttler.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@angular/core';
+import { Action, Store } from '@ngrx/store';
+import { Observable, of as observableOf, interval } from 'rxjs';
+import { filter, map, switchMap, tap, throttleTime, delayWhen } from 'rxjs/operators';
+
+import { AppState } from '../store/app-state';
+import { chunkArray } from './utils.service';
+
+export interface DispatchThrottlerAction {
+  id: string;
+  action: Action;
+}
+
+@Injectable()
+export class DispatchThrottler {
+
+  private chunking = 10;
+  private ignoreWithinX: number;
+  private dispatchRecord: {
+    [id: string]: {
+      time: number,
+      queued: boolean
+    }
+  } = {};
+
+  constructor(private store: Store<AppState>) { }
+
+  setDispatchChunkSize(chunkSize: number) {
+    this.chunking = chunkSize;
+  }
+
+  setDispatchDebounceTime(time: number) {
+    this.ignoreWithinX = time;
+  }
+
+  throttle(actions: DispatchThrottlerAction[]): Observable<any> {
+    // const filteredActions = ;
+    return observableOf({ actions }).pipe(
+      filter(({ actions }) => !!actions.length),
+      map(({ actions }) => {
+        if (this.ignoreWithinX) {
+          const now = new Date().getTime();
+          return actions.filter(action => {
+            const record = this.dispatchRecord[action.id] || { time: 0, queued: false };
+            return !record.queued && now - record.time > this.ignoreWithinX;
+          });
+        }
+        return actions;
+      }),
+      tap(filteredActions => {
+        filteredActions.forEach(action => {
+          if (!this.dispatchRecord[action.id]) {
+            this.dispatchRecord[action.id] = { time: 0, queued: false };
+          }
+          const record = this.dispatchRecord[action.id];
+          record.queued = true;
+        });
+      }),
+      switchMap(filteredActions => observableOf([], ...chunkArray(filteredActions, this.chunking))), // TODO: dispatch first straight away?
+      delayWhen(() => interval(Math.random() * 10000)),
+      tap((filteredActions: DispatchThrottlerAction[]) =>
+        filteredActions.forEach(action => {
+          this.dispatchRecord[action.id].time = new Date().getTime();
+          this.dispatchRecord[action.id].queued = false;
+          this.store.dispatch(action.action);
+        })
+      )
+    );
+  }
+
+}

--- a/src/frontend/app/core/utils.service.ts
+++ b/src/frontend/app/core/utils.service.ts
@@ -232,3 +232,11 @@ export function pathSet(path: string, object: any, value: any) {
     object[params[index++]] = value;
   }
 }
+
+export function chunkArray<T = any>(myArray: T[], chunkSize = 1) {
+  const results = [];
+  while (myArray.length) {
+    results.push(myArray.splice(0, chunkSize));
+  }
+  return results;
+}

--- a/src/frontend/app/features/applications/application-wall/application-wall.component.ts
+++ b/src/frontend/app/features/applications/application-wall/application-wall.component.ts
@@ -1,9 +1,11 @@
 import { animate, query, style, transition, trigger } from '@angular/animations';
 import { Component, OnDestroy } from '@angular/core';
-
 import { Store } from '@ngrx/store';
+import { Observable, Subscription } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { CurrentUserPermissions } from '../../../core/current-user-permissions.config';
+import { DispatchThrottler } from '../../../core/dispatch-throttler';
 import { CardAppComponent } from '../../../shared/components/list/list-types/app/card/card-app.component';
 import { CfAppConfigService } from '../../../shared/components/list/list-types/app/cf-app-config.service';
 import { CfAppsDataSource } from '../../../shared/components/list/list-types/app/cf-apps-data-source';
@@ -12,9 +14,6 @@ import { CfOrgSpaceDataService, initCfOrgSpaceService } from '../../../shared/da
 import { CloudFoundryService } from '../../../shared/data-services/cloud-foundry.service';
 import { AppState } from '../../../store/app-state';
 import { applicationSchemaKey } from '../../../store/helpers/entity-factory';
-
-import { map } from 'rxjs/operators';
-import { Observable, Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-application-wall',
@@ -36,7 +35,8 @@ import { Observable, Subscription } from 'rxjs';
     provide: ListConfig,
     useClass: CfAppConfigService
   },
-    CfOrgSpaceDataService]
+    CfOrgSpaceDataService,
+    DispatchThrottler]
 })
 export class ApplicationWallComponent implements OnDestroy {
 

--- a/src/frontend/app/features/applications/application-wall/application-wall.component.ts
+++ b/src/frontend/app/features/applications/application-wall/application-wall.component.ts
@@ -5,7 +5,6 @@ import { Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { CurrentUserPermissions } from '../../../core/current-user-permissions.config';
-import { DispatchThrottler } from '../../../core/dispatch-throttler';
 import { CardAppComponent } from '../../../shared/components/list/list-types/app/card/card-app.component';
 import { CfAppConfigService } from '../../../shared/components/list/list-types/app/cf-app-config.service';
 import { CfAppsDataSource } from '../../../shared/components/list/list-types/app/cf-apps-data-source';
@@ -35,8 +34,8 @@ import { applicationSchemaKey } from '../../../store/helpers/entity-factory';
     provide: ListConfig,
     useClass: CfAppConfigService
   },
-    CfOrgSpaceDataService,
-    DispatchThrottler]
+    CfOrgSpaceDataService
+  ]
 })
 export class ApplicationWallComponent implements OnDestroy {
 

--- a/src/frontend/app/features/applications/create-application/create-application.component.ts
+++ b/src/frontend/app/features/applications/create-application/create-application.component.ts
@@ -1,15 +1,14 @@
-
-import { tap, first, filter } from 'rxjs/operators';
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Subscription } from 'rxjs';
+import { filter, first, tap } from 'rxjs/operators';
 
 import { CfAppsDataSource } from '../../../shared/components/list/list-types/app/cf-apps-data-source';
-import { CfOrgSpaceDataService, CfOrgSpaceSelectMode } from '../../../shared/data-services/cf-org-space-service.service';
+import { CfOrgSpaceDataService } from '../../../shared/data-services/cf-org-space-service.service';
 import { AppState } from '../../../store/app-state';
-import { selectPaginationState } from '../../../store/selectors/pagination.selectors';
 import { applicationSchemaKey } from '../../../store/helpers/entity-factory';
-import { PaginationMonitorFactory } from '../../../shared/monitors/pagination-monitor.factory';
+import { selectPaginationState } from '../../../store/selectors/pagination.selectors';
+
 
 @Component({
   selector: 'app-create-application',

--- a/src/frontend/app/shared/components/list/list-types/app/cf-app-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/cf-app-config.service.ts
@@ -33,10 +33,9 @@ export class CfAppConfigService extends ListConfig<APIResource> implements IList
     private utilsService: UtilsService,
     private appStateService: ApplicationStateService,
     private cfOrgSpaceService: CfOrgSpaceDataService,
-    private throttler: DispatchThrottler
   ) {
     super();
-    this.appsDataSource = new CfAppsDataSource(this.store, throttler);
+    this.appsDataSource = new CfAppsDataSource(this.store, new DispatchThrottler(this.store, 5, 5000));
 
     this.multiFilterConfigs = [
       createListFilterConfig('cf', 'Cloud Foundry', this.cfOrgSpaceService.cf),

--- a/src/frontend/app/shared/components/list/list-types/app/cf-app-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/cf-app-config.service.ts
@@ -2,6 +2,7 @@ import { DatePipe } from '@angular/common';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 
+import { DispatchThrottler } from '../../../../../core/dispatch-throttler';
 import { UtilsService } from '../../../../../core/utils.service';
 import { ListView } from '../../../../../store/actions/list.actions';
 import { AppState } from '../../../../../store/app-state';
@@ -13,7 +14,9 @@ import { IListConfig, IListMultiFilterConfig, ListConfig, ListViewTypes } from '
 import { createListFilterConfig } from '../../list.helper';
 import { CardAppComponent } from './card/card-app.component';
 import { CfAppsDataSource } from './cf-apps-data-source';
-import { TableCellAppCfOrgSpaceHeaderComponent } from './table-cell-app-cforgspace-header/table-cell-app-cforgspace-header.component';
+import {
+  TableCellAppCfOrgSpaceHeaderComponent,
+} from './table-cell-app-cforgspace-header/table-cell-app-cforgspace-header.component';
 import { TableCellAppCfOrgSpaceComponent } from './table-cell-app-cforgspace/table-cell-app-cforgspace.component';
 import { TableCellAppInstancesComponent } from './table-cell-app-instances/table-cell-app-instances.component';
 import { TableCellAppNameComponent } from './table-cell-app-name/table-cell-app-name.component';
@@ -29,10 +32,11 @@ export class CfAppConfigService extends ListConfig<APIResource> implements IList
     private store: Store<AppState>,
     private utilsService: UtilsService,
     private appStateService: ApplicationStateService,
-    private cfOrgSpaceService: CfOrgSpaceDataService
+    private cfOrgSpaceService: CfOrgSpaceDataService,
+    private throttler: DispatchThrottler
   ) {
     super();
-    this.appsDataSource = new CfAppsDataSource(this.store, this);
+    this.appsDataSource = new CfAppsDataSource(this.store, throttler);
 
     this.multiFilterConfigs = [
       createListFilterConfig('cf', 'Cloud Foundry', this.cfOrgSpaceService.cf),

--- a/src/frontend/app/shared/components/list/list-types/app/cf-app-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/cf-app-config.service.ts
@@ -2,7 +2,6 @@ import { DatePipe } from '@angular/common';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 
-import { DispatchThrottler } from '../../../../../core/dispatch-throttler';
 import { UtilsService } from '../../../../../core/utils.service';
 import { ListView } from '../../../../../store/actions/list.actions';
 import { AppState } from '../../../../../store/app-state';
@@ -35,7 +34,7 @@ export class CfAppConfigService extends ListConfig<APIResource> implements IList
     private cfOrgSpaceService: CfOrgSpaceDataService,
   ) {
     super();
-    this.appsDataSource = new CfAppsDataSource(this.store, new DispatchThrottler(this.store, 1, 5000));
+    this.appsDataSource = new CfAppsDataSource(this.store);
 
     this.multiFilterConfigs = [
       createListFilterConfig('cf', 'Cloud Foundry', this.cfOrgSpaceService.cf),

--- a/src/frontend/app/shared/components/list/list-types/app/cf-app-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/cf-app-config.service.ts
@@ -35,7 +35,7 @@ export class CfAppConfigService extends ListConfig<APIResource> implements IList
     private cfOrgSpaceService: CfOrgSpaceDataService,
   ) {
     super();
-    this.appsDataSource = new CfAppsDataSource(this.store, new DispatchThrottler(this.store, 5, 5000));
+    this.appsDataSource = new CfAppsDataSource(this.store, new DispatchThrottler(this.store, 1, 5000));
 
     this.multiFilterConfigs = [
       createListFilterConfig('cf', 'Cloud Foundry', this.cfOrgSpaceService.cf),

--- a/src/frontend/app/shared/components/list/list-types/app/cf-apps-data-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/cf-apps-data-source.ts
@@ -2,7 +2,7 @@ import { Store } from '@ngrx/store';
 import { schema } from 'normalizr';
 import { Subscription } from 'rxjs';
 import { tag } from 'rxjs-spy/operators/tag';
-import { debounceTime, distinctUntilChanged, withLatestFrom, map, switchMap } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, withLatestFrom, map, switchMap, concatMap, mergeMap } from 'rxjs/operators';
 
 import { DispatchThrottler } from '../../../../../core/dispatch-throttler';
 import { getRowMetadata } from '../../../../../features/cloud-foundry/cf.helpers';
@@ -85,7 +85,7 @@ export class CfAppsDataSource extends ListDataSource<APIResource> {
       destroy: () => this.statsSub.unsubscribe()
     });
 
-    throttler.setDispatchDebounceTime(5000);
+    throttler.setDispatchDebounceTime(10000);
 
     this.statsSub = this.page$.pipe(
       // The page observable will fire often, here we're only interested in updating the stats on actual page changes
@@ -113,7 +113,7 @@ export class CfAppsDataSource extends ListDataSource<APIResource> {
         });
         return actions;
       }),
-      switchMap(throttler.throttle.bind(throttler)),
+      mergeMap(throttler.throttle.bind(throttler)),
       tag('stat-obs')).subscribe();
   }
 }


### PR DESCRIPTION
Fixes #1857

As per issue.. Cover two cases where we might spam stats requests on the app wall
1) User has large page size containing a high number of started apps (worst case scenario 80 simultaneous requests)
2) User switches between pages containing a high number of started apps, stats were requested on each page change (worst case scenario 80 requests per page change)

We now batch up requests and also ignore new requests if made within a short amount of time
