### PR TITLE
Use SHA256 to compare SSH public key fingerprint

### DIFF
--- a/src/jetstream/plugins/cfappssh/app_ssh.go
+++ b/src/jetstream/plugins/cfappssh/app_ssh.go
@@ -28,6 +28,9 @@ const (
 
 	// Inactivity timeout
 	inActivityTimeout = 10 * time.Second
+
+	md5FingerprintLength          = 47 // inclusive of space between bytes
+	base64Sha256FingerprintLength = 43
 )
 
 // Allow connections from any Origin
@@ -188,8 +191,17 @@ func sendSSHError(format string, a ...interface{}) error {
 
 func sshHostKeyChecker(fingerprint string) ssh.HostKeyCallback {
 	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
-		if fingerprint == ssh.FingerprintLegacyMD5(key) {
-			return nil
+		switch len(fingerprint) {
+		case base64Sha256FingerprintLength:
+			if fmt.Sprintf("SHA256:%s", fingerprint) == ssh.FingerprintSHA256(key) {
+				return nil
+			}
+		case md5FingerprintLength:
+			if fingerprint == ssh.FingerprintLegacyMD5(key) {
+				return nil
+			}
+		default:
+			return errors.New("Unsupported host key fingerprint format")
 		}
 		return errors.New("Host key fingerprint is incorrect")
 	}


### PR DESCRIPTION
## Description
MD5 is deprecated and cf info endpoint returns now SHA256 fingerprint.
Use SHA256 to compare fingerprints instead MD5


## Motivation and Context

This fixes ssh to an app instance functionality.

## How Has This Been Tested?
Manually 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message