### PR TITLE
Diagnostics does not show GitHub details when cloned via HTTPS

### DIFF
--- a/src/frontend/app/features/about/diagnostics-page/diagnostics-page.component.ts
+++ b/src/frontend/app/features/about/diagnostics-page/diagnostics-page.component.ts
@@ -93,9 +93,17 @@ export class DiagnosticsPageComponent implements OnInit {
   }
 
   private getGitHubProject(prj: string): string {
-    const parts = prj.split(':');
-    if (parts.length === 2 && parts[0].indexOf('@github.com') >= 0) {
-      return parts[1];
+    let projectUrl = prj;
+    // Remove trailing .git if it is there
+    if (projectUrl.endsWith('.git')) {
+      projectUrl = projectUrl.substr(0, projectUrl.length - 4);
+    }
+
+    // Handle either SSH or HTTPS GitHub URLs
+    if (projectUrl.toLowerCase().startsWith('git@github.com:')) {
+      return projectUrl.substr(15);
+    } else if (projectUrl.toLowerCase().startsWith('https://github.com/')) {
+      return projectUrl.substr(19);
     }
     return '';
   }


### PR DESCRIPTION
Fixes #3006 