### PR TITLE
E2E: Get default stack from CF. Set memory and disk on app.

### DIFF
--- a/src/test-e2e/application/application-deploy-e2e.spec.ts
+++ b/src/test-e2e/application/application-deploy-e2e.spec.ts
@@ -32,8 +32,9 @@ describe('Application Deploy -', function () {
 
   const testApp = e2e.secrets.getDefaultCFEndpoint().testDeployApp || 'nwmac/cf-quick-app';
   const testAppName = ApplicationE2eHelper.createApplicationName();
-  const testAppStack = e2e.secrets.getDefaultCFEndpoint().testDeployAppStack || 'opensuse42';
+  const testAppStack = e2e.secrets.getDefaultCFEndpoint().testDeployAppStack;
   let deployedCommit: promise.Promise<string>;
+  let defaultStack = '';
 
   beforeAll(() => {
     nav = new SideNavigation();
@@ -46,6 +47,13 @@ describe('Application Deploy -', function () {
       .getInfo(ConsoleUserType.admin);
     applicationE2eHelper = new ApplicationE2eHelper(setup);
     cfHelper = new CFHelpers(setup);
+  });
+
+  beforeAll(() => {
+    const that = this;
+    const endpointName = e2e.secrets.getDefaultCFEndpoint().name;
+    const endpointGuid = e2e.helper.getEndpointGuid(e2e.info, endpointName);
+    return cfHelper.fetchDefaultStack(endpointGuid).then(stack => defaultStack = stack);
   });
 
   afterAll(() => {
@@ -280,7 +288,7 @@ describe('Application Deploy -', function () {
         expect(appSummary.cardCfInfo.space.getValue()).toBe(spaceName);
 
         expect(appSummary.cardBuildInfo.buildPack.getValue()).toBe('binary_buildpack');
-        expect(appSummary.cardBuildInfo.stack.getValue()).toBe(testAppStack);
+        expect(appSummary.cardBuildInfo.stack.getValue()).toBe(testAppStack || defaultStack);
 
         appSummary.cardDeployInfo.waitForTitle('Deployment Info');
         expect(appSummary.cardDeployInfo.github.isDisplayed()).toBeTruthy();

--- a/src/test-e2e/application/application-deploy-e2e.spec.ts
+++ b/src/test-e2e/application/application-deploy-e2e.spec.ts
@@ -50,10 +50,7 @@ describe('Application Deploy -', function () {
   });
 
   beforeAll(() => {
-    const that = this;
-    const endpointName = e2e.secrets.getDefaultCFEndpoint().name;
-    const endpointGuid = e2e.helper.getEndpointGuid(e2e.info, endpointName);
-    return cfHelper.fetchDefaultStack(endpointGuid).then(stack => defaultStack = stack);
+    return cfHelper.fetchDefaultStack(e2e.secrets.getDefaultCFEndpoint()).then(stack => defaultStack = stack);
   });
 
   afterAll(() => {

--- a/src/test-e2e/application/application-view-e2e.spec.ts
+++ b/src/test-e2e/application/application-view-e2e.spec.ts
@@ -19,6 +19,7 @@ describe('Application View -', function () {
   const appName = ApplicationE2eHelper.createApplicationName();
   let app: APIResource<IApp>;
   let appSummary: ApplicationPageSummaryTab;
+  let defaultStack = '';
 
   function createTestAppAndNav(): promise.Promise<any> {
     return cfHelper.basicCreateApp(
@@ -46,6 +47,13 @@ describe('Application View -', function () {
 
     protractor.promise.controlFlow().execute(() => cfHelper.updateDefaultCfOrgSpace());
     protractor.promise.controlFlow().execute(() => createTestAppAndNav());
+  });
+
+  beforeAll(() => {
+    const that = this;
+    const endpointName = e2e.secrets.getDefaultCFEndpoint().name;
+    const endpointGuid = e2e.helper.getEndpointGuid(e2e.info, endpointName);
+    return cfHelper.fetchDefaultStack(endpointGuid).then(stack => defaultStack = stack);
   });
 
   afterAll(() => {
@@ -107,8 +115,8 @@ describe('Application View -', function () {
     });
 
     it('Info', () => {
-      expect(appSummary.cardInfo.memQuota.getValue()).toBe('1 GB');
-      expect(appSummary.cardInfo.diskQuota.getValue()).toBe('1 GB');
+      expect(appSummary.cardInfo.memQuota.getValue()).toBe('23 MB');
+      expect(appSummary.cardInfo.diskQuota.getValue()).toBe('35 MB');
       expect(appSummary.cardInfo.appState.getValue()).toBe('STOPPED');
       expect(appSummary.cardInfo.packageState.getValue()).toBe('PENDING');
       expect(appSummary.cardInfo.services.getValue()).toBe('0');
@@ -125,7 +133,7 @@ describe('Application View -', function () {
 
     it('Build Info', () => {
       expect(appSummary.cardBuildInfo.buildPack.getValue()).toBe('-');
-      expect(appSummary.cardBuildInfo.stack.getValue()).toBe('opensuse42');
+      expect(appSummary.cardBuildInfo.stack.getValue()).toBe(defaultStack);
     });
 
     it('Deployment Info', () => {

--- a/src/test-e2e/application/application-view-e2e.spec.ts
+++ b/src/test-e2e/application/application-view-e2e.spec.ts
@@ -50,10 +50,7 @@ describe('Application View -', function () {
   });
 
   beforeAll(() => {
-    const that = this;
-    const endpointName = e2e.secrets.getDefaultCFEndpoint().name;
-    const endpointGuid = e2e.helper.getEndpointGuid(e2e.info, endpointName);
-    return cfHelper.fetchDefaultStack(endpointGuid).then(stack => defaultStack = stack);
+    return cfHelper.fetchDefaultStack(e2e.secrets.getDefaultCFEndpoint()).then(stack => defaultStack = stack);
   });
 
   afterAll(() => {
@@ -131,7 +128,7 @@ describe('Application View -', function () {
       expect(appSummary.cardCfInfo.space.getValue()).toBe(defaultCf.testSpace);
     });
 
-    it('Build Info', () => {
+    fit('Build Info', () => {
       expect(appSummary.cardBuildInfo.buildPack.getValue()).toBe('-');
       expect(appSummary.cardBuildInfo.stack.getValue()).toBe(defaultStack);
     });

--- a/src/test-e2e/helpers/cf-helpers.ts
+++ b/src/test-e2e/helpers/cf-helpers.ts
@@ -128,12 +128,18 @@ export class CFHelpers {
     });
   }
 
-  fetchDefaultStack(cnsiGuid) {
-    return this.cfRequestHelper.sendCfGet(cnsiGuid, 'stacks?results-per-page=100').then(json => {
-      if (json.resources.length > 0 ) {
-        return json.resources[0].entity.name;
-      }
-      return 'could not get default stack';
+  // Default Stack based on the CF Vendor
+  fetchDefaultStack(endpoint: E2EConfigCloudFoundry) {
+    const reqObj = this.cfRequestHelper.newRequest();
+    const options = {
+      url: endpoint.url + '/v2/info'
+    };
+    return reqObj(options).then((response) => {
+      const json = JSON.parse(response.body);
+      const isSUSE = json.description.indexOf('SUSE') === 0;
+      return isSUSE ? 'opensuse42' : 'cflinuxfs2';
+    }).catch((e) => {
+      return 'unknown';
     });
   }
 

--- a/src/test-e2e/helpers/cf-helpers.ts
+++ b/src/test-e2e/helpers/cf-helpers.ts
@@ -128,6 +128,15 @@ export class CFHelpers {
     });
   }
 
+  fetchDefaultStack(cnsiGuid) {
+    return this.cfRequestHelper.sendCfGet(cnsiGuid, 'stacks?results-per-page=100').then(json => {
+      if (json.resources.length > 0 ) {
+        return json.resources[0].entity.name;
+      }
+      return 'could not get default stack';
+    });
+  }
+
   fetchOrg(cnsiGuid: string, orgName: string): promise.Promise<APIResource<any>> {
     return this.cfRequestHelper.sendCfGet(cnsiGuid, 'organizations?q=name IN ' + orgName).then(json => {
       if (json.total_results > 0) {
@@ -172,7 +181,12 @@ export class CFHelpers {
 
   // For fully fleshed our create see application-e2e-helpers
   basicCreateApp(cnsiGuid: string, spaceGuid: string, appName: string): promise.Promise<APIResource<IApp>> {
-    return this.cfRequestHelper.sendCfPost(cnsiGuid, 'apps', { name: appName, space_guid: spaceGuid });
+    return this.cfRequestHelper.sendCfPost(cnsiGuid, 'apps', {
+      name: appName,
+      space_guid: spaceGuid,
+      memory: 23,
+      disk_quota: 35
+     });
   }
 
   // For fully fleshed out delete see application-e2e-helpers (includes route and service instance deletion)


### PR DESCRIPTION
This PR:

- Fetches the default stack and uses this in the tests, so we don't have to configure this - eases running tests against different CFs

- Sets the memory and disk quota when creating the shell app - since the defaults can be different depending on the CF being uses.