### PR TITLE
use cnsi client in deploy.go

### DIFF
--- a/src/backend/cfapppush/deploy.go
+++ b/src/backend/cfapppush/deploy.go
@@ -548,8 +548,8 @@ func (cfAppPush *CFAppPush) getConfigData(echoContext echo.Context, cnsiGuid str
 	repo := coreconfig.NewRepositoryFromFilepath(filePath, func(error) {})
 
 	repo.SetAuthenticationEndpoint(cnsiRecord.AuthorizationEndpoint)
-	repo.SetUAAOAuthClient(cfAppPush.portalProxy.GetConfig().CFClient)
-	repo.SetUAAOAuthClientSecret(cfAppPush.portalProxy.GetConfig().CFClientSecret)
+	repo.SetUAAOAuthClient(cnsiRecord.ClientId)
+	repo.SetUAAOAuthClientSecret(cnsiRecord.ClientSecret)
 	repo.SetAPIEndpoint(cnsiRecord.APIEndpoint.String())
 	repo.SetDopplerEndpoint(cnsiRecord.DopplerLoggingEndpoint)
 	repo.SetSSLDisabled(cnsiRecord.SkipSSLValidation)


### PR DESCRIPTION
This is a refactor of https://github.com/cloudfoundry-incubator/stratos/pull/2553 to use the endpoint's own client id/secret.