### PR TITLE
Add websocket support for app stream

### DIFF
--- a/src/jetstream/plugins/cloudfoundry/main.go
+++ b/src/jetstream/plugins/cloudfoundry/main.go
@@ -174,6 +174,9 @@ func (c *CloudFoundrySpecification) AddSessionGroupRoutes(echoGroup *echo.Group)
 
 	// Applications Log Streams
 	echoGroup.GET("/:cnsiGuid/apps/:appGuid/stream", c.appStream)
+
+	// Application Stream
+	echoGroup.GET("/:cnsiGuid/apps/:appGuid/appFirehose", c.appFirehose)
 }
 
 func (c *CloudFoundrySpecification) Info(apiEndpoint string, skipSSLValidation bool) (interfaces.CNSIRecord, interface{}, error) {


### PR DESCRIPTION
This PR adds another websocket API that allows us to stream all firehose events for an application.

This can be used to replace polling for app stats in the front-end.