### PR TITLE
Fix redeclaration causing failed updated of nightly helm chart

### DIFF
--- a/deploy/ci/tasks/dev-releases/create-chart-helper.sh
+++ b/deploy/ci/tasks/dev-releases/create-chart-helper.sh
@@ -41,10 +41,10 @@ setupAndPushChange() {
 }
 
 updateHelmDependency() {
-  START_CWD=$(pwd)
+  local START_CWD=$(pwd)
   cd ${STRATOS}/deploy/kubernetes/console
   # Extract helm repo
-  HELM_REPO=$(cat requirements.yaml | grep repo | sed -e 's/.*repository:\s\(.*\)/\1/p' | head -1)
+  local HELM_REPO=$(cat requirements.yaml | grep repo | sed -e 's/.*repository:\s\(.*\)/\1/p' | head -1)
   helm repo add repo ${HELM_REPO}
   helm dependency update
   cd ${START_CWD}


### PR DESCRIPTION
After building nightly dev images, the helm chart is successfully updated because of: 

```
HELM_REPO=/tmp/build/80754af9/helm-repo
....
HELM_REPO=https://cloudfoundry-incubator.github.io/stratos <- occurrs in funciton
....
+ cd https://cloudfoundry-incubator.github.io/stratos <- invalid
```