### PR TITLE
Update cache-control header

### DIFF
--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -645,6 +645,8 @@ func (p *portalProxy) registerRoutes(e *echo.Echo, addSetupMiddleware *setupMidd
 		pp = e.Group("")
 	}
 
+	pp.Use(p.setSecureCacheContentMiddleware)
+
 	// Add middleware to block requests if unconfigured
 	if addSetupMiddleware.addSetup {
 		go p.SetupPoller(addSetupMiddleware)
@@ -732,6 +734,7 @@ func (p *portalProxy) registerRoutes(e *echo.Echo, addSetupMiddleware *setupMidd
 
 	// Serve up static resources
 	if err == nil {
+		e.Use(p.setStaticCacheContentMiddleware)
 		log.Debug("Add URL Check Middleware")
 		e.Use(p.urlCheckMiddleware)
 		e.Use(middleware.Gzip())

--- a/src/jetstream/middleware.go
+++ b/src/jetstream/middleware.go
@@ -135,6 +135,21 @@ func (p *portalProxy) urlCheckMiddleware(h echo.HandlerFunc) echo.HandlerFunc {
 	}
 }
 
+func (p *portalProxy) setStaticCacheContentMiddleware(h echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		log.Debug("setStaticContentHeadersMiddleware")
+		c.Response().Header().Set("cache-control", "no-cache")
+		return h(c)
+	}
+}
+
+func (p *portalProxy) setSecureCacheContentMiddleware(h echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		c.Response().Header().Set("cache-control", "no-store")
+		return h(c)
+	}
+}
+
 func (p *portalProxy) adminMiddleware(h echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		// if user is an admin, passthrough request


### PR DESCRIPTION
- Static files served via backed (AIO + cf push world) should have `cache-control: no-cache`
- IE caches some https content, therefore jetstream shouldn't cache any requests `cache-control: no-store`

Addresses half of #2807