### PR TITLE
Allow auto-registration name to be configured

### DIFF
--- a/src/jetstream/plugins/cloudfoundry/main.go
+++ b/src/jetstream/plugins/cloudfoundry/main.go
@@ -98,8 +98,6 @@ func (c *CloudFoundrySpecification) cfLoginHook(context echo.Context) error {
 
 	// CF auto reg cnsi entry missing, attempt to register
 	if cfCnsi.CNSIType == "" {
-		log.Infof("Auto-registering cloud foundry endpoint %s", cfAPI)
-
 		cfEndpointSpec, _ := c.portalProxy.GetEndpointTypeSpec("cf")
 
 		// Allow the auto-registration name to be configured
@@ -107,6 +105,8 @@ func (c *CloudFoundrySpecification) cfLoginHook(context echo.Context) error {
 		if len(autoRegName) == 0 {
 			autoRegName = "Cloud Foundry"
 		}
+
+		log.Infof("Auto-registering cloud foundry endpoint %s as \"%s\"", cfAPI, autoRegName)
 
 		// Auto-register the Cloud Foundry
 		cfCnsi, err = c.portalProxy.DoRegisterEndpoint(autoRegName, cfAPI, true, c.portalProxy.GetConfig().CFClient, c.portalProxy.GetConfig().CFClientSecret, false, cfEndpointSpec.Info)

--- a/src/jetstream/plugins/cloudfoundry/main.go
+++ b/src/jetstream/plugins/cloudfoundry/main.go
@@ -102,8 +102,14 @@ func (c *CloudFoundrySpecification) cfLoginHook(context echo.Context) error {
 
 		cfEndpointSpec, _ := c.portalProxy.GetEndpointTypeSpec("cf")
 
+		// Allow the auto-registration name to be configured
+		autoRegName := c.portalProxy.GetConfig().AutoRegisterCFName
+		if len(autoRegName) == 0 {
+			autoRegName = "Cloud Foundry"
+		}
+
 		// Auto-register the Cloud Foundry
-		cfCnsi, err = c.portalProxy.DoRegisterEndpoint("Cloud Foundry", cfAPI, true, c.portalProxy.GetConfig().CFClient, c.portalProxy.GetConfig().CFClientSecret, false, cfEndpointSpec.Info)
+		cfCnsi, err = c.portalProxy.DoRegisterEndpoint(autoRegName, cfAPI, true, c.portalProxy.GetConfig().CFClient, c.portalProxy.GetConfig().CFClientSecret, false, cfEndpointSpec.Info)
 		if err != nil {
 			log.Fatal("Could not auto-register Cloud Foundry endpoint", err)
 			return nil

--- a/src/jetstream/repository/interfaces/structs.go
+++ b/src/jetstream/repository/interfaces/structs.go
@@ -228,6 +228,7 @@ type PortalConfig struct {
 	EncryptionKeyFilename           string   `configName:"ENCRYPTION_KEY_FILENAME"`
 	EncryptionKey                   string   `configName:"ENCRYPTION_KEY"`
 	AutoRegisterCFUrl               string   `configName:"AUTO_REG_CF_URL"`
+	AutoRegisterCFName              string   `configName:"AUTO_REG_CF_NAME"`
 	SSOLogin                        bool     `configName:"SSO_LOGIN"`
 	SSOOptions                      string   `configName:"SSO_OPTIONS"`
 	CookieDomain                    string   `configName:"COOKIE_DOMAIN"`


### PR DESCRIPTION
When auto-registering the Cloud Foundry endpoint, it gets named "Cloud Foundry".

This PR adds an env var that can be set (e.g. in the manifest) to be able to change the name used.

Fixes #2985