### PR TITLE
Ensure CF Cells info is shown for non cf admins

### DIFF
--- a/src/frontend/app/features/cloud-foundry/services/cloud-foundry-organization.service.ts
+++ b/src/frontend/app/features/cloud-foundry/services/cloud-foundry-organization.service.ts
@@ -75,7 +75,7 @@ export class CloudFoundryOrganizationService {
   }
 
   private initialiseObservables() {
-    this.org$ = this.cfUserService.isConnectedUserAdmin(this.store, this.cfGuid).pipe(
+    this.org$ = this.cfUserService.isConnectedUserAdmin(this.cfGuid).pipe(
       switchMap(isAdmin => {
         const relations = [
           createEntityRelationKey(organizationSchemaKey, spaceSchemaKey),
@@ -143,7 +143,7 @@ export class CloudFoundryOrganizationService {
     this.quotaDefinition$ = this.org$.pipe(map(o => o.entity.entity.quota_definition && o.entity.entity.quota_definition.entity));
 
 
-    this.allOrgUsers$ = this.cfUserService.isConnectedUserAdmin(this.store, this.cfGuid).pipe(
+    this.allOrgUsers$ = this.cfUserService.isConnectedUserAdmin(this.cfGuid).pipe(
       switchMap(isAdmin => {
         const action = new GetAllOrgUsers(this.orgGuid, this.usersPaginationKey, this.cfGuid, isAdmin);
         return getPaginationObservables<APIResource<CfUser>>({

--- a/src/frontend/app/features/cloud-foundry/services/cloud-foundry-space.service.ts
+++ b/src/frontend/app/features/cloud-foundry/services/cloud-foundry-space.service.ts
@@ -100,7 +100,7 @@ export class CloudFoundrySpaceService {
   }
 
   private initialiseSpaceObservables() {
-    this.space$ = this.cfUserService.isConnectedUserAdmin(this.store, this.cfGuid).pipe(
+    this.space$ = this.cfUserService.isConnectedUserAdmin(this.cfGuid).pipe(
       switchMap(isAdmin => {
         const relations = [
           createEntityRelationKey(spaceSchemaKey, applicationSchemaKey),
@@ -143,7 +143,7 @@ export class CloudFoundrySpaceService {
       }
     }));
 
-    this.allSpaceUsers$ = this.cfUserService.isConnectedUserAdmin(this.store, this.cfGuid).pipe(
+    this.allSpaceUsers$ = this.cfUserService.isConnectedUserAdmin(this.cfGuid).pipe(
       switchMap(isAdmin => {
         const action = new GetAllSpaceUsers(this.spaceGuid, this.usersPaginationKey, this.cfGuid, isAdmin);
         return getPaginationObservables({

--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-cells/cloud-foundry-cell/cloud-foundry-cell-base/cloud-foundry-cell-base.component.ts
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-cells/cloud-foundry-cell/cloud-foundry-cell-base/cloud-foundry-cell-base.component.ts
@@ -8,6 +8,7 @@ import { entityFactory, metricSchemaKey } from '../../../../../../store/helpers/
 import { getActiveRouteCfCellProvider } from '../../../../cf.helpers';
 import { CloudFoundryEndpointService } from '../../../../services/cloud-foundry-endpoint.service';
 import { CloudFoundryCellService } from '../cloud-foundry-cell.service';
+import { CfUserService } from '../../../../../../shared/data-services/cf-user.service';
 
 @Component({
   selector: 'app-cloud-foundry-cell-base',
@@ -20,6 +21,8 @@ import { CloudFoundryCellService } from '../cloud-foundry-cell.service';
 })
 export class CloudFoundryCellBaseComponent {
 
+  static AppsLinks = 'apps';
+
   tabLinks: ISubHeaderTabs[] = [
     {
       link: 'summary',
@@ -30,7 +33,7 @@ export class CloudFoundryCellBaseComponent {
       label: 'Metrics'
     },
     {
-      link: 'apps',
+      link: CloudFoundryCellBaseComponent.AppsLinks,
       label: 'App Instances'
     },
   ];
@@ -65,5 +68,10 @@ export class CloudFoundryCellBaseComponent {
       ])),
       first()
     );
+
+    this.tabLinks.find(link => link.link === CloudFoundryCellBaseComponent.AppsLinks).hidden =
+      cfEndpointService.currentUser$.pipe(
+        map(user => !user.admin)
+      );
   }
 }

--- a/src/frontend/app/shared/components/list/list-types/cf-cell-apps/cf-cell-apps-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-cell-apps/cf-cell-apps-source.ts
@@ -5,7 +5,7 @@ import { map } from 'rxjs/operators';
 import { IApp } from '../../../../../core/cf-api.types';
 import { EntityServiceFactory } from '../../../../../core/entity-service-factory.service';
 import { GetApplication } from '../../../../../store/actions/application.actions';
-import { FetchCFCellMetricsPaginatedAction, MetricQueryConfig } from '../../../../../store/actions/metrics.actions';
+import { FetchCFMetricsPaginatedAction, MetricQueryConfig } from '../../../../../store/actions/metrics.actions';
 import { AppState } from '../../../../../store/app-state';
 import {
   applicationSchemaKey,
@@ -40,9 +40,9 @@ export class CfCellAppsDataSource
     listConfig: IListConfig<CfCellApp>,
     entityServiceFactory: EntityServiceFactory
   ) {
-    const action = new FetchCFCellMetricsPaginatedAction(
-      cfGuid,
+    const action = new FetchCFMetricsPaginatedAction(
       cellId,
+      cfGuid,
       new MetricQueryConfig(`firehose_container_metric_cpu_percentage{bosh_job_id="${cellId}"}`, {}),
       MetricQueryType.QUERY
     );

--- a/src/frontend/app/shared/components/list/list-types/cf-cells/cf-cells-data-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-cells/cf-cells-data-source.ts
@@ -21,6 +21,7 @@ export class CfCellsDataSource
   constructor(store: Store<AppState>, cfGuid: string, listConfig: IListConfig<IMetricVectorResult<IMetricCell>>) {
     const action = new FetchCFMetricsPaginatedAction(
       cfGuid,
+      cfGuid,
       new MetricQueryConfig('firehose_value_metric_rep_unhealthy_cell', {}),
       MetricQueryType.QUERY
     );

--- a/src/frontend/app/shared/data-services/cf-user.service.ts
+++ b/src/frontend/app/shared/data-services/cf-user.service.ts
@@ -332,7 +332,7 @@ export class CfUserService {
       }));
   }
 
-  public isConnectedUserAdmin = (store, cfGuid: string): Observable<boolean> =>
+  public isConnectedUserAdmin = (cfGuid: string): Observable<boolean> =>
     this.store.select(getCurrentUserCFGlobalStates(cfGuid)).pipe(
       filter(state => !!state),
       map(state => state.isAdmin),

--- a/src/frontend/app/shared/services/metrics-range-selector.service.ts
+++ b/src/frontend/app/shared/services/metrics-range-selector.service.ts
@@ -81,7 +81,7 @@ export class MetricsRangeSelectorService {
         };
       } else {
         return {
-          timeRange: metrics.query.params.window ?
+          timeRange: metrics.query.params && metrics.query.params.window ?
             times.find(time => time.value === metrics.query.params.window) :
             this.getDefaultTimeRange(times)
         };

--- a/src/frontend/app/store/actions/metrics.actions.ts
+++ b/src/frontend/app/store/actions/metrics.actions.ts
@@ -64,11 +64,12 @@ export class MetricsAction implements IRequestAction {
 
 export class FetchCFMetricsAction extends MetricsAction {
   constructor(
+    guid: string,
     cfGuid: string,
     public query: MetricQueryConfig,
     queryType: MetricQueryType = MetricQueryType.QUERY,
     isSeries = true) {
-    super(cfGuid, cfGuid, query, `${MetricsAction.getBaseMetricsURL()}/cf`, queryType, isSeries);
+    super(guid, cfGuid, query, `${MetricsAction.getBaseMetricsURL()}/cf`, queryType, isSeries);
   }
 }
 
@@ -79,13 +80,17 @@ export class FetchCFCellMetricsAction extends MetricsAction {
     public query: MetricQueryConfig,
     queryType: MetricQueryType = MetricQueryType.QUERY,
     isSeries = true) {
-    super(cfGuid + '-' + cellId, cfGuid, query, `${MetricsAction.getBaseMetricsURL()}/cf`, queryType, isSeries);
+    super(cfGuid + '-' + cellId, cfGuid, query, `${MetricsAction.getBaseMetricsURL()}/cf/cells`, queryType, isSeries);
   }
 }
 
 export class FetchCFMetricsPaginatedAction extends FetchCFMetricsAction implements PaginatedAction {
-  constructor(cfGuid: string, public query: MetricQueryConfig, queryType: MetricQueryType = MetricQueryType.QUERY) {
-    super(cfGuid, query, queryType);
+  constructor(
+    guid: string,
+    cfGuid: string,
+    public query: MetricQueryConfig,
+    queryType: MetricQueryType = MetricQueryType.QUERY) {
+    super(guid, cfGuid, query, queryType);
     this.paginationKey = this.metricId;
   }
   actions = [];

--- a/src/jetstream/plugins/metrics/main.go
+++ b/src/jetstream/plugins/metrics/main.go
@@ -72,6 +72,7 @@ func (m *MetricsSpecification) AddAdminGroupRoutes(echoContext *echo.Group) {
 // AddSessionGroupRoutes adds the session routes for this plugin to the Echo server
 func (m *MetricsSpecification) AddSessionGroupRoutes(echoContext *echo.Group) {
 	echoContext.GET("/metrics/cf/app/:appId/:op", m.getCloudFoundryAppMetrics)
+	echoContext.GET("/metrics/cf/cells/:op", m.getCloudFoundryCellMetrics)
 }
 
 func (m *MetricsSpecification) GetType() string {


### PR DESCRIPTION
- Add new `/metrics/cf/cells/:op` endpoint which will allow non-admins to access specific cell queries
- Integrate new `cells` endpoint into front end & test with non-admin user
- Hide cell app instances tab if not cf admin

Also 

- Minor tidy of isConnectedUserAdmin
- Fix console when navigating from app instances to app metrics (bug in v2-master)

