### PR TITLE
Fix bug in `generate-tag-files` concourse task

### DIFF
--- a/deploy/ci/console-dev-releases.yml
+++ b/deploy/ci/console-dev-releases.yml
@@ -110,12 +110,16 @@ jobs:
           patch_base_reg: ((patch-base-reg))
           patch_base_tag: ((patch-base-tag))
           tag_commit: "true"
+      - put: mariadb-image
+        params:
           dockerfile: stratos/deploy/db/Dockerfile.mariadb
           build: stratos/deploy/db
           tag: image-tag/v2-alpha-tag
           patch_base_reg: ((patch-base-reg))
           patch_base_tag: ((patch-base-tag))
           tag_commit: "true"
+      - put: ui-image
+        params:
           dockerfile: stratos/deploy/Dockerfile.ui
           build: stratos/
           target_name: prod-build
@@ -123,6 +127,8 @@ jobs:
           patch_base_reg: ((patch-base-reg))
           patch_base_tag: ((patch-base-tag))
           tag_commit: "true"
+- name: create-chart
+  plan:
   - get: stratos
     passed: [build-images]
     trigger: true

--- a/deploy/ci/console-dev-releases.yml
+++ b/deploy/ci/console-dev-releases.yml
@@ -100,7 +100,6 @@ jobs:
           build_args_file: image-tag/build-args
           patch_base_reg: ((patch-base-reg))
           patch_base_tag: ((patch-base-tag))
-          tag_commit: "true"
       - put: postflight-image
         params:
           dockerfile: stratos/deploy/Dockerfile.bk
@@ -109,7 +108,6 @@ jobs:
           tag: image-tag/v2-alpha-tag
           patch_base_reg: ((patch-base-reg))
           patch_base_tag: ((patch-base-tag))
-          tag_commit: "true"
       - put: mariadb-image
         params:
           dockerfile: stratos/deploy/db/Dockerfile.mariadb
@@ -117,7 +115,6 @@ jobs:
           tag: image-tag/v2-alpha-tag
           patch_base_reg: ((patch-base-reg))
           patch_base_tag: ((patch-base-tag))
-          tag_commit: "true"
       - put: ui-image
         params:
           dockerfile: stratos/deploy/Dockerfile.ui
@@ -126,7 +123,6 @@ jobs:
           tag: image-tag/v2-alpha-tag
           patch_base_reg: ((patch-base-reg))
           patch_base_tag: ((patch-base-tag))
-          tag_commit: "true"
 - name: create-chart
   plan:
   - get: stratos

--- a/deploy/ci/console-dev-releases.yml
+++ b/deploy/ci/console-dev-releases.yml
@@ -100,6 +100,7 @@ jobs:
           build_args_file: image-tag/build-args
           patch_base_reg: ((patch-base-reg))
           patch_base_tag: ((patch-base-tag))
+          tag_commit: "true"
       - put: postflight-image
         params:
           dockerfile: stratos/deploy/Dockerfile.bk
@@ -108,23 +109,20 @@ jobs:
           tag: image-tag/v2-alpha-tag
           patch_base_reg: ((patch-base-reg))
           patch_base_tag: ((patch-base-tag))
-      - put: mariadb-image
-        params:
+          tag_commit: "true"
           dockerfile: stratos/deploy/db/Dockerfile.mariadb
           build: stratos/deploy/db
           tag: image-tag/v2-alpha-tag
           patch_base_reg: ((patch-base-reg))
           patch_base_tag: ((patch-base-tag))
-      - put: ui-image
-        params:
+          tag_commit: "true"
           dockerfile: stratos/deploy/Dockerfile.ui
           build: stratos/
           target_name: prod-build
           tag: image-tag/v2-alpha-tag
           patch_base_reg: ((patch-base-reg))
           patch_base_tag: ((patch-base-tag))
-- name: create-chart
-  plan:
+          tag_commit: "true"
   - get: stratos
     passed: [build-images]
     trigger: true

--- a/deploy/ci/console-nightly-releases.yml
+++ b/deploy/ci/console-nightly-releases.yml
@@ -106,7 +106,6 @@ jobs:
           build: stratos/
           target_name:  prod-build
           tag: stratos/deploy/ci/tasks/dev-releases/nightly-tag
-          tag_commit: true
           build_args_file: image-tag/build-args
       - put: postflight-image
         params:
@@ -114,20 +113,17 @@ jobs:
           build: stratos/
           target_name:  postflight-job
           tag: stratos/deploy/ci/tasks/dev-releases/nightly-tag
-          tag_commit: true
       - put: mariadb-image
         params:
           dockerfile: stratos/deploy/db/Dockerfile.mariadb
           build: stratos/deploy/db
           tag: stratos/deploy/ci/tasks/dev-releases/nightly-tag
-          tag_commit: true
       - put: ui-image
         params:
           dockerfile: stratos/deploy/Dockerfile.ui
           build: stratos/
           target_name: prod-build
           tag: stratos/deploy/ci/tasks/dev-releases/nightly-tag
-          tag_commit: true
           prebuild_script: build/store-git-metadata.sh
 - name: create-chart
   plan:

--- a/deploy/ci/tasks/dev-releases/generate-tag-files.yml
+++ b/deploy/ci/tasks/dev-releases/generate-tag-files.yml
@@ -21,7 +21,9 @@ run:
       LATEST_TAG=$(cat package.json | grep version | grep -Po "([0-9\.]?)*")-$(git log -1 --format="%h")
 
       if [ ! -z ${TAG_SUFFIX} ]; then
-        LATEST_TAG=${LATEST_TAG}-${TAG_SUFFIX}
+        if [ "${TAG_SUFFIX}" != "null" ]; then
+          LATEST_TAG=${LATEST_TAG}-${TAG_SUFFIX}
+        fi
       fi
 
 


### PR DESCRIPTION
No change was necessary to the release pipeline to add commit hashes to releases. As of the commit f5b7c16a9ad45c2aa3b23e1c7c3d8004fe68d807 (which didnt make its way into 2.0.1), we are adding commit hashes to the package.json version by default.

1. Fixed a bug where a release could be published with `2.0.0-null`, when no tag suffix was specified. 
2. Removed `tag_commit: true` from Nightly build pipeline, as this would've caused nightly builds to push uniquely named images daily. Support for `tag_commit` was added in the docker-image-resource in commit https://github.com/irfanhabib/docker-image-resource/commit/719a0bf6e85fe35ed72b2e24d97beec59bbe53ca