### PR TITLE
Update README travis badge link to avoid `current` tab confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stratos
 
-<a href="https://travis-ci.org/cloudfoundry-incubator/stratos"><img src="https://travis-ci.org/cloudfoundry-incubator/stratos.svg?branch=v2-master"></a><a style="padding-left: 4px" href="https://codeclimate.com/github/cloudfoundry-incubator/stratos/maintainability"><img src="https://api.codeclimate.com/v1/badges/61af8b605f385e894632/maintainability" /></a>
+<a href="https://travis-ci.org/cloudfoundry-incubator/stratos/branches"><img src="https://travis-ci.org/cloudfoundry-incubator/stratos.svg?branch=v2-master"></a>&nbsp;<a style="padding-left: 4px" href="https://codeclimate.com/github/cloudfoundry-incubator/stratos/maintainability"><img src="https://api.codeclimate.com/v1/badges/61af8b605f385e894632/maintainability" /></a>
 <a href="https://codecov.io/gh/cloudfoundry-incubator/stratos">
 <img src="https://codecov.io/gh/cloudfoundry-incubator/stratos/branch/master/graph/badge.svg"/></a>
 <a href="https://app.zenhub.com/workspace/o/cloudfoundry-incubator/stratos/boards"><img src="https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png"/></a>


### PR DESCRIPTION
- Link to branch tab instead of current
- Add spacing between badges