### PR TITLE
Update nigthly release pipeline to allow helm repo configuration

### DIFF
--- a/deploy/ci/console-nightly-releases.yml
+++ b/deploy/ci/console-nightly-releases.yml
@@ -19,11 +19,11 @@ resources:
     uri: git@github.com:((github-organization))/((github-repository))
     branch: ((stratos-branch))
     private_key: ((github-private-key))
-- name: stratos-master
+- name: helm-repo
   type: git
   source:
-    uri: git@github.com:((github-organization))/((github-repository))
-    branch: master
+    uri: git@github.com:((helm-repo-github-organization))/((helm-repo-github-repository))
+    branch: ((helm-repo-branch))
     private_key: ((github-private-key))
 # Docker Images
 - name: jetstream-image
@@ -134,7 +134,7 @@ jobs:
   - get: stratos
     passed: [build-images]
     trigger: true
-  - get: stratos-master
+  - get: helm-repo
   - do:
     - task: build
       privileged: true

--- a/deploy/ci/tasks/dev-releases/create-nightly-chart.yml
+++ b/deploy/ci/tasks/dev-releases/create-nightly-chart.yml
@@ -33,7 +33,7 @@ run:
       helm package console
       cp console*.tgz ${ROOT_DIR}/helm-chart/console-helm-chart-v${IMAGE_TAG}.tgz
       cd ${ROOT_DIR}/helm-chart/
-      INDEX_FILE=${STRATOS_MASTER}/index.yaml
+      INDEX_FILE=${HELM_REPO}/index.yaml
       CHART_FILE=${ROOT_DIR}/helm-chart/console-helm-chart-v${IMAGE_TAG}.tgz
       if [ -f ${INDEX_FILE} ]; then
             NIGHTLY_EXISTS=$(cat  ${INDEX_FILE} | grep ${TAG})

--- a/deploy/ci/tasks/dev-releases/create-nightly-chart.yml
+++ b/deploy/ci/tasks/dev-releases/create-nightly-chart.yml
@@ -2,7 +2,7 @@
 platform: linux
 inputs:
 - name: stratos
-- name: stratos-master
+- name: helm-repo
 outputs:
 - name: helm-chart
 image_resource:
@@ -22,7 +22,7 @@ run:
       ROOT_DIR=$PWD
       STRATOS=${ROOT_DIR}/stratos
       source ${STRATOS}/deploy/ci/tasks/dev-releases/create-chart-helper.sh
-      STRATOS_MASTER=${ROOT_DIR}/stratos-master
+      HELM_REPO=${ROOT_DIR}/helm-repo
       cd ${STRATOS}/deploy/kubernetes/
       TAG=$(nightlyTag)
       IMAGE_TAG=${TAG}
@@ -66,10 +66,10 @@ run:
               cp  ${INDEX_FILE} ${ROOT_DIR}/helm-chart/
               MERGE_INDEX="--merge index.yaml"
               helm repo index ./ ${MERGE_INDEX} --url https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download/${TAG}/
-              cp index.yaml ${STRATOS_MASTER}/
+              cp index.yaml ${HELM_REPO}/
             fi
       fi
 
       # Update Helm Repository
-      cd ${STRATOS_MASTER}
+      cd ${HELM_REPO}
       setupAndPushChange


### PR DESCRIPTION
Currently it assumes the repo lives in `master`, in future it'll live in `gh-pages`. The official release pipeline already has this