### PR TITLE
Improve performance

### DIFF
--- a/deploy/Dockerfile.all-in-one
+++ b/deploy/Dockerfile.all-in-one
@@ -10,7 +10,7 @@ COPY --chown=stratos:users deploy/db deploy/db
 COPY --chown=stratos:users deploy/all-in-one/config.all-in-one.properties config.properties
 
 RUN npm install \
-    && npm run build-cf \
+    && npm run build \
     && npm run build-backend \
     && npm run deploy-cf
 

--- a/src/backend/app-core/main.go
+++ b/src/backend/app-core/main.go
@@ -734,6 +734,7 @@ func (p *portalProxy) registerRoutes(e *echo.Echo, addSetupMiddleware *setupMidd
 	if err == nil {
 		log.Debug("Add URL Check Middleware")
 		e.Use(p.urlCheckMiddleware)
+		e.Use(middleware.Gzip())
 		e.Static("/", staticDir)
 		e.SetHTTPErrorHandler(getUICustomHTTPErrorHandler(staticDir, e.DefaultHTTPErrorHandler))
 		log.Info("Serving static UI resources")
@@ -760,7 +761,7 @@ func getUICustomHTTPErrorHandler(staticDir string, defaultHandler echo.HTTPError
 }
 
 func getStaticFiles() (string, error) {
-	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	dir, err := filepath.Abs(".")
 	if err == nil {
 		// Look for a folder named 'ui'
 		_, err := os.Stat(dir + "/ui")


### PR DESCRIPTION
Very small change, but huge performance improvement in this PR.

Two changes:

1) Use angular AOT compiler improves processing performance greatly on front-end
2) The angular static output is very large (The main.f361828dc635e1980674.js ~3.75 MB). Using gzip to serve static files reduces this file from 3.75 MB to 866 KB.

I also changed the base path of the static files to be "." (current working directory). This uses the current working directory instead of the location of the binary to determine room path. This helps when an IDE runs your binary in a temp folder, but shouldn't break anything.