### PR TITLE
SSO: Refinements

### DIFF
--- a/src/frontend/app/features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component.ts
+++ b/src/frontend/app/features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component.ts
@@ -53,7 +53,7 @@ export class ConnectEndpointDialogComponent implements OnDestroy {
       types: new Array<EndpointType>('cf', 'metrics')
     },
     {
-      name: 'Single sign-on',
+      name: 'Single Sign-On (SSO)',
       value: 'sso',
       form: {},
       types: new Array<EndpointType>('cf')
@@ -96,7 +96,14 @@ export class ConnectEndpointDialogComponent implements OnDestroy {
     this.canShareEndpointToken = getCanShareTokenForEndpointType(data.type);
 
     // Create the endpoint form
-    const autoSelected = (this.authTypesForEndpoint.length > 0) ? this.authTypesForEndpoint[0] : {};
+    let autoSelected = (this.authTypesForEndpoint.length > 0) ? this.authTypesForEndpoint[0] : {};
+
+    // Auto-select SSO if it is available
+    const ssoIndex = this.authTypesForEndpoint.findIndex(authType => authType.value === 'sso' && data.ssoAllowed);
+    if (ssoIndex >= 0 ) {
+      autoSelected = this.authTypesForEndpoint[ssoIndex];
+    }
+
     this.endpointForm = this.fb.group({
       authType: [autoSelected.value || '', Validators.required],
       authValues: this.fb.group(autoSelected.form || {}),

--- a/src/frontend/app/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.html
+++ b/src/frontend/app/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.html
@@ -19,13 +19,6 @@
     <mat-error *ngIf="urlField.errors && urlField.errors.appUnique">URL is not unique</mat-error>
   </mat-form-field>
   <mat-checkbox matInput name="skipSll" #skipSllField="ngModel" ngModel>Skip SSL validation for the endpoint</mat-checkbox>
-  <mat-checkbox matInput name="ssoAllowed" #ssoAllowedField="ngModel" ngModel>Allow SSO login to this endpoint</mat-checkbox>
-  <div *ngIf="!!ssoAllowedField.value">
-    <p>
-      Please ensure that you have added the Stratos SSO Callback URL shown below to the client's 'redirect_uri'.
-    </p>
-    <pre>{{clientRedirectURI}}</pre>
-  </div>
   <div *ngIf="showAdvancedFields" class="create-endpoint__section">
     <h1 class="create-endpoint__section-title">Advanced Information (Optional)</h1>
     <mat-form-field>
@@ -34,5 +27,12 @@
     <mat-form-field>
       <input matInput id="client_secret" name="client_secret" ngModel #clientSecretField="ngModel" placeholder="Client Secret">
     </mat-form-field>
+  </div>
+  <mat-checkbox matInput name="ssoAllowed" #ssoAllowedField="ngModel" ngModel>Allow SSO login to this endpoint</mat-checkbox>
+  <div *ngIf="!!ssoAllowedField.value">
+    <p>
+      Please ensure that you have added the Stratos SSO Callback URL shown below to the client's 'redirect_uri'.
+    </p>
+    <pre>{{clientRedirectURI}}</pre>
   </div>
 </form>


### PR DESCRIPTION
Minor SSO refinements:

- Fix consistency of SSO casing and hyphenation => 'Single Sign-On'
- Make SSO default when connecting if enabled for the endpoint
- Move the SSO Allowed checkbox to the bottom in 'Advanced Options', so that the form does not move when the checkbox is checked and the advisory text appears