### PR TITLE
Add `acceptance` back to e2e entity prefix

### DIFF
--- a/src/test-e2e/helpers/e2e-helpers.ts
+++ b/src/test-e2e/helpers/e2e-helpers.ts
@@ -1,9 +1,9 @@
-import { ElementArrayFinder, browser, by, element as protractorElement} from 'protractor';
+import { browser, by, element as protractorElement, ElementArrayFinder } from 'protractor';
 import { promise, protractor } from 'protractor/built';
 import { ElementFinder } from 'protractor/built/element';
+
 import { LoginPage } from '../login/login.po';
 import { SecretsHelpers } from './secrets-helpers';
-import { e2e } from '../e2e';
 
 
 export enum ConsoleUserType {
@@ -13,7 +13,7 @@ export enum ConsoleUserType {
 
 export class E2EHelpers {
 
-  static e2eItemPrefix = 'e2e.';
+  static e2eItemPrefix = 'acceptance.e2e.';
   static customOrgSpaceLabel = E2EHelpers.e2eItemPrefix + (process.env.CUSTOM_ORG_SPACE_LABEL || process.env.USER);
 
   secrets = new SecretsHelpers();


### PR DESCRIPTION
- Reverting back to original `acceptance.e2e.` value
- The shortened `e2e.` prefix caused issues when trying to select `e2e` org in drop downs (text also matched `e2e.etc` org names)
