### PR TITLE
Fix issue where app status showed old info after successful deploy

### DIFF
--- a/src/frontend/app/features/applications/application.service.ts
+++ b/src/frontend/app/features/applications/application.service.ts
@@ -13,17 +13,11 @@ import {
 import { APP_GUID, CF_GUID } from '../../shared/entity.tokens';
 import { PaginationMonitor } from '../../shared/monitors/pagination-monitor';
 import { PaginationMonitorFactory } from '../../shared/monitors/pagination-monitor.factory';
-import {
-  AppMetadataTypes,
-  GetAppEnvVarsAction,
-  GetAppStatsAction,
-  GetAppSummaryAction,
-} from '../../store/actions/app-metadata.actions';
+import { AppMetadataTypes, GetAppStatsAction, GetAppSummaryAction } from '../../store/actions/app-metadata.actions';
 import { GetApplication, UpdateApplication, UpdateExistingApplication } from '../../store/actions/application.actions';
 import { GetSpace } from '../../store/actions/space.actions';
 import { AppState } from '../../store/app-state';
 import {
-  appEnvVarsSchemaKey,
   applicationSchemaKey,
   appStatsSchemaKey,
   appSummarySchemaKey,
@@ -173,7 +167,7 @@ export class ApplicationService {
           });
         return appStateService.get(app, appInstances);
       })
-    ).pipe(publishReplay(1), refCount(), );
+    ).pipe(publishReplay(1), refCount());
   }
 
   private constructCoreObservables() {
@@ -181,7 +175,7 @@ export class ApplicationService {
     this.app$ = this.appEntityService.waitForEntity$;
     const moreWaiting$ = this.app$.pipe(
       filter(entityInfo => !!(entityInfo.entity && entityInfo.entity.entity && entityInfo.entity.entity.cfGuid)),
-      map(entityInfo => entityInfo.entity.entity), );
+      map(entityInfo => entityInfo.entity.entity));
     this.appSpace$ = moreWaiting$.pipe(
       first(),
       switchMap(app => {
@@ -206,16 +200,15 @@ export class ApplicationService {
       ))
     );
 
-    this.isDeletingApp$ = this.appEntityService.isDeletingEntity$.pipe(publishReplay(1), refCount(), );
+    this.isDeletingApp$ = this.appEntityService.isDeletingEntity$.pipe(publishReplay(1), refCount());
 
-    this.waitForAppEntity$ = this.appEntityService.waitForEntity$.pipe(publishReplay(1), refCount(), );
+    this.waitForAppEntity$ = this.appEntityService.waitForEntity$.pipe(publishReplay(1), refCount());
 
     this.appSummary$ = this.waitForAppEntity$.pipe(
       switchMap(() => this.appSummaryEntityService.entityObs$),
       publishReplay(1),
       refCount()
     );
-    const action = new GetAppEnvVarsAction(this.appGuid, this.cfGuid);
 
     this.appEnvVars = this.appEnvVarsService.createEnvVarsObs(this.appGuid, this.cfGuid);
   }
@@ -235,7 +228,7 @@ export class ApplicationService {
     // willing to do this to speed up the initial fetch for a running application.
     this.appStats$ = appStats.entities$;
 
-    this.appStatsFetching$ = appStats.pagination$.pipe(publishReplay(1), refCount(), );
+    this.appStatsFetching$ = appStats.pagination$.pipe(publishReplay(1), refCount());
 
     this.application$ = this.waitForAppEntity$.pipe(
       combineLatest(this.store.select(endpointEntitiesSelector)),
@@ -249,17 +242,17 @@ export class ApplicationService {
           stack: entity.entity.stack,
           cf: endpoints[entity.entity.cfGuid],
         };
-      }), publishReplay(1), refCount(), );
+      }), publishReplay(1), refCount());
 
     this.applicationState$ = this.waitForAppEntity$.pipe(
       combineLatest(this.appStats$.pipe(startWith(null))),
       map(([appInfo, appStatsArray]: [EntityInfo, APIResource<AppStat>[]]) => {
         return this.appStateService.get(appInfo.entity.entity, appStatsArray ? appStatsArray.map(apiResource => apiResource.entity) : null);
-      }), publishReplay(1), refCount(), );
+      }), publishReplay(1), refCount());
 
     this.applicationStratProject$ = this.appEnvVars.entities$.pipe(map(applicationEnvVars => {
       return this.appEnvVarsService.FetchStratosProject(applicationEnvVars[0].entity);
-    }), publishReplay(1), refCount(), );
+    }), publishReplay(1), refCount());
 
     this.applicationRunning$ = this.application$.pipe(
       map(app => app ? app.app.entity.state === 'STARTED' : false)
@@ -280,15 +273,15 @@ export class ApplicationService {
       map(ev => getCurrentPageRequestInfo(ev).busy),
       startWith(false),
       publishReplay(1),
-      refCount(), );
+      refCount());
 
     this.isUpdatingEnvVars$ = this.appEnvVars.pagination$.pipe(map(
       ev => getCurrentPageRequestInfo(ev).busy && ev.ids[ev.currentPage]
-    ), startWith(false), publishReplay(1), refCount(), );
+    ), startWith(false), publishReplay(1), refCount());
 
     this.isFetchingStats$ = this.appStatsFetching$.pipe(map(
       appStats => appStats ? getCurrentPageRequestInfo(appStats).busy : false
-    ), startWith(false), publishReplay(1), refCount(), );
+    ), startWith(false), publishReplay(1), refCount());
 
     this.applicationUrl$ = this.appSummaryEntityService.entityObs$.pipe(
       map(({ entity }) => entity),

--- a/src/frontend/app/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.ts
+++ b/src/frontend/app/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.ts
@@ -1,16 +1,13 @@
-
-import { distinct, map, combineLatest } from 'rxjs/operators';
-import { Component, HostBinding, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-import { Store } from '@ngrx/store';
+import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
+import { combineLatest, distinct, map } from 'rxjs/operators';
 
-import { AppState } from '../../../../../../store/app-state';
 import { EntityInfo } from '../../../../../../store/types/api.types';
 import { AppSummary } from '../../../../../../store/types/app-metadata.types';
 import { getFullEndpointApiUrl } from '../../../../../endpoints/endpoint-helpers';
 import { ApplicationMonitorService } from '../../../../application-monitor.service';
 import { ApplicationData, ApplicationService } from '../../../../application.service';
+
 
 @Component({
   selector: 'app-build-tab',
@@ -40,7 +37,7 @@ export class BuildTabComponent implements OnInit {
       ),
       map(([app, appSummary]: [ApplicationData, EntityInfo<AppSummary>]) => {
         return app.fetching || appSummary.entityRequestInfo.fetching;
-      }), distinct(), );
+      }), distinct());
 
     this.sshStatus$ = this.applicationService.application$.pipe(
       combineLatest(this.applicationService.appSpace$),

--- a/src/frontend/app/features/applications/deploy-application/deploy-application-deployer.ts
+++ b/src/frontend/app/features/applications/deploy-application/deploy-application-deployer.ts
@@ -1,4 +1,3 @@
-import { HttpClient } from '@angular/common/http';
 import { Store } from '@ngrx/store';
 import { BehaviorSubject, Observable, of as observableOf, Subject, Subscription } from 'rxjs';
 import websocketConnect from 'rxjs-websockets';
@@ -64,8 +63,6 @@ export class DeployApplicationDeployer {
   // Are we deploying?
   deploying = false;
 
-  private hasSentSource = false;
-
   private inputStream;
 
   private isOpen = false;
@@ -79,7 +76,6 @@ export class DeployApplicationDeployer {
   constructor(
     private store: Store<AppState>,
     public cfOrgSpaceService: CfOrgSpaceDataService,
-    private http: HttpClient,
   ) { }
 
   updateStatus(error = false, errorMsg?: string) {
@@ -152,7 +148,7 @@ export class DeployApplicationDeployer {
             filter((log) => log.type === SocketEventTypes.DATA),
             map((log) => log.message),
             share(),
-        );
+          );
         this.msgSub = this.messages.subscribe();
       })
     ).subscribe();

--- a/src/frontend/app/features/applications/deploy-application/deploy-application-step-source-upload/deploy-application-step-source-upload.component.ts
+++ b/src/frontend/app/features/applications/deploy-application/deploy-application-step-source-upload/deploy-application-step-source-upload.component.ts
@@ -21,11 +21,10 @@ export class DeployApplicationStepSourceUploadComponent implements OnDestroy {
 
   public valid$: Observable<boolean>;
 
-  constructor(private store: Store<AppState>,
+  constructor(store: Store<AppState>,
     public cfOrgSpaceService: CfOrgSpaceDataService,
-    http: HttpClient,
   ) {
-    this.deployer = new DeployApplicationDeployer(store, cfOrgSpaceService, http);
+    this.deployer = new DeployApplicationDeployer(store, cfOrgSpaceService);
     this.valid$ = this.deployer.fileTransferStatus$.pipe(
       filter(status => !!status),
       map((status: FileTransferStatus) => status.filesSent === status.totalFiles),

--- a/src/frontend/app/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.ts
+++ b/src/frontend/app/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.ts
@@ -1,4 +1,3 @@
-import { HttpClient } from '@angular/common/http';
 import { Component, Input, OnDestroy } from '@angular/core';
 import { MatSnackBar } from '@angular/material';
 import { Store } from '@ngrx/store';
@@ -18,14 +17,11 @@ import {
 import { StepOnNextFunction } from '../../../../shared/components/stepper/step/step.component';
 import { CfOrgSpaceDataService } from '../../../../shared/data-services/cf-org-space-service.service';
 import { GetAppEnvVarsAction } from '../../../../store/actions/app-metadata.actions';
+import { GetApplication } from '../../../../store/actions/application.actions';
 import { DeleteDeployAppSection } from '../../../../store/actions/deploy-applications.actions';
 import { RouterNav } from '../../../../store/actions/router.actions';
 import { AppState } from '../../../../store/app-state';
 import { DeployApplicationDeployer } from '../deploy-application-deployer';
-import { FileScannerInfo } from '../deploy-application-step2/deploy-application-fs/deploy-application-fs-scanner';
-
-// Interval to check for new application
-const APP_CHECK_INTERVAL = 3000;
 
 @Component({
   selector: 'app-deploy-application-step3',
@@ -53,9 +49,8 @@ export class DeployApplicationStep3Component implements OnDestroy {
     private store: Store<AppState>,
     snackBar: MatSnackBar,
     public cfOrgSpaceService: CfOrgSpaceDataService,
-    http: HttpClient,
   ) {
-    this.deployer = new DeployApplicationDeployer(store, cfOrgSpaceService, http);
+    this.deployer = new DeployApplicationDeployer(store, cfOrgSpaceService);
     // Observables
     this.errorSub = this.deployer.status$.pipe(
       filter((status) => status.error)
@@ -129,6 +124,8 @@ export class DeployApplicationStep3Component implements OnDestroy {
     this.store.dispatch(new RouterNav({ path: ['applications', cfGuid, this.appGuid] }));
     if (this.appGuid) {
       this.store.dispatch(new GetAppEnvVarsAction(this.appGuid, cfGuid));
+      // Ensure the application package_state is correct
+      this.store.dispatch(new GetApplication(this.appGuid, cfGuid));
     }
     return observableOf({ success: true });
   }


### PR DESCRIPTION
- Deploy an app and wait for the `Deployed` status
- Exit the stepper.. previously the state was stale
- We now fetch the app when exiting stepper to ensure the app package_state is up to date
- This results in the app 'fetching' indicator being shown.. then the summary tab with the correct state
- Note - the only functional change is the dispatch in DeployApplicationStep3Component, everything else is tidying up
