### PR TITLE
Update backend dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,19 +11,20 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:662a18ecf55317daa51ea75dd49cdc936b768019ae80e1c448decc5fe6065fc1"
+  digest = "1:d1a104572273cfb58e801812704dca4fe2eab80f3b0144592a722a76c280c598"
   name = "code.cloudfoundry.org/bytefmt"
   packages = ["."]
   pruneopts = "UT"
-  revision = "b31f603f5e1e047fdb38584e1a922dcc5c4de5c8"
+  revision = "2aa6f33b730c79971cfc3c742f279195b0abc627"
 
 [[projects]]
-  digest = "1:fe6b225c8f7b56cd37aaa2b117f36f7a3da2358195dcdaae778bd2be137eb4ba"
+  digest = "1:a255975969865eed8ecbf27f4c54e431eb258ecef57c6dedfd935b8d85bbdd52"
   name = "code.cloudfoundry.org/cli"
   packages = [
     "actor/actionerror",
     "api/cloudcontroller/ccerror",
     "api/cloudcontroller/ccv2/constant",
+    "api/cloudcontroller/ccversion",
     "api/plugin/pluginerror",
     "api/uaa",
     "api/uaa/constant",
@@ -32,10 +33,8 @@
     "cf/actors",
     "cf/actors/brokerbuilder",
     "cf/actors/planbuilder",
-    "cf/actors/plugininstaller",
     "cf/actors/pluginrepo",
     "cf/actors/servicebuilder",
-    "cf/actors/userprint",
     "cf/api",
     "cf/api/appevents",
     "cf/api/appfiles",
@@ -63,26 +62,7 @@
     "cf/commandregistry",
     "cf/commands",
     "cf/commands/application",
-    "cf/commands/buildpack",
-    "cf/commands/domain",
-    "cf/commands/environmentvariablegroup",
-    "cf/commands/featureflag",
-    "cf/commands/organization",
-    "cf/commands/plugin",
-    "cf/commands/pluginrepo",
-    "cf/commands/quota",
-    "cf/commands/route",
-    "cf/commands/routergroups",
-    "cf/commands/securitygroup",
     "cf/commands/service",
-    "cf/commands/serviceaccess",
-    "cf/commands/serviceauthtoken",
-    "cf/commands/servicebroker",
-    "cf/commands/servicekey",
-    "cf/commands/space",
-    "cf/commands/spacequota",
-    "cf/commands/user",
-    "cf/commandsloader",
     "cf/configuration",
     "cf/configuration/confighelpers",
     "cf/configuration/coreconfig",
@@ -104,16 +84,13 @@
     "cf/terminal",
     "cf/trace",
     "cf/uihelpers",
-    "cf/util/downloader",
     "cf/util/glob",
     "cf/util/json",
     "command",
     "command/translatableerror",
-    "command/v2/constant",
     "i18n/resources",
     "plugin",
     "plugin/models",
-    "plugin/rpc",
     "types",
     "util",
     "util/clissh/ssherror",
@@ -122,14 +99,13 @@
     "util/generic",
     "util/manifest",
     "util/randomword",
-    "util/sorting",
     "util/ui",
     "version",
   ]
   pruneopts = "UT"
-  revision = "9048c6b553bb90bdd92d4156d7e6a54b82a45e72"
+  revision = "efdd631d2f9f411e4474d4e272f93ebeee068600"
   source = "github.com/cloudfoundry/cli"
-  version = "v6.38.0"
+  version = "v6.39.1"
 
 [[projects]]
   branch = "master"
@@ -196,6 +172,30 @@
   revision = "7dc373669fa10ddf827c37c595dee30a2f001be9"
 
 [[projects]]
+  digest = "1:bbb950f3ec3179e246d4825963951937feb34f059d757a8b5b48889bd3d0b70d"
+  name = "github.com/cloudfoundry-incubator/stratos"
+  packages = [
+    "src/jetstream/config",
+    "src/jetstream/datastore",
+    "src/jetstream/plugins/cfapppush",
+    "src/jetstream/plugins/cfapppush/pushapp",
+    "src/jetstream/plugins/cfappssh",
+    "src/jetstream/plugins/cloudfoundry",
+    "src/jetstream/plugins/cloudfoundryhosting",
+    "src/jetstream/plugins/metrics",
+    "src/jetstream/plugins/userinfo",
+    "src/jetstream/repository/cnsis",
+    "src/jetstream/repository/console_config",
+    "src/jetstream/repository/crypto",
+    "src/jetstream/repository/goose-db-version",
+    "src/jetstream/repository/interfaces",
+    "src/jetstream/repository/tokens",
+  ]
+  pruneopts = "UT"
+  revision = "a82510df5f0e7827eca10dc015738c29a56ce36d"
+  version = "2.1.0"
+
+[[projects]]
   digest = "1:24fc51072bca32204c162b79ede835505b3c5c5cce4e2e0cd6184ff2376486c9"
   name = "github.com/cloudfoundry/bosh-cli"
   packages = ["director/template"]
@@ -213,7 +213,7 @@
     "system",
   ]
   pruneopts = "UT"
-  revision = "407dd7546455f1a0a50feba2dcaef0ae88da1810"
+  revision = "15c556314b68953d0449541ded010b033767c805"
 
 [[projects]]
   branch = "master"
@@ -221,7 +221,7 @@
   name = "github.com/cloudfoundry/cli-plugin-repo"
   packages = ["web"]
   pruneopts = "UT"
-  revision = "c64574b2524fa39aea71f3561eb676a16b0e10f8"
+  revision = "d386b12f5a8d9a89df9434a5fbd3720480c5d2f1"
 
 [[projects]]
   branch = "master"
@@ -253,12 +253,12 @@
   revision = "250da0e0e68ce3367b4302f34218f6c064eb9559"
 
 [[projects]]
-  digest = "1:ec52d81d56e55d307da2d3dfc97ab952f9cec61d7df839ba5dd464ec08f9759e"
+  digest = "1:ec66ad050342a3573ed2f5a4337d51b4c6d5d2a717cc6c9ecf86b081235a5759"
   name = "github.com/cyphar/filepath-securejoin"
   packages = ["."]
   pruneopts = "UT"
-  revision = "06bda8370f45268db985f7af15732444d94ed51c"
-  version = "v0.2.1"
+  revision = "a261ee33d7a517f054effbf451841abaafe3e0fd"
+  version = "v0.2.2"
 
 [[projects]]
   digest = "1:76dc72490af7174349349838f2fe118996381b31ea83243812a97e5a0fd5ed55"
@@ -270,11 +270,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:082ee114ca248ab34396a2c1ec493fdf805578f987983dc9aa35f8557f2c7c5a"
+  digest = "1:0d5be6ec5f68e0cfa173b77a51294f4129f70db80995a738c6f399a7393b3af4"
   name = "github.com/docker/docker"
   packages = ["pkg/term/windows"]
   pruneopts = "UT"
-  revision = "678d4b3a6d4cd7824d26592090b4dec507ce4bc2"
+  revision = "a9c061deec0f8d452e4feb7258046d5e32a1143b"
 
 [[projects]]
   branch = "master"
@@ -321,11 +321,19 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:4a0c6bb4805508a6287675fac876be2ac1182539ca8a32468d8128882e9d5009"
+  name = "github.com/golang/snappy"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
+
+[[projects]]
+  branch = "master"
   digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
   name = "github.com/google/go-querystring"
   packages = ["query"]
   pruneopts = "UT"
-  revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
+  revision = "44c6ddd0a2342c386950e880b658017258da92fc"
 
 [[projects]]
   branch = "master"
@@ -333,7 +341,7 @@
   name = "github.com/gopherjs/gopherjs"
   packages = ["js"]
   pruneopts = "UT"
-  revision = "0892b62f0d9fb5857760c3cfca837207185117ee"
+  revision = "0210a2f0f73c96103378b0b935f39868e5731809"
 
 [[projects]]
   digest = "1:c79fb010be38a59d657c48c6ba1d003a8aa651fa56b579d959d74573b7dff8e1"
@@ -352,20 +360,20 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:0fe783ea0c04c7d13f7c55d8f74b01b17e18a8320e7deecf578b41ef99b27205"
+  digest = "1:0aa142ca3543fa3aca344c2fa2d52e01d706a3ce4e1fa893e0ef29b5349ddf7a"
   name = "github.com/gorilla/sessions"
   packages = ["."]
   pruneopts = "UT"
-  revision = "03b6f63cc43ef9c7240a635a5e22b13180e822b8"
-  version = "v1.1.1"
+  revision = "81547393f870a35be888759a606ba7bf71dbe5c7"
+  version = "v1.1.2"
 
 [[projects]]
-  digest = "1:43dd08a10854b2056e615d1b1d22ac94559d822e1f8b6fcc92c1a1057e85188e"
+  digest = "1:7b5c6e2eeaa9ae5907c391a91c132abfd5c9e8a784a341b5625e750c67e6825d"
   name = "github.com/gorilla/websocket"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
-  version = "v1.2.0"
+  revision = "66b9c49e59c6c48f0ffce28c2d8b8a5678502c6d"
+  version = "v1.4.0"
 
 [[projects]]
   branch = "master"
@@ -377,11 +385,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:dd027aa13cbc2cecd3003a5f2c320928847c5fe6eadac8021126683bdbf0189e"
+  digest = "1:f02725ce387d00c747f67ad1024e1a034b530e106b810aef81e0b3cd80930917"
   name = "github.com/jessevdk/go-flags"
   packages = ["."]
   pruneopts = "UT"
-  revision = "5ce624ef26b9223c9085c268589891a7a4dbcfda"
+  revision = "2a52a758370dbcc53ac24326c683cf39a43f2fa4"
   source = "github.com/XenoPhex/go-flags"
 
 [[projects]]
@@ -432,19 +440,19 @@
     "random",
   ]
   pruneopts = "UT"
-  revision = "d6898124de917583f5ff5592ef931d1dfe0ddc05"
-  version = "0.2.6"
+  revision = "2a618302b929cc20862dda3aa6f02f64dbe740dd"
+  version = "v0.2.7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:37ce7d7d80531b227023331002c0d42b4b4b291a96798c82a049d03a54ba79e4"
+  digest = "1:8ef506fc2bb9ced9b151dafa592d4046063d744c646c1bbe801982ce87e4bc24"
   name = "github.com/lib/pq"
   packages = [
     ".",
     "oid",
   ]
   pruneopts = "UT"
-  revision = "90697d60dd844d5ef6ff15135d0203f65d2f53b8"
+  revision = "4ded0e9383f75c197b3a2aaa6d590ac52df6fd79"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -465,7 +473,7 @@
     "jwriter",
   ]
   pruneopts = "UT"
-  revision = "03f2033d19d5860aef995fe360ac7d395cd8ce65"
+  revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
 
 [[projects]]
   digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"
@@ -476,12 +484,12 @@
   version = "v0.0.9"
 
 [[projects]]
-  digest = "1:d4d17353dbd05cb52a2a52b7fe1771883b682806f68db442b436294926bbfafb"
+  digest = "1:0981502f9816113c9c8c4ac301583841855c8cf4da8c72f696b3ebedf6d0e4e5"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
   pruneopts = "UT"
-  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
-  version = "v0.0.3"
+  revision = "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c"
+  version = "v0.0.4"
 
 [[projects]]
   branch = "master"
@@ -500,12 +508,12 @@
   version = "v1.9.0"
 
 [[projects]]
-  digest = "1:e05db7d2d85e06b7973561483c4accb8fa67037ff851c69641d9c281b4c36102"
+  digest = "1:d6f988e7296cebe16d9c405b73bee34da871b382f7438c811279614a725239ae"
   name = "github.com/mholt/archiver"
   packages = ["."]
   pruneopts = "UT"
-  revision = "cdc68dd1f170b8dfc1a0d2231b5bb0967ed67006"
-  version = "v2.0"
+  revision = "de0d89e255e17c8d75a40122055763e743ab0593"
+  version = "v2.1"
 
 [[projects]]
   digest = "1:53f34ba558b7948cb4324bff6c11b6c876a915d2a1ba9486d0c4f2e87841c3ff"
@@ -529,6 +537,17 @@
   pruneopts = "UT"
   revision = "7d2ab221fb3f85d000f66c511b2bf1a54cb98777"
   version = "1.0.0"
+
+[[projects]]
+  digest = "1:4f0885b3f0dba96128a09a6f4b4231c42688fbd05f323224c6aa5adc9f4e87bf"
+  name = "github.com/pierrec/lz4"
+  packages = [
+    ".",
+    "internal/xxh32",
+  ]
+  pruneopts = "UT"
+  revision = "bb6bfd13c6a262f1943c0446eb25b7f54c1fb9a2"
+  version = "v2.0.6"
 
 [[projects]]
   digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
@@ -592,12 +611,12 @@
   version = "v0.5.4"
 
 [[projects]]
-  branch = "master"
   digest = "1:c468422f334a6b46a19448ad59aaffdfc0a36b08fdcc1c749a0b29b6453d7e59"
   name = "github.com/valyala/bytebufferpool"
   packages = ["."]
   pruneopts = "UT"
   revision = "e746df99fe4a3986f4d4f79e13c1e0117ce9c2f7"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -632,7 +651,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:10e257965f5774c1ef03b258130a6caa8dddbfe03041f69d7c16a00463dece62"
+  digest = "1:0a0319f9ca4ef4105cd909596be58789777f985d3ed96bdd01893bb54f639dda"
   name = "golang.org/x/crypto"
   packages = [
     "curve25519",
@@ -645,7 +664,7 @@
     "ssh/terminal",
   ]
   pruneopts = "UT"
-  revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
+  revision = "0e37d006457bf46f9e6692014ba72ef82c33022c"
 
 [[projects]]
   branch = "master"
@@ -656,18 +675,18 @@
     "websocket",
   ]
   pruneopts = "UT"
-  revision = "c39426892332e1bb5ec0a434a079bf82f5d30c54"
+  revision = "f04abc6bdfa7a0171a8a0c9fd2ada9391044d056"
 
 [[projects]]
   branch = "master"
-  digest = "1:26ec91f56010c7c9f74630771a35f12f07f3c1d077455ae6611fe58b21433146"
+  digest = "1:75cb7164c3c9e028922e69b10842159549ab96ffc4800ea189c4a6865dc3bc08"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "14742f9018cd6651ec7364dc6ee08af0baaa1031"
+  revision = "90868a75fefd03942536221d7c0e2f84ec62a668"
 
 [[projects]]
   branch = "master"
@@ -682,15 +701,15 @@
     "unicode/cldr",
   ]
   pruneopts = "UT"
-  revision = "6e3c4e7365ddcc329f090f96e4348398f6310088"
+  revision = "905a57155faa8230500121607930ebb9dd8e139c"
 
 [[projects]]
   digest = "1:c25289f43ac4a68d88b02245742347c94f1e108c534dda442188015ff80669b3"
   name = "google.golang.org/appengine"
   packages = ["cloudsql"]
   pruneopts = "UT"
-  revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
-  version = "v1.1.0"
+  revision = "ae0ab99deb4dc413a2b4bd6c8bdd0eb67f1e4d06"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:4e21fb0d17b9da61f6fbc44efd88db46b37a95d2970ca242fb1e8d7e8cdff900"
@@ -731,7 +750,6 @@
     "code.cloudfoundry.org/cli/cf/appfiles",
     "code.cloudfoundry.org/cli/cf/commandregistry",
     "code.cloudfoundry.org/cli/cf/commands/application",
-    "code.cloudfoundry.org/cli/cf/commandsloader",
     "code.cloudfoundry.org/cli/cf/configuration",
     "code.cloudfoundry.org/cli/cf/configuration/confighelpers",
     "code.cloudfoundry.org/cli/cf/configuration/coreconfig",
@@ -745,6 +763,21 @@
     "code.cloudfoundry.org/cli/util",
     "code.cloudfoundry.org/cli/util/randomword",
     "github.com/antonlindstrom/pgstore",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/config",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/datastore",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/plugins/cfapppush",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/plugins/cfapppush/pushapp",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/plugins/cfappssh",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/plugins/cloudfoundry",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/plugins/cloudfoundryhosting",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/plugins/metrics",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/plugins/userinfo",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/cnsis",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/console_config",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/crypto",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/goose-db-version",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/interfaces",
+    "github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/tokens",
     "github.com/cloudfoundry/noaa",
     "github.com/cloudfoundry/noaa/consumer",
     "github.com/cloudfoundry/noaa/errors",


### PR DESCRIPTION
One of the backend dependencies (go-flags) was pinned to a commit that has been removed, so the build is breaking.