### PR TITLE
Harden the service wall instance card

### DIFF
--- a/src/frontend/app/features/service-catalog/services.service.ts
+++ b/src/frontend/app/features/service-catalog/services.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { BehaviorSubject, combineLatest as observableCombineLatest, Observable, of as observableOf } from 'rxjs';
-import { combineLatest, filter, first, map, publishReplay, refCount, switchMap, tap } from 'rxjs/operators';
+import { combineLatest, filter, first, map, publishReplay, refCount, switchMap } from 'rxjs/operators';
 
 import {
   IService,

--- a/src/frontend/app/features/services/services/services-wall.service.ts
+++ b/src/frontend/app/features/services/services/services-wall.service.ts
@@ -4,7 +4,6 @@ import { Observable } from 'rxjs';
 import { filter, map, publishReplay, refCount } from 'rxjs/operators';
 
 import { IService } from '../../../core/cf-api-svc.types';
-import { EntityServiceFactory } from '../../../core/entity-service-factory.service';
 import { PaginationMonitorFactory } from '../../../shared/monitors/pagination-monitor.factory';
 import { GetAllServices } from '../../../store/actions/service.actions';
 import { GetServicesForSpace } from '../../../store/actions/space.actions';

--- a/src/frontend/app/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
+++ b/src/frontend/app/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
@@ -12,13 +12,13 @@ import { getIdFromRoute } from '../../../../features/cloud-foundry/cf.helpers';
 import { servicesServiceFactoryProvider } from '../../../../features/service-catalog/service-catalog.helpers';
 import { GetApplication } from '../../../../store/actions/application.actions';
 import {
+  ResetCreateServiceInstanceOrgAndSpaceState,
   ResetCreateServiceInstanceState,
   SetCreateServiceInstance,
   SetCreateServiceInstanceCFDetails,
   SetCreateServiceInstanceServiceGuid,
-  SetServiceInstanceGuid,
-  ResetCreateServiceInstanceOrgAndSpaceState,
   SetCreateServiceInstanceServicePlan,
+  SetServiceInstanceGuid,
 } from '../../../../store/actions/create-service-instance.actions';
 import { GetServiceInstance } from '../../../../store/actions/service-instances.actions';
 import { GetAllAppsInSpace, GetSpace } from '../../../../store/actions/space.actions';

--- a/src/frontend/app/shared/components/add-service-instance/create-service-instance-helper.service.ts
+++ b/src/frontend/app/shared/components/add-service-instance/create-service-instance-helper.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@angular/core';
+import { Inject } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { combineLatest as observableCombineLatest, Observable, of as observableOf } from 'rxjs';
 import { filter, first, map, publishReplay, refCount, share, switchMap } from 'rxjs/operators';
@@ -25,13 +25,16 @@ import {
   spaceSchemaKey,
   spaceWithOrgKey,
 } from '../../../store/helpers/entity-factory';
-import { createEntityRelationKey, createEntityRelationPaginationKey } from '../../../store/helpers/entity-relations/entity-relations.types';
+import {
+  createEntityRelationKey,
+  createEntityRelationPaginationKey,
+} from '../../../store/helpers/entity-relations/entity-relations.types';
 import { getPaginationObservables } from '../../../store/reducers/pagination-reducer/pagination-reducer.helper';
 import { selectCreateServiceInstanceServicePlan } from '../../../store/selectors/create-service-instance.selectors';
 import { APIResource } from '../../../store/types/api.types';
 import { QParam } from '../../../store/types/pagination.types';
-import { PaginationMonitorFactory } from '../../monitors/pagination-monitor.factory';
 import { CF_GUID } from '../../entity.tokens';
+import { PaginationMonitorFactory } from '../../monitors/pagination-monitor.factory';
 
 export class CreateServiceInstanceHelper {
   servicePlanVisibilities$: Observable<APIResource<IServicePlanVisibility>[]>;

--- a/src/frontend/app/shared/components/list/list-cards/card/card.component.ts
+++ b/src/frontend/app/shared/components/list/list-cards/card/card.component.ts
@@ -25,8 +25,10 @@ import {
 import { CfServiceCardComponent } from '../../list-types/cf-services/cf-service-card/cf-service-card.component';
 import { CfSpaceCardComponent } from '../../list-types/cf-spaces/cf-space-card/cf-space-card.component';
 import { CfStacksCardComponent } from '../../list-types/cf-stacks/cf-stacks-card/cf-stacks-card.component';
-import { TableCellCustom, CardCell } from '../../list.types';
-import { ServiceInstanceCardComponent } from '../../list-types/services-wall/service-instance-card/service-instance-card.component';
+import {
+  ServiceInstanceCardComponent,
+} from '../../list-types/services-wall/service-instance-card/service-instance-card.component';
+import { CardCell } from '../../list.types';
 
 export const listCards = [
   CardAppComponent,

--- a/src/frontend/app/shared/components/list/list-types/services-wall/service-instance-card/service-instance-card.component.html
+++ b/src/frontend/app/shared/components/list/list-types/services-wall/service-instance-card/service-instance-card.component.html
@@ -1,6 +1,6 @@
-<app-meta-card class="app-service-card" [actionMenu]="cardMenu" [entityConfig]="entityConfig">
+<app-meta-card *ngIf="serviceInstanceEntity" class="app-service-card" [actionMenu]="cardMenu" [entityConfig]="entityConfig">
   <app-meta-card-title>
-    <div class="app-service-card__title">{{ serviceInstanceEntity?.entity.name }}</div>
+    <div class="app-service-card__title">{{ serviceInstanceEntity.entity.name }}</div>
   </app-meta-card-title>
   <app-meta-card-item>
     <app-meta-card-key>Space</app-meta-card-key>
@@ -14,20 +14,20 @@
   </app-meta-card-item>
   <app-meta-card-item>
     <app-meta-card-key>Service Plan</app-meta-card-key>
-    <app-meta-card-value>{{ serviceInstanceEntity?.entity.service_plan?.entity.name}} </app-meta-card-value>
+    <app-meta-card-value>{{ serviceInstanceEntity.entity.service_plan?.entity.name}} </app-meta-card-value>
   </app-meta-card-item>
   <app-meta-card-item>
     <app-meta-card-key>Applications Attached</app-meta-card-key>
-    <app-meta-card-value>{{ serviceInstanceEntity?.entity.service_bindings.length }} </app-meta-card-value>
+    <app-meta-card-value>{{ serviceInstanceEntity.entity.service_bindings.length }} </app-meta-card-value>
   </app-meta-card-item>
   <app-meta-card-item>
     <app-meta-card-key>Last Updated</app-meta-card-key>
-    <app-meta-card-value>{{ serviceInstanceEntity?.entity.last_operation?.updated_at | date:'medium' }} </app-meta-card-value>
+    <app-meta-card-value>{{ serviceInstanceEntity.entity.last_operation?.updated_at | date:'medium' }} </app-meta-card-value>
   </app-meta-card-item>
   <app-meta-card-item>
     <app-meta-card-key>Dashboard</app-meta-card-key>
     <app-meta-card-value>
-      <div *ngIf="!!serviceInstanceEntity?.entity.dashboard_url ; then dashboardUrl; else none"></div>
+      <div *ngIf="!!serviceInstanceEntity.entity.dashboard_url ; then dashboardUrl; else none"></div>
       <ng-template #dashboardUrl>
         <div class="service-instance-card__link">
           <a class="service-instance-card__icon-link" [href]="serviceInstanceEntity.entity.dashboard_url" target="_blank" appClickStopPropagation>

--- a/src/frontend/app/shared/components/list/list-types/services-wall/service-instance-card/service-instance-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/services-wall/service-instance-card/service-instance-card.component.ts
@@ -1,27 +1,21 @@
-import { Component, OnInit, Input } from '@angular/core';
-import { Store } from '@ngrx/store';
-import { BehaviorSubject, Observable, of as observableOf } from 'rxjs';
+import { Component, Input, OnInit } from '@angular/core';
+import { BehaviorSubject, of as observableOf } from 'rxjs';
 
-import { IServiceInstance, IServiceExtra } from '../../../../../../core/cf-api-svc.types';
-import { ServicesWallService } from '../../../../../../features/services/services/services-wall.service';
-import { AppState } from '../../../../../../store/app-state';
+import { IServiceExtra, IServiceInstance } from '../../../../../../core/cf-api-svc.types';
+import { CurrentUserPermissions } from '../../../../../../core/current-user-permissions.config';
+import { CurrentUserPermissionsService } from '../../../../../../core/current-user-permissions.service';
+import { entityFactory, serviceInstancesSchemaKey } from '../../../../../../store/helpers/entity-factory';
 import { APIResource } from '../../../../../../store/types/api.types';
 import { ServiceActionHelperService } from '../../../../../data-services/service-action-helper.service';
+import { ComponentEntityMonitorConfig } from '../../../../../shared.types';
 import { AppChip } from '../../../../chips/chips.component';
 import { MetaCardMenuItem } from '../../../list-cards/meta-card/meta-card-base/meta-card.component';
 import { CardCell } from '../../../list.types';
-import { CurrentUserPermissionsService } from '../../../../../../core/current-user-permissions.service';
-import { CurrentUserPermissions } from '../../../../../../core/current-user-permissions.config';
-import { ComponentEntityMonitorConfig } from '../../../../../shared.types';
-import { entityFactory, serviceInstancesSchemaKey } from '../../../../../../store/helpers/entity-factory';
 
 @Component({
   selector: 'app-service-instance-card',
   templateUrl: './service-instance-card.component.html',
   styleUrls: ['./service-instance-card.component.scss'],
-  providers: [
-    ServicesWallService
-  ]
 })
 export class ServiceInstanceCardComponent extends CardCell<APIResource<IServiceInstance>> implements OnInit {
   serviceInstanceEntity: APIResource<IServiceInstance>;


### PR DESCRIPTION
- Ensure we only show the template, which requires serviceInstanceEntity, when we have it
- Removed ServicesWallService provider, it's not used (ctor never called)
- Removed/Sorted imports
- Fixes #2814
