### PR TITLE
E2E Tests: Make App Wall tests more resilient. Split out App Routes test.

### DIFF
--- a/src/test-e2e/application/application-routes-e2e.spec.ts
+++ b/src/test-e2e/application/application-routes-e2e.spec.ts
@@ -9,7 +9,7 @@ import { ApplicationE2eHelper } from './application-e2e-helpers';
 import { ApplicationPageRoutesTab } from './po/application-page-routes.po';
 import { CreateRoutesPage } from './po/routes-create-page.po';
 
-fdescribe('Application Routes -', () => {
+describe('Application Routes -', () => {
 
   let applicationE2eHelper: ApplicationE2eHelper;
   let cfGuid, app: APIResource<IApp>;

--- a/src/test-e2e/application/application-routes-e2e.spec.ts
+++ b/src/test-e2e/application/application-routes-e2e.spec.ts
@@ -9,12 +9,14 @@ import { ApplicationE2eHelper } from './application-e2e-helpers';
 import { ApplicationPageRoutesTab } from './po/application-page-routes.po';
 import { CreateRoutesPage } from './po/routes-create-page.po';
 
-describe('Application Routes -', () => {
+fdescribe('Application Routes -', () => {
 
   let applicationE2eHelper: ApplicationE2eHelper;
   let cfGuid, app: APIResource<IApp>;
   let appRoutes;
   let routeHostName, routePath;
+
+  const EC = protractor.ExpectedConditions;
 
   beforeAll(() => {
     const setup = e2e.setup(ConsoleUserType.user)
@@ -40,13 +42,27 @@ describe('Application Routes -', () => {
 
   function spaceContainsRoute(spaceGuid: string, host: string, path: string): promise.Promise<boolean> {
     return applicationE2eHelper.cfHelper.fetchRoutesInSpace(cfGuid, spaceGuid)
-      .then(routes => !!routes.filter(route => route.entity.host === host && route.entity.path === '/' + path).length);
+      .then(routes => !!routes.find(route => route.entity.host === host && route.entity.path === '/' + path));
+  }
+
+  function waitForRouteToBeDeleted(spaceGuid: string, host: string, path: string, count = 0): promise.Promise<boolean> {
+    return spaceContainsRoute(app.entity.space_guid, routeHostName, routePath).then(exists => {
+      if (!exists) {
+        return true;
+      }
+      count++;
+      if (count === 10) {
+        return false;
+      }
+      e2e.sleep(1000);
+      return waitForRouteToBeDeleted(spaceGuid, host, path, count);
+    });
   }
 
   // All of these tests assume that they run after each other
 
   it('Go to Application Routes Tab', () => {
-    const appRoutes = new ApplicationPageRoutesTab(cfGuid, app.metadata.guid);
+    appRoutes = new ApplicationPageRoutesTab(cfGuid, app.metadata.guid);
     appRoutes.navigateTo();
 
     // Check empty initial state
@@ -162,7 +178,7 @@ describe('Application Routes -', () => {
       expect(appRoutes.list.table.getCell(0, 2).getText()).toBe('No');
     });
   });
-  
+
   it('Delete route', () => {
     expect(appRoutes.isActivePage()).toBeTruthy();
 
@@ -175,16 +191,17 @@ describe('Application Routes -', () => {
       expect(message.indexOf(routeHostName)).toBeGreaterThanOrEqual(0);
       expect(message.indexOf('/' + routePath)).toBeGreaterThanOrEqual(0);
     });
+
+    e2e.sleep(5000);
     confirm.confirm();
     confirm.waitUntilNotShown();
 
     appRoutes.list.header.getRefreshListButton().click();
-
     expect(appRoutes.list.empty.getCustom().isDisplayed()).toBeTruthy();
     expect(appRoutes.list.empty.getCustomLineOne()).toBe('This application has no routes');
 
-    expect(spaceContainsRoute(app.entity.space_guid, routeHostName, routePath)).toBeFalsy();
-
+    browser.wait(waitForRouteToBeDeleted(app.entity.space_guid, routeHostName, routePath),
+    10000, 'Route should have been deleted from the space');
   });
 
   afterAll(() => {

--- a/src/test-e2e/application/application-routes-e2e.spec.ts
+++ b/src/test-e2e/application/application-routes-e2e.spec.ts
@@ -13,6 +13,8 @@ describe('Application Routes -', () => {
 
   let applicationE2eHelper: ApplicationE2eHelper;
   let cfGuid, app: APIResource<IApp>;
+  let appRoutes;
+  let routeHostName, routePath;
 
   beforeAll(() => {
     const setup = e2e.setup(ConsoleUserType.user)
@@ -36,13 +38,25 @@ describe('Application Routes -', () => {
     });
   });
 
-
   function spaceContainsRoute(spaceGuid: string, host: string, path: string): promise.Promise<boolean> {
     return applicationE2eHelper.cfHelper.fetchRoutesInSpace(cfGuid, spaceGuid)
       .then(routes => !!routes.filter(route => route.entity.host === host && route.entity.path === '/' + path).length);
   }
 
-  function testCreateNewRoute(appRoutes: ApplicationPageRoutesTab): { newRouteHostName: string, newRoutePath: string } {
+  // All of these tests assume that they run after each other
+
+  it('Go to Application Routes Tab', () => {
+    const appRoutes = new ApplicationPageRoutesTab(cfGuid, app.metadata.guid);
+    appRoutes.navigateTo();
+
+    // Check empty initial state
+    expect(appRoutes.list.empty.getDefault().isPresent()).toBeFalsy();
+    expect(appRoutes.list.empty.getDefault().getComponent().isPresent()).toBeFalsy();
+    expect(appRoutes.list.empty.getCustom().getComponent().isDisplayed()).toBeTruthy();
+    expect(appRoutes.list.empty.getCustomLineOne()).toBe('This application has no routes');
+  });
+
+  it('Add a new route', () => {
     expect(appRoutes.list.header.getAdd().isDisplayed()).toBeTruthy();
     appRoutes.list.header.getAdd().click();
 
@@ -60,11 +74,11 @@ describe('Application Routes -', () => {
     httpRouteForm.clearField('host');
     expect(addRoutePage.stepper.canNext()).toBeFalsy();
 
-    const newRouteHostName = '0-' + ApplicationE2eHelper.createRouteName();
-    const newRoutePath = 'thisIsAPath';
+    routeHostName = '0-' + ApplicationE2eHelper.createRouteName();
+    routePath = 'thisIsAPath';
     httpRouteForm.fill({
-      host: newRouteHostName,
-      path: newRoutePath
+      host: routeHostName,
+      path: routePath
     });
     expect(addRoutePage.stepper.canNext()).toBeTruthy();
     addRoutePage.stepper.next();
@@ -78,26 +92,22 @@ describe('Application Routes -', () => {
     expect(appRoutes.list.table.getRows().count()).toBe(1);
     appRoutes.list.table.getCell(0, 1).getText().then(route => {
       expect(route).toBeTruthy();
-      expect(route.startsWith(newRouteHostName)).toBeTruthy();
-      expect(route.endsWith('/' + newRoutePath)).toBeTruthy();
-      expect(spaceContainsRoute(app.entity.space_guid, newRouteHostName, newRoutePath)).toBeTruthy();
+      expect(route.startsWith(routeHostName)).toBeTruthy();
+      expect(route.endsWith('/' + routePath)).toBeTruthy();
+      expect(spaceContainsRoute(app.entity.space_guid, routeHostName, routePath)).toBeTruthy();
     });
     expect(appRoutes.list.table.getCell(0, 2).getText()).toBe('No');
-    return {
-      newRouteHostName,
-      newRoutePath
-    };
-  }
+  });
 
-  function testUnmapOfNewRoute(appRoutes: ApplicationPageRoutesTab, newRouteHostName: string, newRoutePath: string) {
+  it('Unmap existing route', () => {
     const unmapActionMenu = appRoutes.list.table.openRowActionMenuByIndex(0);
     unmapActionMenu.waitUntilShown();
     unmapActionMenu.clickItem('Unmap');
     const confirm = new ConfirmDialogComponent();
     confirm.getMessage().then(message => {
       expect(message).toBeTruthy();
-      expect(message.indexOf(newRouteHostName)).toBeGreaterThanOrEqual(0);
-      expect(message.indexOf('/' + newRoutePath)).toBeGreaterThanOrEqual(0);
+      expect(message.indexOf(routeHostName)).toBeGreaterThanOrEqual(0);
+      expect(message.indexOf('/' + routePath)).toBeGreaterThanOrEqual(0);
     });
     confirm.confirm();
     confirm.waitUntilNotShown();
@@ -106,11 +116,11 @@ describe('Application Routes -', () => {
       expect(appRoutes.list.empty.getCustom().isDisplayed()).toBeTruthy();
       expect(appRoutes.list.empty.getCustomLineOne()).toBe('This application has no routes');
 
-      expect(spaceContainsRoute(app.entity.space_guid, newRouteHostName, newRoutePath)).toBeTruthy();
+      expect(spaceContainsRoute(app.entity.space_guid, routeHostName, routePath)).toBeTruthy();
     });
-  }
+  });
 
-  function testMapExistingRoute(appRoutes: ApplicationPageRoutesTab, routeHostName: string, routePath: string) {
+  it('Map existing route', () => {
     const addRoutePage = new CreateRoutesPage(cfGuid, app.metadata.guid, app.entity.space_guid);
 
     // Bind the just unbound route back to app
@@ -151,10 +161,9 @@ describe('Application Routes -', () => {
       });
       expect(appRoutes.list.table.getCell(0, 2).getText()).toBe('No');
     });
-
-  }
-
-  function testDeleteOfRoute(appRoutes: ApplicationPageRoutesTab, routeHostName: string, routePath: string) {
+  });
+  
+  it('Delete route', () => {
     expect(appRoutes.isActivePage()).toBeTruthy();
 
     const deleteActionMenu = appRoutes.list.table.openRowActionMenuByIndex(0);
@@ -175,25 +184,6 @@ describe('Application Routes -', () => {
     expect(appRoutes.list.empty.getCustomLineOne()).toBe('This application has no routes');
 
     expect(spaceContainsRoute(app.entity.space_guid, routeHostName, routePath)).toBeFalsy();
-  }
-
-
-  it('Add a new route', () => {
-
-    const appRoutes = new ApplicationPageRoutesTab(cfGuid, app.metadata.guid);
-    appRoutes.navigateTo();
-
-    // Check empty initial state
-    expect(appRoutes.list.empty.getDefault().isPresent()).toBeFalsy();
-    expect(appRoutes.list.empty.getDefault().getComponent().isPresent()).toBeFalsy();
-    expect(appRoutes.list.empty.getCustom().getComponent().isDisplayed()).toBeTruthy();
-    expect(appRoutes.list.empty.getCustomLineOne()).toBe('This application has no routes');
-
-    // All these tests are designed to lead on from each other.
-    const { newRouteHostName, newRoutePath } = testCreateNewRoute(appRoutes);
-    testUnmapOfNewRoute(appRoutes, newRouteHostName, newRoutePath);
-    testMapExistingRoute(appRoutes, newRouteHostName, newRoutePath);
-    testDeleteOfRoute(appRoutes, newRouteHostName, newRoutePath);
 
   });
 

--- a/src/test-e2e/applications/application-wall-e2e.spec.ts
+++ b/src/test-e2e/applications/application-wall-e2e.spec.ts
@@ -32,9 +32,9 @@ describe('Application Wall Tests -', () => {
   function createAppNames(count: number): string[] {
     const appNames = [];
     // Ensure the app names all have the same prefix
-    baseAppName = ApplicationE2eHelper.createApplicationName(null, '-wallTest-');
+    baseAppName = ApplicationE2eHelper.createApplicationName(null, '-wallTest');
     for (let i = 0; i < count; i++) {
-      appNames.push(`${baseAppName}${i}`);
+      appNames.push(`${baseAppName}-${i}`);
     }
     return appNames;
   }
@@ -96,7 +96,7 @@ describe('Application Wall Tests -', () => {
   }
 
   function navAppWall() {
-    // Note - always nave to page... this will pick up all the new org
+    // Note - always nav to page... this will pick up all the new org
     appsPage.navigateTo();
     appsPage.isActivePage().then(active => {
       if (!active) {
@@ -172,12 +172,14 @@ describe('Application Wall Tests -', () => {
     beforeAll(() => {
       appNames = createAppNames(3);
       setup(orgName, appNames, true);
-      expect(appList.getTotalResults()).toBeLessThanOrEqual(9);
       expect(appList.pagination.isDisplayed()).toBeFalsy();
     }, timeAllowed);
 
     beforeAll(() => {
       appList.header.getMultiFilterForm().fill({ cf: defaultCf.name, org: orgName });
+      browser.wait(() => {
+        return appList.getTotalResults().then(results => results === 3);
+      });
     });
 
     afterAll(() => tearDown(orgName), timeAllowed);
@@ -185,7 +187,7 @@ describe('Application Wall Tests -', () => {
     describe('Sorting', () => {
 
       beforeAll(() => {
-        appList.header.setSearchText(baseAppName);
+        // appList.header.setSearchText(baseAppName);
         expect(appList.getTotalResults()).toBeLessThanOrEqual(9);
         expect(appList.pagination.isDisplayed()).toBeFalsy();
       });

--- a/src/test-e2e/applications/application-wall-e2e.spec.ts
+++ b/src/test-e2e/applications/application-wall-e2e.spec.ts
@@ -25,13 +25,16 @@ describe('Application Wall Tests -', () => {
   let space2: APIResource<ISpace>;
   let space1Apps: string[];
   let space2Apps: string[];
+  let baseAppName: string;
 
   const timeAllowed = 60000;
 
   function createAppNames(count: number): string[] {
     const appNames = [];
+    // Ensure the app names all have the same prefix
+    baseAppName = ApplicationE2eHelper.createApplicationName(null, '-wallTest-');
     for (let i = 0; i < count; i++) {
-      appNames.push(ApplicationE2eHelper.createApplicationName(null, `-wallTest-${i}`));
+      appNames.push(`${baseAppName}${i}`);
     }
     return appNames;
   }
@@ -179,12 +182,21 @@ describe('Application Wall Tests -', () => {
 
     afterAll(() => tearDown(orgName), timeAllowed);
 
-    it('sort by name', () => {
-      testSortBy('Application Name');
-    });
+    describe('Sorting', () => {
 
-    it('sort by creation', () => {
-      testSortBy('Creation Date');
+      beforeAll(() => {
+        appList.header.setSearchText(baseAppName);
+        expect(appList.getTotalResults()).toBeLessThanOrEqual(9);
+        expect(appList.pagination.isDisplayed()).toBeFalsy();
+      });
+
+      it('sort by name', () => {
+        testSortBy('Application Name');
+      });
+
+      it('sort by creation', () => {
+        testSortBy('Creation Date');
+      });
     });
 
     it('text filter by existing', () => {


### PR DESCRIPTION
The app wall tests fail if there are more than 9 apps that already exist.

This PR makes them more resilient.

It also splits out the App Routes tests so we can pinpoint where the unreliability is.