### PR TITLE
Beef up v2 api doc, create v3 api doc

### DIFF
--- a/docs/cf-api-v2-usage.md
+++ b/docs/cf-api-v2-usage.md
@@ -1,9 +1,11 @@
 # Cloud Foundry API v2 Feature Usage
 
 1. [High Level Stratos Concepts](#High-Level-Stratos-Concepts)
-2. [API Parameters](#API-Parameters)
-3. [API Examples](#API-Examples)
-3. [Summary](#Summary)
+1. [API Parameters](#API-Parameters)
+1. [API Examples](#API-Examples)
+1. [V2 Specifics](#V2-Specifics)
+1. [V2 Summary](#V2-Summary)
+
 
 ## High Level Stratos Concepts
 
@@ -99,6 +101,7 @@ The console user will connect to a CF with their personal CF credentials. These 
 the console but also how we have to fetch data.
 
 #### Listing users & their roles
+
 - We provide a way for users of all types to view a list of users (at the cf, organisation and space levels) and their roles
 - We have to fetch this information differently between CF administrators with certain scopes and non-cf administrators
 - CF Admins can list users via `/users`
@@ -113,7 +116,6 @@ the console but also how we have to fetch data.
 - Permissions are dictated by the admin/non-admin state of the connected user, cf feature flags and all of the users organisation and space roles
 - For CF admins we skip fetching roles, as there admin state overrides roles
 - For non-admins we hit each `users/<non-admin's guid>/<role>` endpoint, there's a lot of duplicated data here
-
 
 ## API Parameters
 
@@ -682,7 +684,123 @@ users/f2d71b96-4268-4a29-b8a1-88c856ee7f75/spaces?results-per-page=100&page=1
 ```
 </details>
 
-## Summary
+## V2 Specifics
+
+### Sorting/Filtering
+As described elsewhere Stratos lists can be sorted and/or filtered. To support this we try to make use of sorting and filtering via the API,
+ however in many cases this is not possible resulting in Stratos fetching the entire list and handling sorting, filtering and pagination
+ locally. Obviously this is a major issue when there are large numbers of rows.
+
+Below is a list of each endpoint and the type of sorting / filtering we use with them. Items marked in __*bold and italic*__ are missing
+ from the v2 api.
+
+Endpoint | Sorted Locally | Sorted via API | Filtered Locally | Filtered via API | Used API Pagination | Desired Sort
+--- | --- | --- | --- | --- | --- | ---
+`apps/${guid}/stats` | __*index in array*__, __*`state`*__, __*`usage.mem`*__, __*`usage.disk`*__, __*`usage.cpu`*__, __*`uptime`*__ | - | __*`state`*__ | -
+`apps/${guid}/routes` | __*`host`*__, __*`port`*__ | - | - | -
+`apps/${guid}/service_bindings` | `created_at`
+`apps` | __*`name`*__, __*`instances`*__, __*`disk_quota`*__, __*`memory`*__, `created_at` | - | `name`, `organisation`, `space` | `organisation`, `space`
+`organizations/${orgGuid}/spaces` | __*`name`*__, `created_at` | - | `name` | -
+`organizations`| __*`name`*__, `created_at` | - | `name` | -
+`organizations/${guid}/users` | __*`username`*__ | - | __*`username`*__
+`spaces` | __*`name`*__
+`spaces/${spaceGuid}/routes` | - | `created_at` | - | - | Yes | __*Host*__
+`spaces/${spaceGuid}/apps` | - | `created_at` | - | - | Yes | __*Name*__, __*Status*__
+`spaces/${spaceGuid}/services` | __*`name`*__ |  `created_at` | - | - |
+`spaces/${spaceGuid}/service_instances` | - | `created_at` | - | - | Yes | __*Instance name*__,__*Service name*__,__*Service Plan name*__,
+Other endpoints |
+`buildpacks` | __*`position`*__,  __*`name`*__, `created_at` | - | __*`name`*__ | -
+`config/feature_flags` | __*`name`*__ | - | __*`name`*__
+`events` | - | `timestamp` | - | `actee`, `type` | Yes |
+`security_groups` | __*`name`*__, `created_at` | - | __*`name`*__ | -
+`service_brokers`| __*`name`*__
+`service_instances` | `created_at` | - | `name`, `organisation`, `space` | -
+`service_instances/${guid}/service_bindings` | `created_at` |
+`service_plan_visibilities` | __*`service_plan_guid`*__
+`service_plan/${guid}/service_instances` | `created_at` |
+`services`| __*`label`*__, __*`active`*__, __*`bindable`*__ | - | `label`
+`services/${guid}/service_plans` | __*`name`*__, `created_at` |
+`stacks` | __*`name`*__, `created_at` | - | __*`name`*__
+`users` | __*`name`*__, `created_at` | - | `name` | -
+__*``*__
+
+### Inline Relations
+Below is a list of all the inline relations we use for each of the more fleshed out v3 endpoints of apps, spaces and organisations.
+
+#### Application
+Endpoint | Inline Relations
+--- | ---
+`apps` | <ul><li>app --> route</li><li>app --> space</li><li>space --> org</li></ul>
+`apps/${appGuid}` | <ul><li>app --> route</li><li>route --> domain</li><li>app --> space</li><li>space --> org</li><li>app --> stack</li><li>app --> service binding</li></ul>
+`apps/${appGuid}/routes` | <ul><li>route --> domain</li><li>route --> application</li></ul>
+`apps/${appGuid}/service_bindings` | <ul><li>service binding --> service instance</li></ul>
+`apps/${appGuid}/stats` | -
+`apps/${appGuid}/env` | -
+`apps/${appGuid}/summary` | -
+`apps/${appGuid}/routes/${routeGuid}` | -
+`apps/${appGuid}/instances/${index}` | -
+`apps/${appGuid}/restage` | -
+
+#### Organisation
+Endpoint | Inline Relations | Notes
+--- | --- | ---
+`organizations/${orgGuid}` | <ul><li>org --> space</li><li>space --> service instances</li><li>space --> apps</li><li>space --> routes</li><li>org --> domain</li><li>org --> quota definition</li><li>org --> private domains</li><li>org --> users</li><li>org --> managers</li><li>org --> billing managers</li><li>org --> auditors</li></ul>
+`organizations/${orgGuid}/spaces` | <ul><li>space --> apps</li><li>space --> service instances</li><li>space --> space quota</li></ul>
+`organizations` | <ul><li>org --> space</li><li>space --> service instances</li><li>space --> apps</li><li>space --> routes</li><li>org --> domain</li><li>org --> quota definition</li><li>org --> private domains</li></ul>
+`organizations/${orgGuid}/users` | <ul><li>user --> orgs</li><li>user --> audited orgs</li><li>user --> managed orgs</li><li>user --> billing manager</li><li>user --> space dev</li><li>user --> space manager</li><li>user --> space auditor</li></ul> | We can't switch to `/users?organization_guid=${guid}` as this fails for no cf admins
+
+#### Space
+Endpoint | Inline Relations | Notes
+--- | --- | ---
+`spaces` | - | Note currently used, spaces are either fetchined inline with an org or via the org spaces endpoint
+`spaces/${spaceGuid}` | <ul><li>space --> org</li><li>space --> domains</li><li>space --> routes</li><li>route --> domain</li><li>route --> applications</li></ul>
+`spaces/${spaceGuid}/routes` | <ul><li>route --> domain</li><li>route --> application</li></ul>
+`spaces/${spaceGuid}/apps` | -
+`spaces/${spaceGuid}/user_roles` | -
+`spaces/${spaceGuid}/services` | <ul><li>service --> service plan</li></ul>
+`spaces/${spaceGuid}/service_instances` | <ul><li>service instance --> service bindings</li><li>service binding --> application</li><li>service instance --> service plan</li><li>service instance --> space</li><li>space --> org</li><li>service instance --> service</li></ul>
+
+
+#### Others
+The include-relations property is populated by walking our relationship tree, so for a complete and exhaustive list of all possible
+relations please see the [`entity-factory.ts`](https://github.com/cloudfoundry-incubator/stratos/blob/v2-master/src/frontend/app/store/helpers/entity-factory.ts).
+
+In terms of api requests we also make use of...
+
+- `/buildpacks`
+- `/config/feature_flags`
+- `/events`
+- `/routes`
+- `/security_groups`
+- `/services`
+- `/service_bindings`
+- `/service_brokers`
+- `/service_instances`
+- `/service_plan_visibilities`
+- `/service_plan`
+- `/shared_domains`
+- `/stacks`
+- `/users`
+
+### Cloud Foundry, Organisation and Space Summary Information
+In the `Cloud Foundry` section of Stratos we show summary pages at the CF, Org and Space levels. These consist of information from the core
+cf/org/space but also statistic such as number of users or memory used within that cf/org/sapce. The only way to fetch these stats is via
+requesting a large amount of additional data, either inline with the org/space or as separate requests.
+Below is a table showing the stats at each level. The counts are respective of that level (number of routes in that specific cf, org or space)
+
+Stat/Info | CF Summary | Org Summary | Space Summary
+--- | --- | --- | ---
+No. of Apps | *yep* | *yep* | *yep*
+No. of App Instances | | *yep* | *yep*
+No. of Organisations | *yep*
+No. of Users | *yep* | *yep* | *yep*
+Memory Usage | *yep* | *yep* | *yep*
+No. of Routes | | *yep*| *yep*
+No. of Private Domains | |*yep*
+No. of Service Instances | | *yep*| *yep*
+Last 10 updated apps | *yep* | *yep* | *yep*
+
+## V2 Summary
 
 ### Current v2 Issues
 

--- a/docs/cf-api-v2-usage.md
+++ b/docs/cf-api-v2-usage.md
@@ -826,7 +826,8 @@ Last 10 updated apps | *yep* | *yep* | *yep*
 - The `<role>_url` in a user entity can only be called by an administrator or by the same user
   > Desired - URL behaves as per the `/users` suggestion above the response contains the organisaitons that are visible to the user that
     calls the url
-- `include-relations` works by specifying the name of the child property. If the inline-depth is greater than one this can lead relations being fetched that might not actually be required
+- `include-relations` works by specifying the name of the child property. If the `inline-relations-depth` is greater than one this can lead
+ relations being fetched that might not actually be required
   > Desired - Minor nice to have. Be able to specify relations like `include-relations=application-route,route-domain`
 
 ### Critical v2 Features

--- a/docs/cf-api-v3.md
+++ b/docs/cf-api-v3.md
@@ -77,6 +77,9 @@ Then Stratos should either ..
   - Stratos show summary information such as number of users (see [Cloud Foundry API v2 Feature Usage V2 Specifics - Cloud Foundry, Organisation and Space Summary Information](cf-api-v2-usage.md#cloud-foundry-organisation-and-space-summary-information) for specific stats)
   - In an ideal world we could hit one endpoint that would give us the counts for all of these details. Filters could then limit this to
     an organisation or space
+- Fetching a list of users as a non-cf admin involves making a request to every organisation (`organization/${guid}/users`). The response
+  of all of these calls contains a lot of overlapping data
+  - Ideally making a request to `/users` as a user with 0:M org roles would return a list of users in those organisations
 
 ### Stratos Tasks
 - Depending on adoption approach, Stratos needs to support v2 and v3 endpoints concurrently

--- a/docs/cf-api-v3.md
+++ b/docs/cf-api-v3.md
@@ -19,14 +19,14 @@ See [Cloud Foundry API v2 Feature Usage](cf-api-v2-usage.md) for v2 information
 ### Collections - Sorting
 - It looks like all endpoints can be sorted via `created_at` and `updated_at` dates, plus some also have `name`. Given that v2 really only
   supported sorting by `created_at` date this should be fine for feature parity
-- However in order for Stratos to leave behind local sorting there are many missing sort fields (see [Cloud Foundry API v2 Feature Usage - Sorting/Filtering](cf-api-v2-usage.md#Sorting/Filtering))
+- However in order for Stratos to leave behind local sorting there are many missing sort fields (see [Cloud Foundry API v2 Feature Usage - Sorting/Filtering](cf-api-v2-usage.md#sortingfiltering))
 
 ### Collections - Filtering
 - Similar level of filtering is available with the addition of `name`
-- In order for Stratos to leave behind local filtering there are still some fields that need to be implemented (see [Cloud Foundry API v2 Feature Usage # V2 Specifics # Sorting/Filtering](cf-api-v2-usage.md))
+- In order for Stratos to leave behind local filtering there are still some fields that need to be implemented (see [Cloud Foundry API v2 Feature Usage - Sorting/Filtering](cf-api-v2-usage.md#sortingfiltering))
 
 ### Entity Validation
-- For v2 info see [Cloud Foundry API v2 Feature Usage - Entity Relations & Validation](cf-api-v2-usage.md#Entity-Relations-&-Validation)
+- For v2 info see [Cloud Foundry API v2 Feature Usage - Entity Relations & Validation](cf-api-v2-usage.md#entity-relations--validation)
 - It looks like, given that `include` is considerable beefed up, this will still be possible in v3. An update of the entity relations
   process will be required though.
 
@@ -67,14 +67,14 @@ Then Stratos should either ..
   - Might be wrong on this one due to the lack of current `include` integration
 
 ### Frustrating Issues
-- Cannot utilise v3 pagination due to limited sorting and filtering functionality (see [Cloud Foundry API v2 Feature Usage - Sorting/Filtering](cf-api-v2-usage.md#Sorting/Filtering) for missing fields)
+- Cannot utilise v3 pagination due to limited sorting and filtering functionality (see [Cloud Foundry API v2 Feature Usage - Sorting/Filtering](cf-api-v2-usage.md#sortingFiltering) for missing fields)
   - This is currently on par with v2, but causes us a lot of headaches for large data sets
 - The Stratos method of calculating application state is much harder
   - Additional requests to app `/packages` are required. This would be resolved if applications were `link`ed to package
   - Would love a flag in `/apps` to also return the `processes` data. This would mean a longer request time, but we're making that request
     in the frontend anyway.
 - No easy way to fetch organisation or space summary information
-  - Stratos show summary information such as number of users (see [Cloud Foundry API v2 Feature Usage V2 Specifics - Cloud Foundry, Organisation and Space Summary Information](cf-api-v2-usage.md#Cloud-Foundry,-Organisation-and-Space-Summary-Information) for specific stats)
+  - Stratos show summary information such as number of users (see [Cloud Foundry API v2 Feature Usage V2 Specifics - Cloud Foundry, Organisation and Space Summary Information](cf-api-v2-usage.md#cloud-foundry-organisation-and-space-summary-information) for specific stats)
   - In an ideal world we could hit one endpoint that would give us the counts for all of these details. Filters could then limit this to
     an organisation or space
 

--- a/docs/cf-api-v3.md
+++ b/docs/cf-api-v3.md
@@ -1,0 +1,94 @@
+# Cloud Foundry API v3
+
+See [Cloud Foundry API v2 Feature Usage](cf-api-v2-usage.md) for v2 information
+
+## Comparing v2 features to v3
+
+### Entity Relations... `include-relations` --> `include`
+- Like `include-relations`, `include` is used to request entity types in full in the response.
+- These are included in a bucket at the end, rather than including inline (avoid the case where same `space` entity is repeated in `apps` request)
+- Very limited implementation
+  - `/apps` only supports `space` include
+  - `/organization` doesn't support any includes
+  - `/space` doesn't support any includes
+- Unclear if `include` will cover chained entities aka `inline-relations-depth` from v2
+
+### Collections - Pagination
+- This is covered just fine (fetch a specific page, total page count, total result count, etc)
+
+### Collections - Sorting
+- It looks like all endpoints can be sorted via `created_at` and `updated_at` dates, plus some also have `name`. Given that v2 really only
+  supported sorting by `created_at` date this should be fine for feature parity
+- However in order for Stratos to leave behind local sorting there are many missing sort fields (see [Cloud Foundry API v2 Feature Usage - Sorting/Filtering](cf-api-v2-usage.md#Sorting/Filtering))
+
+### Collections - Filtering
+- Similar level of filtering is available with the addition of `name`
+- In order for Stratos to leave behind local filtering there are still some fields that need to be implemented (see [Cloud Foundry API v2 Feature Usage # V2 Specifics # Sorting/Filtering](cf-api-v2-usage.md))
+
+### Entity Validation
+- For v2 info see [Cloud Foundry API v2 Feature Usage - Entity Relations & Validation](cf-api-v2-usage.md#Entity-Relations-&-Validation)
+- It looks like, given that `include` is considerable beefed up, this will still be possible in v3. An update of the entity relations
+  process will be required though.
+
+### Application State
+- For v2 info see [Cloud Foundry API v2 Feature Usage - Application State](cf-api-v2-usage.md#Application-State)
+- The improved application state string that stratos shows will be much harder to determine
+  - App `package_state` is from a separate entity that is not `linked` and requires an additional request
+  - App `package_updated_at` is from a separate entity that is not `linked` and requires an additional request
+  - App instance state should now come form `/processes` and given that instance:process are now not 1:1 harder to summaries state from
+
+## Availability
+- Stratos needs to support cloud foundry's with different api versions from many different providers and epochs
+- Currently, it looks like neither SCF (2.84.0), IBM Cloud (2.106.0) or PCFDev (2.82.0) support v3 with `includes`. PWS (2.125.0) and
+ SAP (2.120.0) however do.
+
+> Note - cf-dev I haven't tested as it's unsupported on linux (major regression from PCFDev there)
+
+> Note - Couldn't find an easy way to determine the version of v3
+
+## Stratos Adoption of v3
+
+Given that...
+- Endpoints are being converted to v3 iteratively, not all are available at the moment
+- Stratos will need to support v2 for a while to come (legacy installs, etc)
+
+Then Stratos should either ..
+- Wait until v3 has feature parity with v2, create new Stratos that uses v3 and mothball versions of Stratos that talk to v2
+- Support both versions at runtime, switching each endpoint from v2 to v3 at determined cut off dates
+
+### Blocking Issues
+- `include` replacement does not have parity with v2.
+  - Not supported on all endpoints and does not cover enough `links`/relations (see [Cloud Foundry API v2 Feature Usage - Inline-Relations](cf-api-v2-usage.md#Inline-Relations))
+  - Not supported by common CFs used to develop with (SCF, PCFDev).
+- Cannot determine if a CF supports v3 or when it does support v3 which endpoints it has
+  - Getting the v2 version is simple, I don't know if there's correlation to v3 version
+  - Having a v3/info which published which endpoints are supported would help a lot. Including whether `include` is supported
+- Chained `links`/relations don't appear to be supported (fetch app-->space-->org all in one request)
+  - Might be wrong on this one due to the lack of current `include` integration
+
+### Frustrating Issues
+- Cannot utilise v3 pagination due to limited sorting and filtering functionality (see [Cloud Foundry API v2 Feature Usage - Sorting/Filtering](cf-api-v2-usage.md#Sorting/Filtering) for missing fields)
+  - This is currently on par with v2, but causes us a lot of headaches for large data sets
+- The Stratos method of calculating application state is much harder
+  - Additional requests to app `/packages` are required. This would be resolved if applications were `link`ed to package
+  - Would love a flag in `/apps` to also return the `processes` data. This would mean a longer request time, but we're making that request
+    in the frontend anyway.
+- No easy way to fetch organisation or space summary information
+  - Stratos show summary information such as number of users (see [Cloud Foundry API v2 Feature Usage V2 Specifics - Cloud Foundry, Organisation and Space Summary Information](cf-api-v2-usage.md#Cloud-Foundry,-Organisation-and-Space-Summary-Information) for specific stats)
+  - In an ideal world we could hit one endpoint that would give us the counts for all of these details. Filters could then limit this to
+    an organisation or space
+
+### Stratos Tasks
+- Depending on adoption approach, Stratos needs to support v2 and v3 endpoints concurrently
+  - Mask the input/output to v3 requests, such that store, pagination, list configuration and entity validation remains mostly unchanged
+  - To do this ...
+    - Query params need to be converted when making v3 requests
+    - v3 responses need to be converted into v2 format (entity/metadata, `<x>_url`, etc).
+- Update application deploy/lifecycle process to match new v3 process (https://github.com/cloudfoundry-incubator/stratos/issues/3150)
+- Support new 'processes' concept (https://github.com/cloudfoundry-incubator/stratos/issues/3154), including updating how
+  we determine application state
+- Fully investigate non `get` methods (create an application, delete a space, etc)
+
+### Questions
+- Will `include` cover children of children? For instance `app` --> `route` --> `domain`
+  - How will lists be covered? For instance `organization` --> `space` --> `service instances`

--- a/docs/cf-api-v3.md
+++ b/docs/cf-api-v3.md
@@ -59,12 +59,14 @@ Then Stratos should either ..
 ### Blocking Issues
 - `include` replacement does not have parity with v2.
   - Not supported on all endpoints and does not cover enough `links`/relations (see [Cloud Foundry API v2 Feature Usage - Inline-Relations](cf-api-v2-usage.md#Inline-Relations))
+  - New v3 entities are not `links` (`/apps` `package`, `processes`, `route_mappings`, `environment_variables`, `droplets`, `tasks`)
   - Not supported by common CFs used to develop with (SCF, PCFDev).
 - Cannot determine if a CF supports v3 or when it does support v3 which endpoints it has
   - Getting the v2 version is simple, I don't know if there's correlation to v3 version
   - Having a v3/info which published which endpoints are supported would help a lot. Including whether `include` is supported
 - Chained `links`/relations don't appear to be supported (fetch app-->space-->org all in one request)
   - Might be wrong on this one due to the lack of current `include` integration
+- `/organizations` and `/spaces` endpoints are not completed and contain only guid, create/updated date and name (space additionally has experimental `organization`)
 
 ### Frustrating Issues
 - Cannot utilise v3 pagination due to limited sorting and filtering functionality (see [Cloud Foundry API v2 Feature Usage - Sorting/Filtering](cf-api-v2-usage.md#sortingFiltering) for missing fields)
@@ -80,6 +82,8 @@ Then Stratos should either ..
 - Fetching a list of users as a non-cf admin involves making a request to every organisation (`organization/${guid}/users`). The response
   of all of these calls contains a lot of overlapping data
   - Ideally making a request to `/users` as a user with 0:M org roles would return a list of users in those organisations
+- Not all v2 endpoints exist in v3, for instance no `domains`, `events`, `route`, org/space quota definitions, etc
+  - This would make our entity validation much more complex
 
 ### Stratos Tasks
 - Depending on adoption approach, Stratos needs to support v2 and v3 endpoints concurrently

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ng": "ng",
     "start": "npm run customize && ng serve",
     "start-high-mem": "npm run customize && node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng serve",
-    "start-prod": "ng serve --prod",
+    "start-prod-high-mem": "npm run customize && node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng serve --prod",
     "start-dev": "ng serve --aot=false",
     "test": "ng test --code-coverage",
     "test-debug": "ng test --watch=true --source-map=true",

--- a/src/frontend/app/features/services/services/services-wall.service.ts
+++ b/src/frontend/app/features/services/services/services-wall.service.ts
@@ -6,7 +6,7 @@ import { filter, map, publishReplay, refCount } from 'rxjs/operators';
 import { IService } from '../../../core/cf-api-svc.types';
 import { PaginationMonitorFactory } from '../../../shared/monitors/pagination-monitor.factory';
 import { GetAllServices } from '../../../store/actions/service.actions';
-import { GetServicesForSpace } from '../../../store/actions/space.actions';
+import { GetAllServicesForSpace } from '../../../store/actions/space.actions';
 import { AppState } from '../../../store/app-state';
 import { entityFactory, serviceSchemaKey } from '../../../store/helpers/entity-factory';
 import { createEntityRelationPaginationKey } from '../../../store/helpers/entity-relations/entity-relations.types';
@@ -56,7 +56,7 @@ export class ServicesWallService {
     return getPaginationObservables<APIResource<IService>>(
       {
         store: this.store,
-        action: new GetServicesForSpace(spaceGuid, cfGuid, paginationKey),
+        action: new GetAllServicesForSpace(spaceGuid, cfGuid, paginationKey),
         paginationMonitor: this.paginationMonitorFactory.create(
           paginationKey,
           entityFactory(serviceSchemaKey)

--- a/src/frontend/app/features/services/services/services-wall.service.ts
+++ b/src/frontend/app/features/services/services/services-wall.service.ts
@@ -56,7 +56,7 @@ export class ServicesWallService {
     return getPaginationObservables<APIResource<IService>>(
       {
         store: this.store,
-        action: new GetAllServicesForSpace(spaceGuid, cfGuid, paginationKey),
+        action: new GetAllServicesForSpace(paginationKey, cfGuid, spaceGuid),
         paginationMonitor: this.paginationMonitorFactory.create(
           paginationKey,
           entityFactory(serviceSchemaKey)

--- a/src/frontend/app/shared/components/list/list-types/app-route/cf-app-map-routes-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/app-route/cf-app-map-routes-list-config.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { MatSnackBar } from '@angular/material';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
 
@@ -17,12 +16,11 @@ import {
   createEntityRelationPaginationKey,
 } from '../../../../../store/helpers/entity-relations/entity-relations.types';
 import { APIResource } from '../../../../../store/types/api.types';
-import { ConfirmationDialogService } from '../../../confirmation-dialog.service';
+import { TableCellRadioComponent } from '../../list-table/table-cell-radio/table-cell-radio.component';
 import { ITableColumn } from '../../list-table/table.types';
 import { IListConfig, ListViewTypes } from '../../list.component.types';
 import { CfAppRoutesDataSource } from './cf-app-routes-data-source';
 import { TableCellAppRouteComponent } from './table-cell-app-route/table-cell-app-route.component';
-import { TableCellRadioComponent } from '../../list-table/table-cell-radio/table-cell-radio.component';
 import { TableCellRouteComponent } from './table-cell-route/table-cell-route.component';
 import { TableCellTCPRouteComponent } from './table-cell-tcproute/table-cell-tcproute.component';
 
@@ -97,12 +95,10 @@ export class CfAppMapRoutesListConfigService implements IListConfig<APIResource>
   constructor(
     private store: Store<AppState>,
     private appService: ApplicationService,
-    private confirmDialog: ConfirmationDialogService,
-    private activatedRoute: ActivatedRoute,
+    activatedRoute: ActivatedRoute,
   ) {
     const spaceGuid = activatedRoute.snapshot.queryParamMap.get('spaceGuid');
     const action = new GetSpaceRoutes(spaceGuid, appService.cfGuid, createEntityRelationPaginationKey(spaceSchemaKey, spaceGuid), [
-      createEntityRelationKey(spaceSchemaKey, routeSchemaKey),
       createEntityRelationKey(routeSchemaKey, domainSchemaKey),
       createEntityRelationKey(routeSchemaKey, applicationSchemaKey)
     ]);

--- a/src/frontend/app/shared/components/list/list-types/cf-space-apps/cf-space-apps-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-space-apps/cf-space-apps-list-config.service.ts
@@ -31,11 +31,6 @@ export class CfSpaceAppsListConfigService implements IListConfig<APIResource> {
       columnId: 'apps', headerCell: () => 'Applications',
       cellComponent: TableCellAppNameComponent,
       cellFlex: '1',
-      sort: {
-        type: 'sort',
-        orderKey: 'apps',
-        field: 'entity.name'
-      }
     },
     {
       columnId: 'status',
@@ -46,6 +41,14 @@ export class CfSpaceAppsListConfigService implements IListConfig<APIResource> {
         initialStateOnly: true
       },
       cellComponent: TableCellAppStatusComponent
+    },
+    {
+      columnId: 'instances',
+      headerCell: () => 'Instances',
+      cellDefinition: {
+        getValue: (row: APIResource) => `${row.entity.instances}`
+      },
+      cellFlex: '1'
     },
     {
       columnId: 'creation', headerCell: () => 'Creation Date',
@@ -59,19 +62,6 @@ export class CfSpaceAppsListConfigService implements IListConfig<APIResource> {
       },
       cellFlex: '2'
     },
-    {
-      columnId: 'instances',
-      headerCell: () => 'Instances',
-      cellDefinition: {
-        getValue: (row: APIResource) => `${row.entity.instances}`
-      },
-      cellFlex: '1', sort: {
-        type: 'sort',
-        orderKey: 'instances',
-        field: 'entity.instances'
-      }
-    },
-
   ]
 
   constructor(

--- a/src/frontend/app/shared/components/list/list-types/cf-spaces/cf-spaces-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-spaces/cf-spaces-list-config.service.ts
@@ -46,10 +46,8 @@ export class CfSpacesListConfigService implements IListConfig<APIResource> {
 
   constructor(
     private store: Store<AppState>,
-    private cfOrgService: CloudFoundryOrganizationService,
-    private confirmDialog: ConfirmationDialogService
+    cfOrgService: CloudFoundryOrganizationService,
   ) {
-
     this.dataSource = new CfSpacesDataSourceService(cfOrgService.cfGuid, cfOrgService.orgGuid, this.store, this);
   }
 

--- a/src/frontend/app/store/actions/application.actions.ts
+++ b/src/frontend/app/store/actions/application.actions.ts
@@ -179,7 +179,7 @@ export class DeleteApplicationInstance extends CFStartAction
   guid: string;
   constructor(
     public appGuid: string,
-    private index: number,
+    index: number,
     public endpointGuid: string
   ) {
     super();

--- a/src/frontend/app/store/actions/service-instances.actions.ts
+++ b/src/frontend/app/store/actions/service-instances.actions.ts
@@ -4,19 +4,15 @@ import {
   applicationSchemaKey,
   entityFactory,
   organizationSchemaKey,
+  serviceBindingNoBindingsSchemaKey,
   serviceBindingSchemaKey,
   serviceInstancesSchemaKey,
   serviceInstancesWithSpaceSchemaKey,
   servicePlanSchemaKey,
   serviceSchemaKey,
   spaceSchemaKey,
-  serviceBindingNoBindingsSchemaKey,
 } from '../helpers/entity-factory';
-import {
-  createEntityRelationKey,
-  EntityInlineChildAction,
-  EntityInlineParentAction,
-} from '../helpers/entity-relations/entity-relations.types';
+import { createEntityRelationKey, EntityInlineParentAction } from '../helpers/entity-relations/entity-relations.types';
 import { PaginationAction } from '../types/pagination.types';
 import { CFStartAction, ICFAction } from '../types/request.types';
 import { getActions } from './action.helper';

--- a/src/frontend/app/store/actions/space.actions.ts
+++ b/src/frontend/app/store/actions/space.actions.ts
@@ -241,8 +241,9 @@ export class GetAllServicesForSpace extends CFStartAction implements PaginationA
     page: 1,
     'results-per-page': 100,
     'order-direction': 'desc',
-    'order-direction-field': 'label',
+    'order-direction-field': 'creation',
   };
+  flattenPagination = true;
 }
 
 
@@ -279,34 +280,4 @@ export class GetServiceInstancesForSpace
   };
   parentGuid: string;
   parentEntitySchema = entityFactory(spaceSchemaKey);
-}
-
-export class GetServicesForSpace
-  extends CFStartAction implements PaginationAction, EntityInlineParentAction {
-  constructor(
-    public spaceGuid: string,
-    public endpointGuid: string,
-    public paginationKey: string,
-    public includeRelations: string[] = [
-      createEntityRelationKey(serviceSchemaKey, servicePlanSchemaKey)
-    ],
-    public populateMissing = true
-  ) {
-    super();
-    this.options = new RequestOptions();
-    this.options.url = `spaces/${spaceGuid}/services`;
-    this.options.method = 'get';
-    this.options.params = new URLSearchParams();
-  }
-  actions = getActions('Space', 'Get all Services');
-  entity = [entityFactory(serviceSchemaKey)];
-  entityKey = serviceSchemaKey;
-  options: RequestOptions;
-  initialParams = {
-    page: 1,
-    'results-per-page': 100,
-    'order-direction': 'desc',
-    'order-direction-field': 'creation',
-  };
-  flattenPagination = true;
 }


### PR DESCRIPTION
Also some small tidy ups I found along the way...

- Add prod high mem npm target
- Remove duplicate `get all services for space` action `GetServicesForSpace`
- Remove undeeded lines
- Remove invalid sorting in space apps table (its non-local and cannot use sort by name & instances)