### PR TITLE
Bug fix (service instance wall) + e2e hardening (edit service instance)

### DIFF
--- a/src/frontend/app/shared/components/list/list-types/services-wall/service-instance-card/service-instance-card.component.ts
+++ b/src/frontend/app/shared/components/list/list-types/services-wall/service-instance-card/service-instance-card.component.ts
@@ -17,7 +17,7 @@ import { CardCell } from '../../../list.types';
   templateUrl: './service-instance-card.component.html',
   styleUrls: ['./service-instance-card.component.scss'],
 })
-export class ServiceInstanceCardComponent extends CardCell<APIResource<IServiceInstance>> implements OnInit {
+export class ServiceInstanceCardComponent extends CardCell<APIResource<IServiceInstance>> {
   serviceInstanceEntity: APIResource<IServiceInstance>;
   cfGuid: string;
   cardMenu: MetaCardMenuItem[];
@@ -27,7 +27,7 @@ export class ServiceInstanceCardComponent extends CardCell<APIResource<IServiceI
   entityConfig: ComponentEntityMonitorConfig;
 
   @Input('row')
-  set row(row) {
+  set row(row: APIResource<IServiceInstance>) {
     if (row) {
       this.entityConfig = new ComponentEntityMonitorConfig(row.metadata.guid, entityFactory(serviceInstancesSchemaKey));
       this.serviceInstanceEntity = row;
@@ -36,6 +36,36 @@ export class ServiceInstanceCardComponent extends CardCell<APIResource<IServiceI
       }));
       this.cfGuid = row.entity.cfGuid;
       this.hasMultipleBindings.next(!(row.entity.service_bindings.length > 0));
+      this.cardMenu = [
+        {
+          label: 'Edit',
+          action: this.edit,
+          can: this.currentUserPermissionsService.can(
+            CurrentUserPermissions.SERVICE_INSTANCE_EDIT,
+            this.serviceInstanceEntity.entity.cfGuid,
+            this.serviceInstanceEntity.entity.space_guid
+          )
+        },
+        {
+          label: 'Unbind',
+          action: this.detach,
+          disabled: observableOf(this.serviceInstanceEntity.entity.service_bindings.length === 0),
+          can: this.currentUserPermissionsService.can(
+            CurrentUserPermissions.SERVICE_INSTANCE_EDIT,
+            this.serviceInstanceEntity.entity.cfGuid,
+            this.serviceInstanceEntity.entity.space_guid
+          )
+        },
+        {
+          label: 'Delete',
+          action: this.delete,
+          can: this.currentUserPermissionsService.can(
+            CurrentUserPermissions.SERVICE_INSTANCE_DELETE,
+            this.serviceInstanceEntity.entity.cfGuid,
+            this.serviceInstanceEntity.entity.space_guid
+          )
+        }
+      ];
     }
   }
 
@@ -46,42 +76,6 @@ export class ServiceInstanceCardComponent extends CardCell<APIResource<IServiceI
     super();
   }
 
-  ngOnInit() {
-    this.serviceInstanceTags = this.serviceInstanceEntity.entity.tags.map(t => ({
-      value: t
-    }));
-
-    this.cardMenu = [
-      {
-        label: 'Edit',
-        action: this.edit,
-        can: this.currentUserPermissionsService.can(
-          CurrentUserPermissions.SERVICE_INSTANCE_EDIT,
-          this.serviceInstanceEntity.entity.cfGuid,
-          this.serviceInstanceEntity.entity.space_guid
-        )
-      },
-      {
-        label: 'Unbind',
-        action: this.detach,
-        disabled: observableOf(this.serviceInstanceEntity.entity.service_bindings.length === 0),
-        can: this.currentUserPermissionsService.can(
-          CurrentUserPermissions.SERVICE_INSTANCE_EDIT,
-          this.serviceInstanceEntity.entity.cfGuid,
-          this.serviceInstanceEntity.entity.space_guid
-        )
-      },
-      {
-        label: 'Delete',
-        action: this.delete,
-        can: this.currentUserPermissionsService.can(
-          CurrentUserPermissions.SERVICE_INSTANCE_DELETE,
-          this.serviceInstanceEntity.entity.cfGuid,
-          this.serviceInstanceEntity.entity.space_guid
-        )
-      }
-    ];
-  }
   detach = () => {
     this.serviceActionHelperService.detachServiceBinding
       (this.serviceInstanceEntity.entity.service_bindings,

--- a/src/test-e2e/helpers/e2e-helpers.ts
+++ b/src/test-e2e/helpers/e2e-helpers.ts
@@ -21,7 +21,8 @@ export class E2EHelpers {
   constructor() { }
 
   // This makes identification of acceptance test apps easier in case they leak
-  static createCustomName = (prefix: string, isoTime?: string) => prefix + '.' + (isoTime || (new Date()).toISOString());
+  static createCustomName = (prefix: string, isoTime?: string, trim = false) =>
+    prefix + '.' + (isoTime || (new Date()).toISOString().replace(/[-:.]+/g, ''))
 
   getHost(): string {
     return browser.baseUrl;

--- a/src/test-e2e/marketplace/edit-service-instance-e2e.spec.ts
+++ b/src/test-e2e/marketplace/edit-service-instance-e2e.spec.ts
@@ -7,12 +7,14 @@ import { MetaCard, MetaCardTitleType } from '../po/meta-card.po';
 import { CreateServiceInstance } from './create-service-instance.po';
 import { ServicesHelperE2E } from './services-helper-e2e';
 import { ServicesWallPage } from './services-wall.po';
+import { BrowserViewportScroller } from '@angular/common/src/viewport_scroller';
 
 describe('Edit Service Instance', () => {
   const createServiceInstance = new CreateServiceInstance();
   const servicesWall = new ServicesWallPage();
   let servicesHelperE2E: ServicesHelperE2E;
-  const serviceNamePrefix = 'edited';
+  const serviceNamePrefix = 'e';
+  const serviceNamesToDelete = [];
   beforeAll(() => {
     const e2eSetup = e2e.setup(ConsoleUserType.user)
       .clearAllEndpoints()
@@ -36,64 +38,55 @@ describe('Edit Service Instance', () => {
     servicesWall.waitForPage();
 
     const serviceName = servicesHelperE2E.serviceInstanceName;
+    serviceNamesToDelete.push(serviceName);
 
-    getCardWithTitle(servicesWall, serviceName).then((card: MetaCard) => {
-      card.openActionMenu().then(menu => {
+    return getCardWithTitle(servicesWall, serviceName)
+      .then((card: MetaCard) => card.openActionMenu())
+      .then(menu => {
         menu.clickItem('Edit');
-        browser.getCurrentUrl().then(url => {
+        return browser.getCurrentUrl().then(url => {
           expect(url.endsWith('edit')).toBeTruthy();
           servicesHelperE2E.setServicePlan(true);
           servicesHelperE2E.createServiceInstance.stepper.next();
 
           servicesHelperE2E.addPrefixToServiceName(serviceNamePrefix);
+          serviceNamesToDelete.push(servicesHelperE2E.serviceInstanceName);
           servicesHelperE2E.setServiceInstanceDetail(true);
-          servicesHelperE2E.createServiceInstance.stepper.next();
-
+          return servicesHelperE2E.createServiceInstance.stepper.next();
         });
-      });
-    }).catch(e => fail(e));
+      }).catch(e => fail(e));
   });
 
   it('- should have edited service instance', () => {
-
     servicesWall.waitForPage();
     const editedServiceName = servicesHelperE2E.serviceInstanceName;
-    getCardWithTitle(servicesWall, editedServiceName).then((card: MetaCard) => {
+    return getCardWithTitle(servicesWall, editedServiceName).then((card: MetaCard) => {
       expect(card).toBeDefined();
     }).catch(e => fail(e));
   });
 
   it('- should be able to delete service instance', () => {
-
     servicesWall.waitForPage();
     const editedServiceName = servicesHelperE2E.serviceInstanceName;
-    getCardWithTitle(servicesWall, editedServiceName).then((card: MetaCard) => {
-      card.openActionMenu().then(menu => {
+    return getCardWithTitle(servicesWall, editedServiceName)
+      .then((card: MetaCard) => card.openActionMenu())
+      .then(menu => {
         menu.clickItem('Delete');
         const deleteDialog = new ConfirmDialogComponent();
-
         expect(deleteDialog.isDisplayed()).toBeTruthy();
         expect(deleteDialog.getTitle()).toEqual('Delete Service Instance');
-        deleteDialog.confirm();
-      });
-    }).catch(e => fail(e));
+        return deleteDialog.confirm();
+      }).catch(e => fail(e));
+  });
+
+  afterAll(() => {
+    return servicesHelperE2E.cleanUpServiceInstances(serviceNamesToDelete);
   });
 
 });
 
 function getCardWithTitle(servicesWall: ServicesWallPage, serviceName: string) {
-  return servicesWall.serviceInstancesList.cards.getCards().then((cards: ElementFinder[]) => {
-    return cards.map(card => {
-      const metaCard = new MetaCard(card, MetaCardTitleType.CUSTOM);
-      return metaCard.getTitle();
-    });
-  }).then(cardTitles => {
-    return promise.all(cardTitles).then(titles => {
-      for (let i = 0; i < titles.length; i++) {
-        if (titles[i] === serviceName) {
-          return servicesWall.serviceInstancesList.cards.getCard(i);
-        }
-      }
-    });
-  });
+  servicesWall.serviceInstancesList.header.waitUntilShown();
+  servicesWall.serviceInstancesList.header.setSearchText(serviceName);
+  return servicesWall.serviceInstancesList.cards.findCardByTitle(serviceName, MetaCardTitleType.MAT_CARD);
 }

--- a/src/test-e2e/marketplace/edit-service-instance-e2e.spec.ts
+++ b/src/test-e2e/marketplace/edit-service-instance-e2e.spec.ts
@@ -1,4 +1,4 @@
-import { browser, ElementFinder, promise } from 'protractor';
+import { browser } from 'protractor';
 
 import { e2e } from '../e2e';
 import { ConsoleUserType } from '../helpers/e2e-helpers';
@@ -7,7 +7,6 @@ import { MetaCard, MetaCardTitleType } from '../po/meta-card.po';
 import { CreateServiceInstance } from './create-service-instance.po';
 import { ServicesHelperE2E } from './services-helper-e2e';
 import { ServicesWallPage } from './services-wall.po';
-import { BrowserViewportScroller } from '@angular/common/src/viewport_scroller';
 
 describe('Edit Service Instance', () => {
   const createServiceInstance = new CreateServiceInstance();

--- a/src/test-e2e/marketplace/marketplace-create-service-instances-e2e.spec.ts
+++ b/src/test-e2e/marketplace/marketplace-create-service-instances-e2e.spec.ts
@@ -44,8 +44,6 @@ describe('Marketplace', () => {
       createService(marketplaceSummaryPage, servicesHelperE2E, serviceName, servicesWall);
     });
     afterAll((done) => {
-      // Sleeping because the service instance may not be listed in the `get services` request
-      browser.sleep(1000);
       servicesHelperE2E.cleanUpServiceInstance(servicesHelperE2E.serviceInstanceName).then(() => done());
     });
   });
@@ -75,8 +73,6 @@ describe('Marketplace', () => {
       createService(marketplaceSummaryPage, servicesHelperE2E, serviceName, servicesWall);
     });
     afterAll((done) => {
-      // Sleeping because the service instance may not be listed in the `get services` request
-      browser.sleep(1000);
       servicesHelperE2E.cleanUpServiceInstance(servicesHelperE2E.serviceInstanceName).then(() => done());
     });
   });
@@ -106,8 +102,6 @@ describe('Marketplace', () => {
       createService(marketplaceSummaryPage, servicesHelperE2E, serviceName, servicesWall);
     });
     afterAll((done) => {
-      // Sleeping because the service instance may not be listed in the `get services` request
-      browser.sleep(1000);
       servicesHelperE2E.cleanUpServiceInstance(servicesHelperE2E.serviceInstanceName).then(() => done());
     });
   });


### PR DESCRIPTION
- Fix exception in ServiceInstanceCardComponent caused by row() being called before ngOnInit
- Use standard e2e entity name in services tests
- Harden edit service instance test, clean up any reference to tests that might survive following a failure
- Fixes #2967