### PR TITLE
Add stricter check for jetstream error object

### DIFF
--- a/src/frontend/app/core/jetstream.helpers.ts
+++ b/src/frontend/app/core/jetstream.helpers.ts
@@ -1,0 +1,14 @@
+export interface JetStreamError {
+  error: {
+    status: string;
+    statusCode: number;
+  };
+  errorResponse: any;
+}
+
+export function isJetStreamError(obj): JetStreamError {
+  return obj &&
+    obj.error && obj.error.status && obj.error.statusCode &&
+    obj.errorResponse ?
+    obj as JetStreamError : null;
+}

--- a/src/frontend/app/store/effects/api.effects.ts
+++ b/src/frontend/app/store/effects/api.effects.ts
@@ -1,68 +1,36 @@
 import { Injectable } from '@angular/core';
-import {
-  Headers,
-  Http,
-  Request,
-  RequestOptions,
-  URLSearchParams,
-} from '@angular/http';
+import { Headers, Http, Request, RequestOptions, URLSearchParams } from '@angular/http';
 import { Actions, Effect } from '@ngrx/effects';
-import { Store, Action } from '@ngrx/store';
+import { Store } from '@ngrx/store';
 import { normalize, Schema } from 'normalizr';
 import { Observable } from 'rxjs';
-import { map, mergeMap, withLatestFrom, catchError } from 'rxjs/operators';
+import { catchError, map, mergeMap, withLatestFrom } from 'rxjs/operators';
+
 import { LoggerService } from '../../core/logger.service';
 import { SendEventAction } from '../actions/internal-events.actions';
 import { endpointSchemaKey, entityFactory } from '../helpers/entity-factory';
 import { listEntityRelations } from '../helpers/entity-relations/entity-relations';
+import { EntityInlineParentAction, isEntityInlineParentAction } from '../helpers/entity-relations/entity-relations.types';
+import { CfAPIFlattener, flattenPagination } from '../helpers/paginated-request-helpers';
 import {
-  EntityInlineParentAction,
-  isEntityInlineParentAction,
-} from '../helpers/entity-relations/entity-relations.types';
-import {
-  CfAPIFlattener,
-  flattenPagination,
-} from '../helpers/paginated-request-helpers';
-import { getRequestTypeFromMethod, startApiRequest, getFailApiRequestActions } from '../reducers/api-request-reducer/request-helpers';
+  getFailApiRequestActions,
+  getRequestTypeFromMethod,
+  startApiRequest,
+} from '../reducers/api-request-reducer/request-helpers';
 import { qParamsToString } from '../reducers/pagination-reducer/pagination-reducer.helper';
-import {
-  resultPerPageParam,
-  resultPerPageParamDefault,
-} from '../reducers/pagination-reducer/pagination-reducer.types';
+import { resultPerPageParam, resultPerPageParamDefault } from '../reducers/pagination-reducer/pagination-reducer.types';
 import { selectPaginationState } from '../selectors/pagination.selectors';
 import { EndpointModel } from '../types/endpoint.types';
 import { InternalEventSeverity } from '../types/internal-events.types';
-import {
-  PaginatedAction,
-  PaginationEntityState,
-  PaginationParam,
-} from '../types/pagination.types';
-import {
-  APISuccessOrFailedAction,
-  ICFAction,
-  IRequestAction,
-  RequestEntityLocation,
-} from '../types/request.types';
+import { PaginatedAction, PaginationEntityState, PaginationParam } from '../types/pagination.types';
+import { APISuccessOrFailedAction, ICFAction, IRequestAction, RequestEntityLocation } from '../types/request.types';
 import { environment } from './../../../environments/environment';
-import {
-  ApiActionTypes,
-  ValidateEntitiesStart,
-} from './../actions/request.actions';
+import { ApiActionTypes, ValidateEntitiesStart } from './../actions/request.actions';
 import { AppState, IRequestEntityTypeState } from './../app-state';
-import {
-  APIResource,
-  instanceOfAPIResource,
-  NormalizedResponse,
-} from './../types/api.types';
-import {
-  StartRequestAction,
-  WrapperRequestActionFailed,
-} from './../types/request.types';
-import {
-  RecursiveDelete,
-  RecursiveDeleteComplete,
-  RecursiveDeleteFailed,
-} from './recursive-entity-delete.effect';
+import { APIResource, instanceOfAPIResource, NormalizedResponse } from './../types/api.types';
+import { WrapperRequestActionFailed } from './../types/request.types';
+import { RecursiveDelete, RecursiveDeleteComplete, RecursiveDeleteFailed } from './recursive-entity-delete.effect';
+import { isJetStreamError } from '../../core/jetstream.helpers';
 
 const { proxyAPIVersion, cfAPIVersion } = environment;
 const endpointHeader = 'x-cap-cnsi-list';
@@ -73,14 +41,6 @@ interface APIErrorCheck {
   guid: string;
   url: string;
   errorResponse?: JetStreamCFErrorResponse;
-}
-
-interface JetStreamError {
-  error: {
-    status: string;
-    statusCode: number;
-  };
-  errorResponse: JetStreamCFErrorResponse;
 }
 
 interface JetStreamCFErrorResponse {
@@ -106,7 +66,7 @@ export class APIEffect {
       mergeMap(([action, state]) => {
         return this.doApiRequest(action, state);
       }),
-  );
+    );
 
   private doApiRequest(action: ICFAction | PaginatedAction, state: AppState) {
     const actionClone = { ...action };
@@ -280,7 +240,7 @@ export class APIEffect {
             apiAction.guid,
             apiAction.endpointGuid,
             entityFactory(apiAction.entityKey),
-          ), );
+          ));
         }
         return errorActions;
       }),
@@ -350,19 +310,19 @@ export class APIEffect {
     }
     return Object.keys(resData).map(cfGuid => {
       // Return list of guid+error objects for those endpoints with errors
-      const endpoint = resData ? (resData[cfGuid] as JetStreamError) : null;
-      const succeeded = !endpoint || !endpoint.error;
+      const jetStreamError = isJetStreamError(resData ? resData[cfGuid] : null);
+      const succeeded = !jetStreamError || !jetStreamError.error;
       const errorCode =
-        endpoint && endpoint.error
-          ? endpoint.error.statusCode.toString()
+        jetStreamError && jetStreamError.error
+          ? jetStreamError.error.statusCode.toString()
           : '500';
       let errorResponse = null;
       if (!succeeded) {
         errorResponse =
-          endpoint &&
-            (!!endpoint.errorResponse &&
-              typeof endpoint.errorResponse !== 'string')
-            ? endpoint.errorResponse
+          jetStreamError &&
+            (!!jetStreamError.errorResponse &&
+              typeof jetStreamError.errorResponse !== 'string')
+            ? jetStreamError.errorResponse
             : ({} as JetStreamCFErrorResponse);
         // Use defaults if values are not provided
         errorResponse.code = errorResponse.code || 0;
@@ -414,7 +374,7 @@ export class APIEffect {
           data[guid] !== null &&
           errorCheck.findIndex(error => error.guid === guid && !error.error) >=
           0,
-    )
+      )
       .map(cfGuid => {
         const cfData = data[cfGuid];
         switch (apiAction.entityLocation) {
@@ -605,4 +565,5 @@ export class APIEffect {
   private shouldRecursivelyDelete(requestType: string, apiAction: ICFAction) {
     return requestType === 'delete' && !apiAction.updatingKey;
   }
+
 }


### PR DESCRIPTION
- Previously we just looked for an 'error' property
- This caused issues for the autoscaler team
- We now have a stricter check
