### PR TITLE
Ensure we handle orgs with no users

### DIFF
--- a/src/frontend/app/store/reducers/users.reducer.ts
+++ b/src/frontend/app/store/reducers/users.reducer.ts
@@ -150,6 +150,9 @@ function updateUserMissingRoles(users: IRequestEntityTypeState<APIResource<CfUse
   // (via WrapperRequestActionSuccess). Therefore in order to avoid partial entities we need to stick the whole user set into the store
   // including `missingRoles`.
   const usersInResponse: IRequestEntityTypeState<APIResource<CfUser>> = action.response.entities[cfUserSchemaKey];
+  if (!usersInResponse) {
+    return users;
+  }
 
   // Create a delta of the changes, this will ensure we only return an updated state if there are updates
   const haveUpdatedUsers: boolean = Object.values(usersInResponse).reduce((changes, user) => {

--- a/src/test-e2e/cloud-foundry/organizations-spaces-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/organizations-spaces-e2e.spec.ts
@@ -161,5 +161,43 @@ describe('CF - Manage Organizations and Spaces', () => {
       });
     });
   });
-});
 
+  it('Should create an org and a space', () => {
+    const cardView = cloudFoundry.goToOrgView();
+
+    // Click the add button to add an organization
+    cloudFoundry.header.clickIconButton('add');
+    const modal = new StepperComponent();
+    modal.getStepperForm().fill({
+      'orgname': testOrgName
+    });
+    expect(modal.canNext()).toBeTruthy();
+    modal.next();
+
+    cardView.cards.waitUntilShown();
+
+    // Go to the org and create a space
+    cardView.cards.findCardByTitle(testOrgName).then(org => {
+      org.click();
+
+      cloudFoundry.subHeader.clickItem('Spaces');
+      cardView.cards.waitUntilShown();
+      const list = new ListComponent();
+      list.refresh();
+
+      // Add space
+      // Click the add button to add a space
+      cloudFoundry.header.clickIconButton('add');
+
+      modal.getStepperForm().fill({
+        'spacename': testSpaceName
+      });
+      expect(modal.canNext()).toBeTruthy();
+      modal.next();
+
+      cloudFoundry.subHeader.clickItem('Spaces');
+      cardView.cards.waitUntilShown();
+    });
+
+  });
+});


### PR DESCRIPTION
- fixes #3093
- When we fetch an org users we check if any user has missing roles collections (there's too many too return inline)
- During this check we assumed the org will always have users
- For the case of a new org there are no users