### PR TITLE
Exclude stopped app's from instance counts used with instance quotas

### DIFF
--- a/src/frontend/app/core/cf.helpers.ts
+++ b/src/frontend/app/core/cf.helpers.ts
@@ -1,8 +1,13 @@
 import { APIResource } from '../store/types/api.types';
 import { IApp } from './cf-api.types';
+import { CfApplicationState } from '../store/types/application.types';
 
-export function startedAppInstances(apps: APIResource<IApp>[]): number {
-  return apps ? apps
-    .filter(app => app.entity.state === 'STARTED')
-    .map(app => app.entity.instances).reduce((x, sum) => x + sum, 0) : 0;
+export function getStartedAppInstanceCount(apps: APIResource<IApp>[]): number {
+  if (!apps || !apps.length) {
+    return 0;
+  }
+  return apps
+    .filter(app => app.entity.state === CfApplicationState.STARTED)
+    .map(app => app.entity.instances)
+    .reduce((x, sum) => x + sum, 0);
 }

--- a/src/frontend/app/core/cf.helpers.ts
+++ b/src/frontend/app/core/cf.helpers.ts
@@ -1,0 +1,8 @@
+import { APIResource } from '../store/types/api.types';
+import { IApp } from './cf-api.types';
+
+export function startedAppInstances(apps: APIResource<IApp>[]): number {
+  return apps ? apps
+    .filter(app => app.entity.state === 'STARTED')
+    .map(app => app.entity.instances).reduce((x, sum) => x + sum, 0) : 0;
+}

--- a/src/frontend/app/features/cloud-foundry/services/cloud-foundry-organization.service.ts
+++ b/src/frontend/app/features/cloud-foundry/services/cloud-foundry-organization.service.ts
@@ -6,6 +6,7 @@ import { filter, map, switchMap } from 'rxjs/operators';
 
 import { IServiceInstance } from '../../../core/cf-api-svc.types';
 import { IApp, IOrganization, IPrivateDomain, IQuotaDefinition, ISpace } from '../../../core/cf-api.types';
+import { startedAppInstances } from '../../../core/cf.helpers';
 import { EntityService } from '../../../core/entity-service';
 import { EntityServiceFactory } from '../../../core/entity-service-factory.service';
 import { CfUserService } from '../../../shared/data-services/cf-user.service';
@@ -122,9 +123,7 @@ export class CloudFoundryOrganizationService {
     this.apps$ = this.spaces$.pipe(this.getFlattenedList('apps'));
     this.appInstances$ = this.apps$.pipe(
       filter($apps => !!$apps),
-      map(a => {
-        return a ? a.map(app => app.entity.instances).reduce((x, sum) => x + sum, 0) : 0;
-      })
+      map(startedAppInstances)
     );
 
     this.totalMem$ = this.apps$.pipe(map(a => this.cfEndpointService.getMetricFromApps(a, 'memory')));

--- a/src/frontend/app/features/cloud-foundry/services/cloud-foundry-organization.service.ts
+++ b/src/frontend/app/features/cloud-foundry/services/cloud-foundry-organization.service.ts
@@ -6,7 +6,7 @@ import { filter, map, switchMap } from 'rxjs/operators';
 
 import { IServiceInstance } from '../../../core/cf-api-svc.types';
 import { IApp, IOrganization, IPrivateDomain, IQuotaDefinition, ISpace } from '../../../core/cf-api.types';
-import { startedAppInstances } from '../../../core/cf.helpers';
+import { getStartedAppInstanceCount } from '../../../core/cf.helpers';
 import { EntityService } from '../../../core/entity-service';
 import { EntityServiceFactory } from '../../../core/entity-service-factory.service';
 import { CfUserService } from '../../../shared/data-services/cf-user.service';
@@ -123,7 +123,7 @@ export class CloudFoundryOrganizationService {
     this.apps$ = this.spaces$.pipe(this.getFlattenedList('apps'));
     this.appInstances$ = this.apps$.pipe(
       filter($apps => !!$apps),
-      map(startedAppInstances)
+      map(getStartedAppInstanceCount)
     );
 
     this.totalMem$ = this.apps$.pipe(map(a => this.cfEndpointService.getMetricFromApps(a, 'memory')));

--- a/src/frontend/app/features/cloud-foundry/services/cloud-foundry-space.service.ts
+++ b/src/frontend/app/features/cloud-foundry/services/cloud-foundry-space.service.ts
@@ -5,7 +5,7 @@ import { filter, map, switchMap } from 'rxjs/operators';
 
 import { IServiceInstance } from '../../../core/cf-api-svc.types';
 import { IApp, IQuotaDefinition, IRoute, ISpace } from '../../../core/cf-api.types';
-import { startedAppInstances } from '../../../core/cf.helpers';
+import { getStartedAppInstanceCount } from '../../../core/cf.helpers';
 import { EntityService } from '../../../core/entity-service';
 import { EntityServiceFactory } from '../../../core/entity-service-factory.service';
 import { CfUserService } from '../../../shared/data-services/cf-user.service';
@@ -154,7 +154,7 @@ export class CloudFoundrySpaceService {
     );
 
     this.appInstances$ = this.apps$.pipe(
-      map(startedAppInstances)
+      map(getStartedAppInstanceCount)
     );
 
     this.totalMem$ = this.apps$.pipe(

--- a/src/frontend/app/features/cloud-foundry/services/cloud-foundry-space.service.ts
+++ b/src/frontend/app/features/cloud-foundry/services/cloud-foundry-space.service.ts
@@ -5,30 +5,34 @@ import { filter, map, switchMap } from 'rxjs/operators';
 
 import { IServiceInstance } from '../../../core/cf-api-svc.types';
 import { IApp, IQuotaDefinition, IRoute, ISpace } from '../../../core/cf-api.types';
+import { startedAppInstances } from '../../../core/cf.helpers';
 import { EntityService } from '../../../core/entity-service';
 import { EntityServiceFactory } from '../../../core/entity-service-factory.service';
 import { CfUserService } from '../../../shared/data-services/cf-user.service';
 import { PaginationMonitorFactory } from '../../../shared/monitors/pagination-monitor.factory';
-import { GetSpace, GetAllSpaceUsers } from '../../../store/actions/space.actions';
+import { GetAllSpaceUsers, GetSpace } from '../../../store/actions/space.actions';
 import { AppState } from '../../../store/app-state';
 import {
   applicationSchemaKey,
+  cfUserSchemaKey,
   entityFactory,
   routeSchemaKey,
   serviceBindingSchemaKey,
   serviceInstancesSchemaKey,
+  spaceQuotaSchemaKey,
   spaceSchemaKey,
   spaceWithOrgKey,
-  spaceQuotaSchemaKey,
-  cfUserSchemaKey,
 } from '../../../store/helpers/entity-factory';
 import { createEntityRelationKey, createEntityRelationPaginationKey } from '../../../store/helpers/entity-relations.types';
+import {
+  getPaginationObservables,
+  PaginationObservables,
+} from '../../../store/reducers/pagination-reducer/pagination-reducer.helper';
 import { APIResource, EntityInfo } from '../../../store/types/api.types';
+import { CfUser } from '../../../store/types/user.types';
 import { ActiveRouteCfOrgSpace } from '../cf-page.types';
 import { getSpaceRolesString } from '../cf.helpers';
 import { CloudFoundryEndpointService } from './cloud-foundry-endpoint.service';
-import { PaginationObservables, getPaginationObservables } from '../../../store/reducers/pagination-reducer/pagination-reducer.helper';
-import { CfUser } from '../../../store/types/user.types';
 
 const noQuotaDefinition = (orgGuid: string) => ({
   entity: {
@@ -150,9 +154,7 @@ export class CloudFoundrySpaceService {
     );
 
     this.appInstances$ = this.apps$.pipe(
-      map(a => {
-        return a.map(app => app.entity.instances).reduce((i, x) => i + x, 0);
-      })
+      map(startedAppInstances)
     );
 
     this.totalMem$ = this.apps$.pipe(

--- a/src/frontend/app/shared/components/list/list-types/cf-orgs/cf-org-card/cf-org-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-orgs/cf-org-card/cf-org-card.component.ts
@@ -4,7 +4,7 @@ import { combineLatest as observableCombineLatest, Observable, of as observableO
 import { map, switchMap, tap } from 'rxjs/operators';
 
 import { IApp, IOrganization } from '../../../../../../core/cf-api.types';
-import { startedAppInstances } from '../../../../../../core/cf.helpers';
+import { getStartedAppInstanceCount } from '../../../../../../core/cf.helpers';
 import { CurrentUserPermissions } from '../../../../../../core/current-user-permissions.config';
 import { CurrentUserPermissionsService } from '../../../../../../core/current-user-permissions.service';
 import { getOrgRolesString } from '../../../../../../features/cloud-foundry/cf.helpers';
@@ -97,7 +97,7 @@ export class CfOrgCardComponent extends CardCell<APIResource<IOrganization>> imp
 
   setCounts = (apps: APIResource<any>[]) => {
     this.appCount = apps.length;
-    this.instancesCount = startedAppInstances(apps);
+    this.instancesCount = getStartedAppInstanceCount(apps);
   }
 
   setValues = (role: string, apps: APIResource<IApp>[]) => {

--- a/src/frontend/app/shared/components/list/list-types/cf-orgs/cf-org-card/cf-org-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-orgs/cf-org-card/cf-org-card.component.ts
@@ -4,6 +4,7 @@ import { combineLatest as observableCombineLatest, Observable, of as observableO
 import { map, switchMap, tap } from 'rxjs/operators';
 
 import { IApp, IOrganization } from '../../../../../../core/cf-api.types';
+import { startedAppInstances } from '../../../../../../core/cf.helpers';
 import { CurrentUserPermissions } from '../../../../../../core/current-user-permissions.config';
 import { CurrentUserPermissionsService } from '../../../../../../core/current-user-permissions.service';
 import { getOrgRolesString } from '../../../../../../features/cloud-foundry/cf.helpers';
@@ -96,11 +97,7 @@ export class CfOrgCardComponent extends CardCell<APIResource<IOrganization>> imp
 
   setCounts = (apps: APIResource<any>[]) => {
     this.appCount = apps.length;
-    let count = 0;
-    apps.forEach(a => {
-      count += a.entity.instances;
-    });
-    this.instancesCount = count;
+    this.instancesCount = startedAppInstances(apps);
   }
 
   setValues = (role: string, apps: APIResource<IApp>[]) => {

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces/cf-space-card/cf-space-card.component.html
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces/cf-space-card/cf-space-card.component.html
@@ -12,7 +12,7 @@
   </app-meta-card-item>
   <app-meta-card-item>
     <app-meta-card-key>App Instances</app-meta-card-key>
-    <app-meta-card-value>{{appInstancesCount }} / {{ appIntancesLimit | infinityPipe }}</app-meta-card-value>
+    <app-meta-card-value>{{appInstancesCount }} / {{ appInstancesLimit | infinityPipe }}</app-meta-card-value>
   </app-meta-card-item>
   <app-meta-card-item>
     <app-meta-card-key>Service Instances</app-meta-card-key>

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces/cf-space-card/cf-space-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces/cf-space-card/cf-space-card.component.ts
@@ -2,12 +2,18 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable, Subscription } from 'rxjs';
 import { map, switchMap, tap } from 'rxjs/operators';
+
 import { ISpace } from '../../../../../../core/cf-api.types';
+import { startedAppInstances } from '../../../../../../core/cf.helpers';
 import { CurrentUserPermissions } from '../../../../../../core/current-user-permissions.config';
 import { CurrentUserPermissionsService } from '../../../../../../core/current-user-permissions.service';
 import { getSpaceRolesString } from '../../../../../../features/cloud-foundry/cf.helpers';
-import { CloudFoundryEndpointService } from '../../../../../../features/cloud-foundry/services/cloud-foundry-endpoint.service';
-import { CloudFoundryOrganizationService } from '../../../../../../features/cloud-foundry/services/cloud-foundry-organization.service';
+import {
+  CloudFoundryEndpointService,
+} from '../../../../../../features/cloud-foundry/services/cloud-foundry-endpoint.service';
+import {
+  CloudFoundryOrganizationService,
+} from '../../../../../../features/cloud-foundry/services/cloud-foundry-organization.service';
 import { RouterNav } from '../../../../../../store/actions/router.actions';
 import { AppState } from '../../../../../../store/app-state';
 import { entityFactory, spaceSchemaKey } from '../../../../../../store/helpers/entity-factory';
@@ -32,7 +38,7 @@ export class CfSpaceCardComponent extends CardCell<APIResource<ISpace>> implemen
   serviceInstancesCount: number;
   appInstancesCount: number;
   serviceInstancesLimit: number;
-  appIntancesLimit: number;
+  appInstancesLimit: number;
   orgGuid: string;
   normalisedMemoryUsage: number;
   memoryLimit: number;
@@ -103,16 +109,7 @@ export class CfSpaceCardComponent extends CardCell<APIResource<ISpace>> implemen
 
   setCounts = () => {
     this.appCount = this.row.entity.apps ? this.row.entity.apps.length : 0;
-    let count = 0;
-    if (this.appCount > 0) {
-      this.row.entity.apps.forEach(a => {
-        count += a.entity.instances;
-      });
-    } else {
-      count = 0;
-    }
-
-    this.appInstancesCount = count;
+    this.appInstancesCount = startedAppInstances(this.row.entity.apps);
     this.serviceInstancesCount = this.row.entity.service_instances ? this.row.entity.service_instances.length : 0;
   }
 
@@ -135,7 +132,7 @@ export class CfSpaceCardComponent extends CardCell<APIResource<ISpace>> implemen
         metadata: null
       };
     }
-    this.appIntancesLimit = quotaDefinition.entity.app_instance_limit;
+    this.appInstancesLimit = quotaDefinition.entity.app_instance_limit;
     this.serviceInstancesLimit = quotaDefinition.entity.total_services;
     this.memoryLimit = quotaDefinition.entity.memory_limit;
     this.normalisedMemoryUsage = this.memoryTotal / this.memoryLimit * 100;

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces/cf-space-card/cf-space-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces/cf-space-card/cf-space-card.component.ts
@@ -4,7 +4,7 @@ import { Observable, Subscription } from 'rxjs';
 import { map, switchMap, tap } from 'rxjs/operators';
 
 import { ISpace } from '../../../../../../core/cf-api.types';
-import { startedAppInstances } from '../../../../../../core/cf.helpers';
+import { getStartedAppInstanceCount } from '../../../../../../core/cf.helpers';
 import { CurrentUserPermissions } from '../../../../../../core/current-user-permissions.config';
 import { CurrentUserPermissionsService } from '../../../../../../core/current-user-permissions.service';
 import { getSpaceRolesString } from '../../../../../../features/cloud-foundry/cf.helpers';
@@ -109,7 +109,7 @@ export class CfSpaceCardComponent extends CardCell<APIResource<ISpace>> implemen
 
   setCounts = () => {
     this.appCount = this.row.entity.apps ? this.row.entity.apps.length : 0;
-    this.appInstancesCount = startedAppInstances(this.row.entity.apps);
+    this.appInstancesCount = getStartedAppInstanceCount(this.row.entity.apps);
     this.serviceInstancesCount = this.row.entity.service_instances ? this.row.entity.service_instances.length : 0;
   }
 


### PR DESCRIPTION
- Instances from stopped apps do not apply to org/space instance quotas
- See https://docs.cloudfoundry.org/adminguide/quota-plans.html `app_instance_limit`
- Covers app instance counts on cf org cards list, org space cards list, org summary and space summary
- Fixes #2797
