### PR TITLE
Delete App Stepper: Disable delete of routes and services that are bound to other app/s

### DIFF
--- a/src/frontend/app/features/applications/application-delete/application-delete.component.ts
+++ b/src/frontend/app/features/applications/application-delete/application-delete.component.ts
@@ -73,7 +73,7 @@ export class ApplicationDeleteComponent<T> {
       cellDefinition: {
         getValue: row => row.entity.service_instance.entity.name
       },
-      cellFlex: '0 0 200px'
+      cellFlex: '1 0'
     },
     {
       columnId: 'service',
@@ -102,12 +102,13 @@ export class ApplicationDeleteComponent<T> {
       headerCell: () => 'Host',
       columnId: 'host',
       cellComponent: TableCellRouteComponent,
-      cellFlex: '0 0 400px'
+      cellFlex: '1 0'
     },
     {
       columnId: 'tcproute',
       headerCell: () => 'TCP Route',
       cellComponent: TableCellTCPRouteComponent,
+      cellFlex: '1'
     }
   ];
   public appDeleteColumns: ITableColumn<APIResource<IApp>>[] = [
@@ -119,24 +120,27 @@ export class ApplicationDeleteComponent<T> {
         getLink: row => `/applications/${row.metadata.guid}`,
         newTab: true,
       },
-      cellFlex: '0 0 200px'
+      cellFlex: '1 0'
     },
     {
       columnId: 'status',
       headerCell: () => 'Status',
       cellComponent: TableCellAppStatusComponent,
+      cellFlex: '1'
     },
     {
       columnId: 'instances',
       headerCell: () => 'Instances',
-      cellComponent: TableCellAppInstancesComponent
+      cellComponent: TableCellAppInstancesComponent,
+      cellFlex: '1'
     },
     {
       columnId: 'creation',
       headerCell: () => 'Creation Date',
       cellDefinition: {
         getValue: (row: APIResource) => this.datePipe.transform(row.metadata.created_at, 'medium')
-      }
+      },
+      cellFlex: '1'
     }
   ];
 

--- a/src/frontend/app/features/applications/application-delete/application-delete.component.ts
+++ b/src/frontend/app/features/applications/application-delete/application-delete.component.ts
@@ -102,7 +102,7 @@ export class ApplicationDeleteComponent<T> {
       headerCell: () => 'Host',
       columnId: 'host',
       cellComponent: TableCellRouteComponent,
-      cellFlex: '0 0 200px'
+      cellFlex: '0 0 400px'
     },
     {
       columnId: 'tcproute',
@@ -146,7 +146,6 @@ export class ApplicationDeleteComponent<T> {
   public selectedApplication$: Observable<APIResource<IApp>[]>;
   public selectedRoutes$ = new ReplaySubject<APIResource<IRoute>[]>(1);
   public selectedServiceInstances$ = new ReplaySubject<APIResource<IServiceBinding>[]>(1);
-  private appWallFetchAction: GetAllApplications;
   public fetchingApplicationData$: Observable<boolean>;
 
   public serviceInstancesSchemaKey = serviceInstancesSchemaKey;
@@ -168,7 +167,7 @@ export class ApplicationDeleteComponent<T> {
     private datePipe: DatePipe
   ) {
     this.setupAppMonitor();
-    this.cancelUrl = `/application/${applicationService.cfGuid}/${applicationService.appGuid}`;
+    this.cancelUrl = `/applications/${applicationService.cfGuid}/${applicationService.appGuid}`;
     const { fetch, monitors } = this.buildRelatedEntitiesActionMonitors();
     const { instanceMonitor, routeMonitor } = monitors;
     this.instanceMonitor = instanceMonitor;
@@ -221,7 +220,6 @@ export class ApplicationDeleteComponent<T> {
    * Builds the related entities actions and monitors to monitor the state of the entities.
    */
   public buildRelatedEntitiesActionMonitors() {
-    const serviceToInstanceRelationKey = createEntityRelationKey(serviceBindingSchemaKey, serviceInstancesSchemaKey);
     const { appGuid, cfGuid } = this.applicationService;
     const instanceAction = AppServiceBindingDataSource.createGetAllServiceBindings(appGuid, cfGuid);
     const routesAction = new GetAppRoutes(appGuid, cfGuid);

--- a/src/frontend/app/features/applications/application-delete/delete-app-instances/app-delete-instances-routes-list-config.service.ts
+++ b/src/frontend/app/features/applications/application-delete/delete-app-instances/app-delete-instances-routes-list-config.service.ts
@@ -41,8 +41,8 @@ export class AppDeleteServiceInstancesListConfigService extends AppServiceBindin
 
   constructor(store: Store<AppState>,
     appService: ApplicationService,
-    private _datePipe: DatePipe,
-    private currentUserPermissionService: CurrentUserPermissionsService,
+    _datePipe: DatePipe,
+    currentUserPermissionService: CurrentUserPermissionsService,
     private paginationMonitorFactory: PaginationMonitorFactory
   ) {
     super(store, appService, _datePipe, currentUserPermissionService);
@@ -56,7 +56,7 @@ export class AppDeleteServiceInstancesListConfigService extends AppServiceBindin
     this.viewType = ListViewTypes.TABLE_ONLY;
     this.allowSelection = true;
 
-    // Show a warning if there is more than one service binding associated with a service instance
+    // Disable select if there is more than one service binding associated with a service instance
     this.dataSource.getRowState = (serviceBinding: APIResource<IServiceBinding>): Observable<RowState> => {
       if (!serviceBinding) {
         return observableOf({});
@@ -76,8 +76,8 @@ export class AppDeleteServiceInstancesListConfigService extends AppServiceBindin
         });
         this.obsCache[serviceBinding.entity.service_instance_guid] = pagObs.pagination$.pipe(
           map(pag => ({
-            message: `There are other applications bound to this service instance (${pag.totalResults - 1}).`,
-            warning: pag.totalResults > 1,
+            disabledReason: 'Service is attached to other applications',
+            disabled: pag.totalResults > 1
           }))
         );
         // Ensure the request is made by sub'ing to the entities observable

--- a/src/frontend/app/features/applications/application-delete/delete-app-instances/delete-app-instances.component.ts
+++ b/src/frontend/app/features/applications/application-delete/delete-app-instances/delete-app-instances.component.ts
@@ -25,8 +25,6 @@ export class DeleteAppServiceInstancesComponent implements OnDestroy {
   private selectedSub: Subscription;
 
   constructor(private config: ListConfig<APIResource>) {
-    const dataSource = this.config.getDataSource();
-
     this.selectedSub = this.config.getDataSource().selectedRows$.subscribe(
       (selected) => {
         this.selected.emit(Array.from(selected.values()));

--- a/src/frontend/app/features/applications/application-delete/delete-app-routes/app-delete-routes-list-config.service.ts
+++ b/src/frontend/app/features/applications/application-delete/delete-app-routes/app-delete-routes-list-config.service.ts
@@ -2,29 +2,41 @@ import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 
 import { ConfirmationDialogService } from '../../../../shared/components/confirmation-dialog.service';
-import { ITableColumn } from '../../../../shared/components/list/list-table/table.types';
 import {
   CfAppRoutesListConfigService,
 } from '../../../../shared/components/list/list-types/app-route/cf-app-routes-list-config.service';
 import { ListView } from '../../../../store/actions/list.actions';
 import { AppState } from '../../../../store/app-state';
-import { APIResource } from '../../../../store/types/api.types';
 import { ApplicationService } from '../../application.service';
-import { IServiceInstance } from '../../../../core/cf-api-svc.types';
+import { IRoute } from '../../../../core/cf-api.types';
+import { APIResource } from '../../../../store/types/api.types';
+import { RowState } from '../../../../shared/components/list/data-sources-controllers/list-data-source-types';
+import { Observable, of as observableOf } from 'rxjs';
+import { GetAppRoutes } from '../../../../store/actions/application-service-routes.actions';
+import { createEntityRelationKey } from '../../../../store/helpers/entity-relations/entity-relations.types';
+import { routeSchemaKey, domainSchemaKey, applicationSchemaKey } from '../../../../store/helpers/entity-factory';
+
 
 @Injectable()
 export class AppDeleteRoutesListConfigService extends CfAppRoutesListConfigService {
-  serviceInstanceColumns: ITableColumn<APIResource<IServiceInstance>>[];
   defaultView: ListView;
   constructor(
     store: Store<AppState>,
     appService: ApplicationService,
     confirmDialog: ConfirmationDialogService
   ) {
-    super(store, appService, confirmDialog);
+    super(store, appService, confirmDialog, new GetAppRoutes(appService.appGuid, appService.cfGuid, null, [
+      createEntityRelationKey(routeSchemaKey, domainSchemaKey),
+      createEntityRelationKey(routeSchemaKey, applicationSchemaKey),
+    ]));
     this.getGlobalActions = () => null;
     this.getMultiActions = () => null;
     this.getSingleActions = () => null;
     this.allowSelection = true;
+    this.routesDataSource.getRowState = (route: APIResource<IRoute>): Observable<RowState> =>
+      observableOf({
+        disabledReason: 'Route is attached to other applications',
+        disabled: route && route.entity.apps ? route.entity.apps.length > 1 : false
+      });
   }
 }

--- a/src/frontend/app/features/applications/application-delete/delete-app-routes/delete-app-routes.component.ts
+++ b/src/frontend/app/features/applications/application-delete/delete-app-routes/delete-app-routes.component.ts
@@ -1,13 +1,10 @@
-import { Component, OnInit, Input, Output, EventEmitter, OnDestroy } from '@angular/core';
-import { APIResource } from '../../../../store/types/api.types';
-import { IRoute } from '../../../../core/cf-api.types';
-import { ApplicationServiceMock } from '../../../../test-framework/application-service-helper';
-import { ListConfig } from '../../../../shared/components/list/list.component.types';
-import { CfAppRoutesListConfigService } from '../../../../shared/components/list/list-types/app-route/cf-app-routes-list-config.service';
-import { AppDeleteRoutesListConfigService } from './app-delete-routes-list-config.service';
+import { Component, EventEmitter, OnDestroy, Output } from '@angular/core';
 import { Subscription } from 'rxjs';
 
 import { IServiceBinding } from '../../../../core/cf-api-svc.types';
+import { ListConfig } from '../../../../shared/components/list/list.component.types';
+import { APIResource } from '../../../../store/types/api.types';
+import { AppDeleteRoutesListConfigService } from './app-delete-routes-list-config.service';
 
 @Component({
   selector: 'app-delete-app-routes',
@@ -28,8 +25,6 @@ export class DeleteAppRoutesComponent implements OnDestroy {
   private selectedSub: Subscription;
 
   constructor(private config: ListConfig<APIResource>) {
-    const dataSource = this.config.getDataSource();
-
     this.selectedSub = this.config.getDataSource().selectedRows$.subscribe(
       (selected) => {
         this.selected.emit(Array.from(selected.values()));

--- a/src/frontend/app/features/applications/application/application-tabs-base/tabs/routes-tab/routes-tab/routes-tab.component.ts
+++ b/src/frontend/app/features/applications/application/application-tabs-base/tabs/routes-tab/routes-tab/routes-tab.component.ts
@@ -23,7 +23,6 @@ import { ApplicationService } from '../../../../../application.service';
   providers: [
     {
       provide: ListConfig,
-      useClass: CfAppRoutesListConfigService,
       useFactory: (
         store: Store<AppState>,
         appService: ApplicationService,

--- a/src/frontend/app/features/applications/application/application-tabs-base/tabs/routes-tab/routes-tab/routes-tab.component.ts
+++ b/src/frontend/app/features/applications/application/application-tabs-base/tabs/routes-tab/routes-tab/routes-tab.component.ts
@@ -1,19 +1,20 @@
 import { Component, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Subscription } from 'rxjs';
+import { first } from 'rxjs/operators';
 
+import { ConfirmationDialogService } from '../../../../../../../shared/components/confirmation-dialog.service';
 import {
   CfAppRoutesListConfigService,
 } from '../../../../../../../shared/components/list/list-types/app-route/cf-app-routes-list-config.service';
 import { ListConfig } from '../../../../../../../shared/components/list/list.component.types';
 import { PaginationMonitorFactory } from '../../../../../../../shared/monitors/pagination-monitor.factory';
-import { AppState } from '../../../../../../../store/app-state';
-import { EntityInfo, APIResource } from '../../../../../../../store/types/api.types';
-import { ApplicationService } from '../../../../../application.service';
 import { FetchAllDomains } from '../../../../../../../store/actions/domains.actions';
+import { AppState } from '../../../../../../../store/app-state';
+import { domainSchemaKey, entityFactory } from '../../../../../../../store/helpers/entity-factory';
 import { getPaginationObservables } from '../../../../../../../store/reducers/pagination-reducer/pagination-reducer.helper';
-import { entityFactory, domainSchemaKey } from '../../../../../../../store/helpers/entity-factory';
-import { first } from 'rxjs/operators';
+import { APIResource, EntityInfo } from '../../../../../../../store/types/api.types';
+import { ApplicationService } from '../../../../../application.service';
 
 @Component({
   selector: 'app-routes-tab',
@@ -22,7 +23,14 @@ import { first } from 'rxjs/operators';
   providers: [
     {
       provide: ListConfig,
-      useClass: CfAppRoutesListConfigService
+      useClass: CfAppRoutesListConfigService,
+      useFactory: (
+        store: Store<AppState>,
+        appService: ApplicationService,
+        confirmDialog: ConfirmationDialogService) => {
+        return new CfAppRoutesListConfigService(store, appService, confirmDialog);
+      },
+      deps: [Store, ApplicationService, ConfirmationDialogService]
     }
   ]
 })
@@ -32,7 +40,6 @@ export class RoutesTabComponent implements OnInit {
   constructor(
     private store: Store<AppState>,
     private appService: ApplicationService,
-    private listConfig: ListConfig<EntityInfo>,
     private paginationMonitorFactory: PaginationMonitorFactory
   ) {
   }

--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-build-packs/cloud-foundry-build-packs.component.ts
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-build-packs/cloud-foundry-build-packs.component.ts
@@ -1,14 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
-import { ListDataSource } from '../../../../shared/components/list/data-sources-controllers/list-data-source';
-import {
-  CfBuildpackCardComponent,
-} from '../../../../shared/components/list/list-types/cf-buildpacks/cf-buildpack-card/cf-buildpack-card.component';
 import {
   CfBuildpacksListConfigService,
 } from '../../../../shared/components/list/list-types/cf-buildpacks/cf-buildpacks-list-config.service';
 import { ListConfig } from '../../../../shared/components/list/list.component.types';
-import { APIResource } from '../../../../store/types/api.types';
 
 @Component({
   selector: 'app-cloud-foundry-build-packs',
@@ -21,8 +16,4 @@ import { APIResource } from '../../../../store/types/api.types';
     }
   ]
 })
-export class CloudFoundryBuildPacksComponent {
-  constructor(private listConfig: ListConfig<APIResource>) {
-    const dataSource: ListDataSource<APIResource> = listConfig.getDataSource();
-  }
-}
+export class CloudFoundryBuildPacksComponent { }

--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-feature-flags/cloud-foundry-feature-flags.component.ts
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-feature-flags/cloud-foundry-feature-flags.component.ts
@@ -1,7 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
-import { IFeatureFlag } from '../../../../core/cf-api.types';
-import { ListDataSource } from '../../../../shared/components/list/data-sources-controllers/list-data-source';
 import {
   CfFeatureFlagsListConfigService,
 } from '../../../../shared/components/list/list-types/cf-feature-flags/cf-feature-flags-list-config.service';
@@ -18,13 +16,4 @@ import { ListConfig } from '../../../../shared/components/list/list.component.ty
     }
   ]
 })
-export class CloudFoundryFeatureFlagsComponent implements OnInit {
-
-  constructor(private listConfig: ListConfig<IFeatureFlag>) {
-    const dataSource: ListDataSource<IFeatureFlag> = listConfig.getDataSource();
-  }
-
-  ngOnInit() {
-  }
-
-}
+export class CloudFoundryFeatureFlagsComponent { }

--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-spaces/cloud-foundry-organization-spaces.component.ts
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-spaces/cloud-foundry-organization-spaces.component.ts
@@ -1,12 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
-import { ListDataSource } from '../../../../../shared/components/list/data-sources-controllers/list-data-source';
 import {
   CfSpacesListConfigService,
 } from '../../../../../shared/components/list/list-types/cf-spaces/cf-spaces-list-config.service';
 import { ListConfig } from '../../../../../shared/components/list/list.component.types';
-import { APIResource } from '../../../../../store/types/api.types';
-import { ISpace } from '../../../../../core/cf-api.types';
 
 @Component({
   selector: 'app-cloud-foundry-organization-spaces',
@@ -19,13 +16,4 @@ import { ISpace } from '../../../../../core/cf-api.types';
     }
   ]
 })
-export class CloudFoundryOrganizationSpacesComponent implements OnInit {
-
-  constructor(private listConfig: ListConfig<APIResource<ISpace>>) {
-    const dataSource: ListDataSource<APIResource<ISpace>> = listConfig.getDataSource();
-  }
-
-  ngOnInit() {
-  }
-
-}
+export class CloudFoundryOrganizationSpacesComponent { }

--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-users/cloud-foundry-organization-users.component.ts
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-users/cloud-foundry-organization-users.component.ts
@@ -1,8 +1,9 @@
-import { Component, OnInit } from '@angular/core';
-import { ListConfig } from '../../../../../shared/components/list/list.component.types';
+import { Component } from '@angular/core';
+
 import {
-  CfOrgUsersListConfigService
+  CfOrgUsersListConfigService,
 } from '../../../../../shared/components/list/list-types/cf-org-users/cf-org-users-list-config.service';
+import { ListConfig } from '../../../../../shared/components/list/list.component.types';
 
 @Component({
   selector: 'app-cloud-foundry-organization-users',
@@ -13,11 +14,4 @@ import {
     useClass: CfOrgUsersListConfigService
   }]
 })
-export class CloudFoundryOrganizationUsersComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
-
-}
+export class CloudFoundryOrganizationUsersComponent { }

--- a/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organizations.component.ts
+++ b/src/frontend/app/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organizations.component.ts
@@ -1,10 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
-import { ListDataSource } from '../../../../shared/components/list/data-sources-controllers/list-data-source';
 import { CfOrgCardComponent } from '../../../../shared/components/list/list-types/cf-orgs/cf-org-card/cf-org-card.component';
 import { CfOrgsListConfigService } from '../../../../shared/components/list/list-types/cf-orgs/cf-orgs-list-config.service';
 import { ListConfig } from '../../../../shared/components/list/list.component.types';
-import { APIResource } from '../../../../store/types/api.types';
 
 @Component({
   selector: 'app-cloud-foundry-organizations',
@@ -17,12 +15,6 @@ import { APIResource } from '../../../../store/types/api.types';
     }
   ]
 })
-export class CloudFoundryOrganizationsComponent implements OnInit {
+export class CloudFoundryOrganizationsComponent {
   cardComponent = CfOrgCardComponent;
-
-  constructor(private listConfig: ListConfig<APIResource>) {
-    const dataSource: ListDataSource<APIResource> = listConfig.getDataSource();
-  }
-
-  ngOnInit() { }
 }

--- a/src/frontend/app/shared/components/list/data-sources-controllers/list-data-source-types.ts
+++ b/src/frontend/app/shared/components/list/data-sources-controllers/list-data-source-types.ts
@@ -90,6 +90,7 @@ export interface RowState {
   highlighted?: boolean;
   deleting?: boolean;
   warning?: boolean;
+  disabled?: boolean;
   [customState: string]: any;
 }
 

--- a/src/frontend/app/shared/components/list/data-sources-controllers/list-data-source.ts
+++ b/src/frontend/app/shared/components/list/data-sources-controllers/list-data-source.ts
@@ -1,10 +1,9 @@
-
-import { of as observableOf, BehaviorSubject, OperatorFunction, Observable, Subscription, ReplaySubject } from 'rxjs';
-
-import { tap, distinctUntilChanged, filter, first, map, publishReplay, refCount } from 'rxjs/operators';
 import { DataSource } from '@angular/cdk/table';
 import { Store } from '@ngrx/store';
 import { schema } from 'normalizr';
+import { BehaviorSubject, Observable, of as observableOf, OperatorFunction, ReplaySubject, Subscription, combineLatest } from 'rxjs';
+import { tag } from 'rxjs-spy/operators';
+import { publishReplay, refCount, tap, first } from 'rxjs/operators';
 
 import { SetResultCount } from '../../../../store/actions/pagination.actions';
 import { AppState } from '../../../../store/app-state';
@@ -12,10 +11,10 @@ import { getPaginationObservables } from '../../../../store/reducers/pagination-
 import { PaginatedAction, PaginationEntityState } from '../../../../store/types/pagination.types';
 import { PaginationMonitor } from '../../../monitors/pagination-monitor';
 import { IListDataSourceConfig } from './list-data-source-config';
-import { getDefaultRowState, getRowUniqueId, IListDataSource, RowsState, RowState } from './list-data-source-types';
+import { getRowUniqueId, IListDataSource, RowsState, RowState } from './list-data-source-types';
 import { getDataFunctionList } from './local-filtering-sorting';
 import { LocalListController } from './local-list-controller';
-import { tag } from 'rxjs-spy/operators';
+
 
 export class DataFunctionDefinition {
   type: 'sort' | 'filter';
@@ -69,7 +68,6 @@ export abstract class ListDataSource<T, A = T> extends DataSource<T> implements 
   // Misc
   public isLoadingPage$: Observable<boolean> = observableOf(false);
   public rowsState: Observable<RowsState>;
-  public getRowState: (row: T) => Observable<RowState> = null;
 
   // ------------- Private
   private entities$: Observable<T>;
@@ -91,6 +89,8 @@ export abstract class ListDataSource<T, A = T> extends DataSource<T> implements 
   private seedSyncSub: Subscription;
 
   public refresh: () => void;
+
+  public getRowState: (row: T) => Observable<RowState> = () => observableOf({});
 
   constructor(
     private config: IListDataSourceConfig<A, T>
@@ -204,32 +204,55 @@ export abstract class ListDataSource<T, A = T> extends DataSource<T> implements 
   }
 
   selectedRowToggle(row: T, multiMode: boolean = true) {
-    const exists = this.selectedRows.has(this.getRowUniqueId(row));
-    if (exists) {
-      this.selectedRows.delete(this.getRowUniqueId(row));
-      this.selectAllChecked = false;
-    } else {
-      if (!multiMode) {
-        this.selectedRows.clear();
+    this.getRowState(row).pipe(
+      first()
+    ).subscribe(rowState => {
+      if (rowState.disabled) {
+        return;
       }
-      this.selectedRows.set(this.getRowUniqueId(row), row);
-      this.selectAllChecked = multiMode && this.selectedRows.size === this.filteredRows.length;
-    }
-    this.selectedRows$.next(this.selectedRows);
-    this.isSelecting$.next(multiMode && this.selectedRows.size > 0);
+      const exists = this.selectedRows.has(this.getRowUniqueId(row));
+      if (exists) {
+        this.selectedRows.delete(this.getRowUniqueId(row));
+        this.selectAllChecked = false;
+      } else {
+        if (!multiMode) {
+          this.selectedRows.clear();
+        }
+        this.selectedRows.set(this.getRowUniqueId(row), row);
+        this.selectAllChecked = multiMode && this.selectedRows.size === this.filteredRows.length;
+      }
+      this.selectedRows$.next(this.selectedRows);
+      this.isSelecting$.next(multiMode && this.selectedRows.size > 0);
+    });
   }
 
   selectAllFilteredRows() {
     this.selectAllChecked = !this.selectAllChecked;
-    for (const row of this.filteredRows) {
-      if (this.selectAllChecked) {
-        this.selectedRows.set(this.getRowUniqueId(row), row);
-      } else {
-        this.selectedRows.delete(this.getRowUniqueId(row));
-      }
-    }
-    this.selectedRows$.next(this.selectedRows);
-    this.isSelecting$.next(this.selectedRows.size > 0);
+
+    const updatedAllRows = this.filteredRows.reduce((obs, row) => {
+      obs.push(this.getRowState(row).pipe(
+        first(),
+        tap(rowState => {
+          if (rowState.disabled) {
+            return;
+          }
+          if (this.selectAllChecked) {
+            this.selectedRows.set(this.getRowUniqueId(row), row);
+          } else {
+            this.selectedRows.delete(this.getRowUniqueId(row));
+          }
+        })
+      ));
+      return obs;
+    }, []);
+
+    combineLatest(...updatedAllRows).pipe(
+      first()
+    ).subscribe(() => {
+      this.selectedRows$.next(this.selectedRows);
+      this.isSelecting$.next(this.selectedRows.size > 0);
+    });
+
   }
 
   selectClear() {

--- a/src/frontend/app/shared/components/list/list-table/table-cell-select/table-cell-select.component.html
+++ b/src/frontend/app/shared/components/list/list-table/table-cell-select/table-cell-select.component.html
@@ -1,1 +1,2 @@
-<mat-checkbox [disabled]="(dataSource.isAdding$ | async) || (disable$ | async)" [checked]="dataSource.selectedRows?.has(dataSource.getRowUniqueId(row))" (change)="dataSource.selectedRowToggle(row)"></mat-checkbox>
+<mat-checkbox [disabled]="(dataSource.isAdding$ | async) || (disable$ | async)" [checked]="!(disable$ | async) && dataSource.selectedRows?.has(dataSource.getRowUniqueId(row))"
+  (change)="dataSource.selectedRowToggle(row)" [matTooltip]="tooltip$ | async"></mat-checkbox>

--- a/src/frontend/app/shared/components/list/list-table/table-cell-select/table-cell-select.component.ts
+++ b/src/frontend/app/shared/components/list/list-table/table-cell-select/table-cell-select.component.ts
@@ -15,6 +15,7 @@ import { TableCellCustom } from '../../list.types';
 export class TableCellSelectComponent<T> extends TableCellCustom<T> implements OnInit {
 
   disable$: Observable<boolean>;
+  tooltip$: Observable<string>;
 
   @Input()
   rowState: Observable<RowState>;
@@ -22,6 +23,9 @@ export class TableCellSelectComponent<T> extends TableCellCustom<T> implements O
   ngOnInit() {
     this.disable$ = this.rowState.pipe(
       map(state => state.disabled)
+    );
+    this.tooltip$ = this.rowState.pipe(
+      map(state => state.disabled ? state.disabledReason : null)
     );
   }
 }

--- a/src/frontend/app/shared/components/list/list-types/app-route/cf-app-routes-list-config.service.spec.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-route/cf-app-routes-list-config.service.spec.ts
@@ -1,14 +1,16 @@
-import { TestBed, inject } from '@angular/core/testing';
-
-import { CfAppRoutesListConfigService } from './cf-app-routes-list-config.service';
-import { ApplicationService } from '../../../../../features/applications/application.service';
-import { ApplicationServiceMock } from '../../../../../test-framework/application-service-helper';
-import { CoreModule } from '../../../../../core/core.module';
-import { SharedModule } from '../../../../shared.module';
-import { StoreModule } from '@ngrx/store';
-import { appReducers } from '../../../../../store/reducers.module';
+import { inject, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Store, StoreModule } from '@ngrx/store';
+
+import { CoreModule } from '../../../../../core/core.module';
+import { ApplicationService } from '../../../../../features/applications/application.service';
+import { AppState } from '../../../../../store/app-state';
+import { appReducers } from '../../../../../store/reducers.module';
+import { ApplicationServiceMock } from '../../../../../test-framework/application-service-helper';
 import { getInitialTestStoreState } from '../../../../../test-framework/store-test-helper';
+import { SharedModule } from '../../../../shared.module';
+import { ConfirmationDialogService } from '../../../confirmation-dialog.service';
+import { CfAppRoutesListConfigService } from './cf-app-routes-list-config.service';
 
 describe('CfAppRoutesListConfigService', () => {
 
@@ -18,7 +20,17 @@ describe('CfAppRoutesListConfigService', () => {
     TestBed.configureTestingModule({
       providers: [
         { provide: ApplicationService, useClass: ApplicationServiceMock },
-        CfAppRoutesListConfigService
+        {
+          provide: CfAppRoutesListConfigService,
+          useFactory: (
+            store: Store<AppState>,
+            appService: ApplicationService,
+            confirmDialog: ConfirmationDialogService) => {
+            return new CfAppRoutesListConfigService(store, appService, confirmDialog);
+          },
+          deps: [Store, ApplicationService, ConfirmationDialogService]
+        }
+
       ],
       imports: [
         SharedModule,

--- a/src/frontend/app/shared/components/list/list-types/app-route/cf-app-routes-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-route/cf-app-routes-list-config.service.ts
@@ -169,14 +169,15 @@ export class CfAppRoutesListConfigService extends ListConfig<APIResource> {
   constructor(
     private store: Store<AppState>,
     private appService: ApplicationService,
-    private confirmDialog: ConfirmationDialogService
+    private confirmDialog: ConfirmationDialogService,
+    getRoutesAction: GetAppRoutes = null
   ) {
     super();
 
     this.routesDataSource = new CfAppRoutesDataSource(
       this.store,
       this.appService,
-      new GetAppRoutes(appService.appGuid, appService.cfGuid),
+      getRoutesAction || new GetAppRoutes(appService.appGuid, appService.cfGuid),
       this
     );
   }


### PR DESCRIPTION
- Fixes #3034
- Wire in disabled state to table checkbox
- Create disabled checkbox tooltip
- Handle 'select all' checkbox with disabled checkboxes. Alternatively we can remove the 'select all' checkbox if some are disabled

Also
- Delete app - fixed cancel of stepper on fresh load
- Delete app - final confirm step - Allow first columns to grow whilst still keeping some alignment. This gives specifically the route more space
- Lots of imports/unused code tidy ups


