### PR TITLE
General fixes following demo walk through

### DIFF
--- a/src/frontend/app/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.ts
+++ b/src/frontend/app/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.ts
@@ -49,19 +49,17 @@ export class DeployApplicationStep3Component implements OnDestroy {
   private errorSub: Subscription;
   private validSub: Subscription;
 
-  private fsData: FileScannerInfo;
-
   constructor(
     private store: Store<AppState>,
-    private snackBar: MatSnackBar,
+    snackBar: MatSnackBar,
     public cfOrgSpaceService: CfOrgSpaceDataService,
-    private http: HttpClient,
+    http: HttpClient,
   ) {
     this.deployer = new DeployApplicationDeployer(store, cfOrgSpaceService, http);
     // Observables
     this.errorSub = this.deployer.status$.pipe(
       filter((status) => status.error)
-    ).subscribe(status => this.snackBar.open(status.errorMsg, 'Dismiss'));
+    ).subscribe(status => snackBar.open(status.errorMsg, 'Dismiss'));
 
     const appGuid$ = this.deployer.applicationGuid$.pipe(
       filter((appGuid) => appGuid !== null),

--- a/src/frontend/app/features/applications/routes/map-routes/map-routes.component.ts
+++ b/src/frontend/app/features/applications/routes/map-routes/map-routes.component.ts
@@ -36,7 +36,7 @@ export class MapRoutesComponent implements OnInit, OnDestroy {
   constructor(
     private store: Store<AppState>,
     private appService: ApplicationService,
-    private listConfig: ListConfig<APIResource>,
+    listConfig: ListConfig<APIResource>,
     private paginationMonitorFactory: PaginationMonitorFactory
   ) {
     this.routesDataSource = listConfig.getDataSource() as CfAppRoutesDataSource;

--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-cells/cloud-foundry-cell/cloud-foundry-cell-base/cloud-foundry-cell-base.component.html
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-cells/cloud-foundry-cell/cloud-foundry-cell-base/cloud-foundry-cell-base.component.html
@@ -1,5 +1,5 @@
 <app-page-header [breadcrumbs]="breadcrumbs$ | async" [tabs]="tabLinks">
-  <h1> {{ name$ | async }}</h1>
+  <h1 *ngIf="name$ | async as name"> Cell: {{ name }}</h1>
 </app-page-header>
 <app-loading-page [entityId]="waitForEntityId" [entitySchema]="waitForEntitySchema" [text]="'Retrieving cell'">
   <router-outlet></router-outlet>

--- a/src/frontend/app/shared/components/cards/card-app-instances/card-app-instances.component.ts
+++ b/src/frontend/app/shared/components/cards/card-app-instances/card-app-instances.component.ts
@@ -1,14 +1,13 @@
-import { CardStatus } from './../../application-state/application-state.service';
 import { Component, ElementRef, Input, OnDestroy, OnInit, Renderer, ViewChild } from '@angular/core';
-import { Store } from '@ngrx/store';
 import { Observable, Subscription } from 'rxjs';
+import { map, first, tap } from 'rxjs/operators';
 
 import { ApplicationService } from '../../../../features/applications/application.service';
 import { AppMetadataTypes } from '../../../../store/actions/app-metadata.actions';
-import { AppState } from '../../../../store/app-state';
-import { ConfirmationDialogService } from '../../confirmation-dialog.service';
-import { map } from 'rxjs/operators';
 import { ConfirmationDialogConfig } from '../../confirmation-dialog.config';
+import { ConfirmationDialogService } from '../../confirmation-dialog.service';
+import { CardStatus } from './../../application-state/application-state.service';
+import { MatSnackBar, MatSnackBarRef, SimpleSnackBar } from '@angular/material';
 
 const appInstanceScaleToZeroConfirmation = new ConfirmationDialogConfig('Set Instance count to 0',
   'Are you sure you want to set the instance count to 0?', 'Confirm', true);
@@ -30,10 +29,10 @@ export class CardAppInstancesComponent implements OnInit, OnDestroy {
   status$: Observable<CardStatus>;
 
   constructor(
-    private store: Store<AppState>,
     public appService: ApplicationService,
     private renderer: Renderer,
-    private confirmDialog: ConfirmationDialogService) {
+    private confirmDialog: ConfirmationDialogService,
+    private snackBar: MatSnackBar) {
     this.status$ = this.appService.applicationState$.pipe(
       map(state => state.indicator)
     );
@@ -52,6 +51,7 @@ export class CardAppInstancesComponent implements OnInit, OnDestroy {
   public runningInstances$: Observable<number>;
 
   private app: any;
+  private snackBarRef: MatSnackBarRef<SimpleSnackBar>;
 
   ngOnInit() {
     this.sub = this.appService.application$.subscribe(app => {
@@ -64,6 +64,9 @@ export class CardAppInstancesComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.sub.unsubscribe();
+    if (this.snackBarRef) {
+      this.snackBarRef.dismiss();
+    }
   }
 
   scaleUp(current: number) {
@@ -95,7 +98,13 @@ export class CardAppInstancesComponent implements OnInit, OnDestroy {
     if (value === 0) {
       this.confirmDialog.open(appInstanceScaleToZeroConfirmation, doUpdate);
     } else {
-      doUpdate();
+      doUpdate().pipe(
+        first(),
+      ).subscribe(actionState => {
+        if (actionState.error) {
+          this.snackBarRef = this.snackBar.open(`Failed to update instance count: ${actionState.message}`, 'Dismiss');
+        }
+      });
     }
   }
 }

--- a/src/frontend/app/shared/components/list/list-table/table-cell-radio/table-cell-radio.component.ts
+++ b/src/frontend/app/shared/components/list/list-table/table-cell-radio/table-cell-radio.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 
 import { TableCellCustom } from '../../list.types';
 
@@ -10,7 +10,21 @@ import { TableCellCustom } from '../../list.types';
 export class TableCellRadioComponent<T> extends TableCellCustom<T> implements OnInit {
   disable: boolean;
 
+  private _row: T;
+  @Input('row')
+  get row() { return this._row; }
+  set row(row: T) {
+    this._row = row;
+    if (row) {
+      this.updateDisabled();
+    }
+  }
+
   ngOnInit() {
+    this.updateDisabled();
+  }
+
+  updateDisabled() {
     this.disable = this.config ? this.config.isDisabled(this.row) : false;
   }
 }

--- a/src/frontend/app/shared/components/list/list-types/app-instance/cf-app-instances-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-instance/cf-app-instances-config.service.ts
@@ -116,7 +116,7 @@ export class CfAppInstancesConfigService implements IListConfig<ListAppInstance>
       metricResults$: null
     },
     cellComponent: TableCellCfCellComponent,
-    cellFlex: '3'
+    cellFlex: '2'
   };
 
   viewType = ListViewTypes.TABLE_ONLY;

--- a/src/frontend/app/store/reducers/api-request-reducers.generator.ts
+++ b/src/frontend/app/store/reducers/api-request-reducers.generator.ts
@@ -132,16 +132,16 @@ export function requestDataReducer(state, action) {
     [appSummarySchemaKey]: [updateAppSummaryRoutesReducer],
     [applicationSchemaKey]: [
       updateApplicationRoutesReducer(),
-      endpointDisconnectApplicationReducer('application')
+      endpointDisconnectApplicationReducer()
     ],
     [spaceSchemaKey]: [
-      endpointDisconnectApplicationReducer('space'),
-      applicationAddRemoveReducer('space'),
+      endpointDisconnectApplicationReducer(),
+      applicationAddRemoveReducer(),
       userSpaceOrgReducer(true)
     ],
     [organizationSchemaKey]: [
       updateOrganizationSpaceReducer(),
-      endpointDisconnectApplicationReducer('organization'),
+      endpointDisconnectApplicationReducer(),
       userSpaceOrgReducer(false)
     ]
   };

--- a/src/frontend/app/store/reducers/application-add-remove-reducer.ts
+++ b/src/frontend/app/store/reducers/application-add-remove-reducer.ts
@@ -5,13 +5,13 @@ import { IApp, ISpace } from '../../core/cf-api.types';
 import { deepMergeState } from '../helpers/reducer.helper';
 
 
-export function applicationAddRemoveReducer(name) {
+export function applicationAddRemoveReducer() {
   return function (state: APIResource, action: APISuccessOrFailedAction) {
     switch (action.type) {
       case CREATE_SUCCESS:
-      return addApplicationToSpace(state, action);
+        return addApplicationToSpace(state, action);
       case DELETE_SUCCESS:
-      return deleteApplicationFromSpace(state, action);
+        return deleteApplicationFromSpace(state, action);
     }
     return state;
   };
@@ -28,7 +28,7 @@ function addApplicationToSpace(state: APIResource, action: APISuccessOrFailedAct
       if (space.entity.apps) {
         const newSpaceEntity = {
           entity: {
-            apps: [ ...space.entity.apps, app.metadata.guid ]
+            apps: [...space.entity.apps, app.metadata.guid]
           }
         };
         updatedSpaces[spaceGuid] = newSpaceEntity;
@@ -53,7 +53,7 @@ function deleteApplicationFromSpace(state: APIResource, action: APISuccessOrFail
   const updatedSpaces = {};
   Object.keys(state).forEach(spaceGuid => {
     const space = state[spaceGuid] as APIResource<SpaceAsAppRefs>;
-    const apps = <string[]> space.entity.apps;
+    const apps = <string[]>space.entity.apps;
     if (apps && apps.findIndex((value) => value === appGuid) >= 0) {
       const newSpaceEntity = {
         entity: {

--- a/src/frontend/app/store/reducers/endpoint-disconnect-application.reducer.ts
+++ b/src/frontend/app/store/reducers/endpoint-disconnect-application.reducer.ts
@@ -1,26 +1,23 @@
-import { APIResource } from '../types/api.types';
-import { IRequestEntityTypeState } from '../app-state';
+import { IApp } from '../../core/cf-api.types';
 import { DISCONNECT_ENDPOINTS_SUCCESS, DisconnectEndpoint, UNREGISTER_ENDPOINTS_SUCCESS } from '../actions/endpoint.actions';
-export function endpointDisconnectApplicationReducer(entityKey) {
-  return function (state: APIResource, action: DisconnectEndpoint) {
+import { APIResource } from '../types/api.types';
+
+export function endpointDisconnectApplicationReducer() {
+  return function (state: { [appGuid: string]: APIResource<{ cfGuid: string }> }, action: DisconnectEndpoint) {
     switch (action.type) {
       case DISCONNECT_ENDPOINTS_SUCCESS:
       case UNREGISTER_ENDPOINTS_SUCCESS:
-        return deletionApplicationFromEndpoint(state, action.guid, entityKey);
+        return deletionApplicationFromEndpoint(state, action.guid);
     }
     return state;
   };
 }
 
-function deletionApplicationFromEndpoint(state: APIResource, endpointGuid, entityKey: string) {
-  const oldEntities = Object.values(state);
-  const entities = {};
-  oldEntities.forEach(app => {
-    if (app.cfGuid !== endpointGuid && app.guid) {
-      entities[app.guid] = app;
+function deletionApplicationFromEndpoint(state: { [appGuid: string]: APIResource<{ cfGuid: string }> }, endpointGuid) {
+  return Object.values(state).reduce((newEntities, app) => {
+    if (app.entity.cfGuid !== endpointGuid && app.metadata.guid) {
+      newEntities[app.metadata.guid] = app;
     }
-  });
-  return entities;
+    return newEntities;
+  }, {});
 }
-
-


### PR DESCRIPTION
Blocked on #3107

- Show snackbar error when scaling app instances (for instance hit memory quota)
- Ensure radio button in bind to existing route table is disabled for current app (refresh on stepper)
- Tweaked width of app instance table cell column
- Show 'Cell:<x>' in cell summary breadcrumb
- Unused params

Also fix delete of request data on disconnect/unregister  …
- Previously disconnecting any endpoint would wipe out all app, org and space data of all endpoints, regardless of the disconnect type or cfGuid
- This was due to to an error accessing the entity.cfGuid property
- This is now fixed, along with some general tidy up
- Note - Stale data on metrics endpoint disconnect is still an issue #3113