### PR TITLE
E2E Tests: Capture video of E2E tests running in the browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ addons:
   chrome: stable
 before_install:
 - export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
-- sleep 3 # give xvfb some time to start  
+- "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1366x768x24"
+- sleep 3
 install:
 - npm install npm@5.6.0 -g
 - npm install
@@ -62,8 +62,12 @@ jobs:
   - name: E2E Tests
     before_script:
     - chmod +x ./deploy/ci/travis/run-e2e-tests.sh
+    # Install ffmpeg so we can capture a video of the display as the tests run
+    - sudo add-apt-repository -y ppa:mc3man/trusty-media
+    - sudo apt-get -qq update
+    - sudo apt-get install -y ffmpeg
     script:
-    - "./deploy/ci/travis/run-e2e-tests.sh quick"
+    - "./deploy/ci/travis/run-e2e-tests.sh video"
     - "./deploy/ci/travis/upload-e2e-test-report.sh"
 notifications:
   slack:

--- a/deploy/ci/travis/run-e2e-tests.sh
+++ b/deploy/ci/travis/run-e2e-tests.sh
@@ -21,59 +21,43 @@ export CERTS_PATH=./dev-certs
 # There are two ways of running - building and deploying a full docker-compose deployment
 # or doing a local build and running that with sqlite
 
-E2E_TARGET="e2e-local"
+# Single arg if set to 'video' will use ffmpeg to capture the browser window as a video as the tests run
+CAPTURE_VIDEO=$1
 
-# Single arg to script can change whether we do a quick of full deploy
-RUN_TYPE=$1
+echo "Using local deployment for e2e tests"
+# Quick deploy locally
+# Start a local UAA - this will take a few seconds to come up in the background
+docker run -d -p 8080:8080 splatform/stratos-uaa
 
-if [ "${RUN_TYPE}" == "quick" ]; then
-  echo "Using local deployment for e2e tests"
-  # Quick deploy locally
-  # Start a local UAA - this will take a few seconds to come up in the background
-  docker run -d -p 8080:8080 splatform/stratos-uaa
+# Get go 1.0 and dep
+curl -sL -o ~/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+chmod +x ~/bin/gimme
+eval "$(gimme 1.9)"
+curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+go version
+dep version
 
-  # Get go 1.0 and dep
-  curl -sL -o ~/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
-  chmod +x ~/bin/gimme
-  eval "$(gimme 1.9)"
-  curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-  go version
-  dep version
-  
-  npm run build
-  npm run build-backend
-  # Copy travis config.properties file
-  cp deploy/ci/travis/config.properties src/jetstream/
-  pushd src/jetstream
-  ./jetstream > backend.log &
-  popd
+npm run build
+npm run build-backend
+# Copy travis config.properties file
+cp deploy/ci/travis/config.properties src/jetstream/
+pushd src/jetstream
+./jetstream > backend.log &
+popd
 
-  E2E_TARGET="e2e -- --dev-server-target= --base-url=https://127.0.0.1:5443"
-else
-  echo "Using docker-compose deployment for e2e tests"
-  # Full deploy in docker compose - this is slow
-  # Move the node_modules folder - the docker build will remove it anyway
-  mv ./node_modules /tmp/node_modules
-
-  echo "Building images locally"
-  ./deploy/docker-compose/build.sh -n -l
-  echo "Build Finished"
-  docker images
-
-  echo "Running Stratos in Docker Compose"
-  pushd deploy/ci/travis
-  docker-compose up -d
-  popd
-
-  # The build cleared node_modules, so move back the one we kept
-  #npm install
-  rm -rf ./node_modules
-  mv /tmp/node_modules ./node_modules
-fi
+E2E_TARGET="e2e -- --dev-server-target= --base-url=https://127.0.0.1:5443"
 
 # Test report folder name override
 TIMESTAMP=`date '+%Y%m%d-%H.%M.%S'`
 export E2E_REPORT_FOLDER="./e2e-reports/${TIMESTAMP}-Travis-Job-${TRAVIS_JOB_NUMBER}"
+mkdir -p "${E2E_REPORT_FOLDER}"
+
+# Capture video if configured
+if [ "$CAPTURE_VIDEO" == "video" ]; then
+  echo "Starting video capture"
+  ffmpeg -video_size 1366x768 -framerate 25 -f x11grab -draw_mouse 0 -i :99.0 ${E2E_REPORT_FOLDER}/ScreenCapture.mp4 >/dev/null 2>&1 &
+  FFMPEG=$!
+fi
 
 set +e
 echo "Running e2e tests"
@@ -81,22 +65,14 @@ npm run ${E2E_TARGET}
 RESULT=$?
 set -e
 
-if [ "${TRAVIS_EVENT_TYPE}" != "pull_request" ]; then
-  pushd deploy/ci/travis
-  # Uncomment to copy logs to the travis log
-  #docker-compose stop
-  #docker-compose logs mariadb
-  #docker-compose logs goose
-  #docker-compose logs proxy 
-  docker-compose down
-  popd
+# Copy the backend log to the test report folder if the tests failed
+if [ $RESULT -ne 0 ]; then
+  cp src/jetstream/backend.log ${E2E_REPORT_FOLDER}/jetstream.log
 fi
 
-# Copy the backend log to the test report folder if the tests failed
-if [ "${RUN_TYPE}" == "quick" ]; then
-  if [ $RESULT -ne 0 ]; then
-    cp src/jetstream/backend.log ${E2E_REPORT_FOLDER}/jetstream.log
-  fi
+if [ "$CAPTURE_VIDEO" == "video" ]; then
+  echo "Stopping video capture"
+  kill -INT $FFMPEG
 fi
 
 # Check environment variable that will ignore E2E failures

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -68,7 +68,7 @@ exports.config = {
     'browserName': 'chrome',
     chromeOptions: {
       useAutomationExtension: false,
-      args: ['--no-sandbox', '--disable-dev-shm-usage']
+      args: ['--no-sandbox', '--disable-dev-shm-usage', '--disable-infobars']
     },
     acceptInsecureCerts: true
   },


### PR DESCRIPTION
Fixes: #3055

This PR:

Captures video of running tests
We now start xvfb with the correct resolution
Install ffmpeg so that we can capture display
Tidies up e2e script to remove docker-compose way of running, as this is no longer user
Update e2e script to start ffmpeg to capture video