### PR TITLE
Add user has roles filter to users tables

### DIFF
--- a/src/frontend/app/shared/components/list/list-types/app/cf-app-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/cf-app-config.service.ts
@@ -6,11 +6,10 @@ import { UtilsService } from '../../../../../core/utils.service';
 import { ListView } from '../../../../../store/actions/list.actions';
 import { AppState } from '../../../../../store/app-state';
 import { APIResource } from '../../../../../store/types/api.types';
-import { CfOrgSpaceDataService } from '../../../../data-services/cf-org-space-service.service';
+import { CfOrgSpaceDataService, createCfOrgSpaceFilterConfig } from '../../../../data-services/cf-org-space-service.service';
 import { ApplicationStateService } from '../../../application-state/application-state.service';
 import { ITableColumn } from '../../list-table/table.types';
 import { IListConfig, IListMultiFilterConfig, ListConfig, ListViewTypes } from '../../list.component.types';
-import { createListFilterConfig } from '../../list.helper';
 import { CardAppComponent } from './card/card-app.component';
 import { CfAppsDataSource } from './cf-apps-data-source';
 import {
@@ -37,9 +36,9 @@ export class CfAppConfigService extends ListConfig<APIResource> implements IList
     this.appsDataSource = new CfAppsDataSource(this.store, this);
 
     this.multiFilterConfigs = [
-      createListFilterConfig('cf', 'Cloud Foundry', this.cfOrgSpaceService.cf),
-      createListFilterConfig('org', 'Organization', this.cfOrgSpaceService.org),
-      createListFilterConfig('space', 'Space', this.cfOrgSpaceService.space),
+      createCfOrgSpaceFilterConfig('cf', 'Cloud Foundry', this.cfOrgSpaceService.cf),
+      createCfOrgSpaceFilterConfig('org', 'Organization', this.cfOrgSpaceService.org),
+      createCfOrgSpaceFilterConfig('space', 'Space', this.cfOrgSpaceService.space),
     ];
   }
   appsDataSource: CfAppsDataSource;

--- a/src/frontend/app/shared/components/list/list-types/app/cf-apps-data-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/cf-apps-data-source.ts
@@ -100,7 +100,6 @@ export class CfAppsDataSource extends ListDataSource<APIResource> {
           const appState = app.entity.state;
           const appGuid = app.metadata.guid;
           const cfGuid = app.entity.cfGuid;
-          const dispatching = false;
           if (appState === 'STARTED') {
             actions.push({
               id: appGuid,

--- a/src/frontend/app/shared/components/list/list-types/cf-org-users/cf-org-users-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-org-users/cf-org-users-list-config.service.ts
@@ -8,6 +8,7 @@ import {
   CloudFoundryOrganizationService,
 } from '../../../../../features/cloud-foundry/services/cloud-foundry-organization.service';
 import { AppState } from '../../../../../store/app-state';
+import { CfUser } from '../../../../../store/types/user.types';
 import { CfUserService } from '../../../../data-services/cf-user.service';
 import { CfUserListConfigService } from '../cf-users/cf-user-list-config.service';
 
@@ -21,7 +22,14 @@ export class CfOrgUsersListConfigService extends CfUserListConfigService {
     router: Router,
     activeRouteCfOrgSpace: ActiveRouteCfOrgSpace,
     userPerms: CurrentUserPermissionsService) {
-    super(store, cfUserService, router, activeRouteCfOrgSpace, userPerms, cfOrgService.org$);
+    super(
+      store,
+      cfUserService,
+      router,
+      activeRouteCfOrgSpace,
+      userPerms,
+      (user: CfUser): boolean => cfUserService.hasRolesInOrg(user, activeRouteCfOrgSpace.orgGuid, false),
+      cfOrgService.org$
+    );
   }
-
 }

--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-services-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-services-list-config.service.ts
@@ -1,9 +1,7 @@
-
-import {of as observableOf,  BehaviorSubject ,  Observable } from 'rxjs';
-
-import {map, first} from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
+import { BehaviorSubject, of as observableOf } from 'rxjs';
+import { first, map } from 'rxjs/operators';
 
 import { EndpointsService } from '../../../../../core/endpoints.service';
 import { ActiveRouteCfOrgSpace } from '../../../../../features/cloud-foundry/cf-page.types';
@@ -11,13 +9,13 @@ import { ListView } from '../../../../../store/actions/list.actions';
 import { AppState } from '../../../../../store/app-state';
 import { endpointsRegisteredEntitiesSelector } from '../../../../../store/selectors/endpoint.selectors';
 import { APIResource } from '../../../../../store/types/api.types';
-import { CfOrgSpaceItem } from '../../../../data-services/cf-org-space-service.service';
+import { EndpointModel } from '../../../../../store/types/endpoint.types';
+import { CfOrgSpaceItem, createCfOrgSpaceFilterConfig } from '../../../../data-services/cf-org-space-service.service';
+import { ITableColumn } from '../../list-table/table.types';
 import { IListConfig, IListMultiFilterConfig, ListViewTypes } from '../../list.component.types';
-import { createListFilterConfig } from '../../list.helper';
 import { CfServiceCardComponent } from './cf-service-card/cf-service-card.component';
 import { CfServicesDataSource } from './cf-services-data-source';
-import { ITableColumn } from '../../list-table/table.types';
-import { EndpointModel } from '../../../../../store/types/endpoint.types';
+
 
 @Injectable()
 export class CfServicesListConfigService implements IListConfig<APIResource> {
@@ -69,16 +67,16 @@ export class CfServicesListConfigService implements IListConfig<APIResource> {
     this.cf = {
       list$: this.store
         .select(endpointsRegisteredEntitiesSelector).pipe(
-        first(),
-        map(endpoints => {
-          return Object.values(endpoints)
-            .filter((endpoint: EndpointModel) => endpoint.connectionStatus === 'connected' && endpoint.cnsi_type === 'cf');
-        }), ),
+          first(),
+          map(endpoints => {
+            return Object.values(endpoints)
+              .filter((endpoint: EndpointModel) => endpoint.connectionStatus === 'connected' && endpoint.cnsi_type === 'cf');
+          })),
       loading$: observableOf(false),
       select: new BehaviorSubject(undefined)
     };
     this.multiFilterConfigs = [
-      createListFilterConfig('cf', 'Cloud Foundry', this.cf),
+      createCfOrgSpaceFilterConfig('cf', 'Cloud Foundry', this.cf),
     ];
   }
 

--- a/src/frontend/app/shared/components/list/list-types/cf-space-users/cf-space-users-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-space-users/cf-space-users-list-config.service.ts
@@ -11,6 +11,7 @@ import { CloudFoundrySpaceService } from '../../../../../features/cloud-foundry/
 import { AppState } from '../../../../../store/app-state';
 import { CfUserService } from '../../../../data-services/cf-user.service';
 import { CfUserListConfigService } from '../cf-users/cf-user-list-config.service';
+import { CfUser } from '../../../../../store/types/user.types';
 
 @Injectable()
 export class CfSpaceUsersListConfigService extends CfUserListConfigService {
@@ -22,6 +23,15 @@ export class CfSpaceUsersListConfigService extends CfUserListConfigService {
     router: Router,
     activeRouteCfOrgSpace: ActiveRouteCfOrgSpace,
     userPerms: CurrentUserPermissionsService) {
-    super(store, cfUserService, router, activeRouteCfOrgSpace, userPerms, cfOrgService.org$, cfSpaceService.space$);
+    super(
+      store,
+      cfUserService,
+      router,
+      activeRouteCfOrgSpace,
+      userPerms,
+      (user: CfUser): boolean => cfUserService.hasSpaceRoles(user, activeRouteCfOrgSpace.spaceGuid),
+      cfOrgService.org$,
+      cfSpaceService.space$
+    );
   }
 }

--- a/src/frontend/app/shared/components/list/list-types/cf-users/cf-permission-cell.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-users/cf-permission-cell.ts
@@ -27,10 +27,6 @@ export interface ICellPermissionList<T> extends IUserRole<T> {
   spaceGuid?: string;
 }
 
-interface ICellPermissionUpdates {
-  [key: string]: Observable<boolean>;
-}
-
 export abstract class CfPermissionCell<T> extends TableCellCustom<APIResource<CfUser>> {
   userEntity: BehaviorSubject<CfUser> = new BehaviorSubject(null);
 

--- a/src/frontend/app/shared/components/list/list-types/cf-users/cf-user-data-source.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-users/cf-user-data-source.service.ts
@@ -2,16 +2,64 @@ import { Store } from '@ngrx/store';
 
 import { getRowMetadata } from '../../../../../features/cloud-foundry/cf.helpers';
 import { cfUserSchemaKey, entityFactory } from '../../../../../store/helpers/entity-factory';
-import { PaginatedAction } from '../../../../../store/types/pagination.types';
+import { PaginatedAction, PaginationEntityState } from '../../../../../store/types/pagination.types';
 import { ListDataSource } from '../../data-sources-controllers/list-data-source';
 import { ListConfig } from '../../list.component.types';
 import { AppState } from './../../../../../store/app-state';
 import { APIResource } from './../../../../../store/types/api.types';
 import { CfUser } from './../../../../../store/types/user.types';
 
+export const userListUserVisibleKey = 'showUsers';
+// TODO: RC location
+export enum UserListUsersVisible {
+  ALL = 'all',
+  WITH_ROLE = 'withRole',
+  NO_ROLE = 'noRole'
+}
+
+// export const userHas(): boolean {
+//   return false;
+// }
+
+export const userHasRole = (user: CfUser, roleProperty: string): boolean => {
+  return !!user[roleProperty] && !!user[roleProperty].length;
+};
+
+// const userHasAnyRole = (user: CfUser): boolean => {
+//   return userHasRole(user, 'organizations') ||
+//     userHasRole(user, 'spaces') ||
+//     userHasRole(user, 'managed_organizations') ||
+//     userHasRole(user, 'managed_spaces') ||
+//     userHasRole(user, 'audited_organizations') ||
+//     userHasRole(user, 'audited_spaces') ||
+//     userHasRole(user, 'billing_managed_organizations');
+// };
+
+function createUserVisibilityFilter(userHasRoles: (user: CfUser) => boolean):
+  (entities: APIResource<CfUser>[], paginationState: PaginationEntityState) => APIResource<CfUser>[] {
+  return (entities: APIResource<CfUser>[], paginationState: PaginationEntityState): APIResource<CfUser>[] => {
+    const filter: UserListUsersVisible = paginationState.clientPagination.filter.items[userListUserVisibleKey];
+    if (!filter || filter === UserListUsersVisible.ALL) {
+      return entities;
+    }
+    return entities.reduce((response, user) => {
+      const hasARole = userHasRoles(user.entity);
+      if ((filter === UserListUsersVisible.WITH_ROLE && hasARole) || (filter === UserListUsersVisible.NO_ROLE && !hasARole)) {
+        response.push(user);
+      }
+      return response;
+    }, []);
+  };
+}
+
 
 export class CfUserDataSourceService extends ListDataSource<APIResource<CfUser>> {
-  constructor(store: Store<AppState>, action: PaginatedAction, listConfigService: ListConfig<APIResource<CfUser>>) {
+  constructor(
+    store: Store<AppState>,
+    action: PaginatedAction,
+    listConfigService: ListConfig<APIResource<CfUser>>,
+    userHasRoles: (user: CfUser) => boolean
+  ) {
     super({
       store,
       action,
@@ -19,7 +67,7 @@ export class CfUserDataSourceService extends ListDataSource<APIResource<CfUser>>
       getRowUniqueId: getRowMetadata,
       paginationKey: action.paginationKey,
       isLocal: true,
-      transformEntities: [{ type: 'filter', field: 'entity.username' }],
+      transformEntities: [{ type: 'filter', field: 'entity.username' }, createUserVisibilityFilter(userHasRoles)],
       listConfig: listConfigService
     });
   }

--- a/src/frontend/app/shared/components/list/list-types/cf-users/cf-user-data-source.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-users/cf-user-data-source.service.ts
@@ -8,32 +8,7 @@ import { ListConfig } from '../../list.component.types';
 import { AppState } from './../../../../../store/app-state';
 import { APIResource } from './../../../../../store/types/api.types';
 import { CfUser } from './../../../../../store/types/user.types';
-
-export const userListUserVisibleKey = 'showUsers';
-// TODO: RC location
-export enum UserListUsersVisible {
-  ALL = 'all',
-  WITH_ROLE = 'withRole',
-  NO_ROLE = 'noRole'
-}
-
-// export const userHas(): boolean {
-//   return false;
-// }
-
-export const userHasRole = (user: CfUser, roleProperty: string): boolean => {
-  return !!user[roleProperty] && !!user[roleProperty].length;
-};
-
-// const userHasAnyRole = (user: CfUser): boolean => {
-//   return userHasRole(user, 'organizations') ||
-//     userHasRole(user, 'spaces') ||
-//     userHasRole(user, 'managed_organizations') ||
-//     userHasRole(user, 'managed_spaces') ||
-//     userHasRole(user, 'audited_organizations') ||
-//     userHasRole(user, 'audited_spaces') ||
-//     userHasRole(user, 'billing_managed_organizations');
-// };
+import { UserListUsersVisible, userListUserVisibleKey } from './cf-user-list-helpers';
 
 function createUserVisibilityFilter(userHasRoles: (user: CfUser) => boolean):
   (entities: APIResource<CfUser>[], paginationState: PaginationEntityState) => APIResource<CfUser>[] {

--- a/src/frontend/app/shared/components/list/list-types/cf-users/cf-user-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-users/cf-user-list-config.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { combineLatest, Observable, of as observableOf } from 'rxjs';
-import { filter, map, switchMap, tap } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, Observable, of as observableOf } from 'rxjs';
+import { filter, map, switchMap, tap, first } from 'rxjs/operators';
 
 import { IOrganization, ISpace } from '../../../../../core/cf-api.types';
 import { CurrentUserPermissionsChecker } from '../../../../../core/current-user-permissions.checker';
@@ -15,11 +15,20 @@ import { AppState } from './../../../../../store/app-state';
 import { APIResource, EntityInfo } from './../../../../../store/types/api.types';
 import { CfUserService } from './../../../../data-services/cf-user.service';
 import { ITableColumn } from './../../list-table/table.types';
-import { IListAction, IMultiListAction, ListConfig, ListViewTypes } from './../../list.component.types';
+import {
+  IListAction,
+  IListMultiFilterConfig,
+  IMultiListAction,
+  ListConfig,
+  ListViewTypes,
+} from './../../list.component.types';
 import { CfOrgPermissionCellComponent } from './cf-org-permission-cell/cf-org-permission-cell.component';
 import { CfSpacePermissionCellComponent } from './cf-space-permission-cell/cf-space-permission-cell.component';
-import { CfUserDataSourceService } from './cf-user-data-source.service';
-
+import { CfUserDataSourceService, UserListUsersVisible, userListUserVisibleKey, userHasRole } from './cf-user-data-source.service';
+import { cfUserSchemaKey } from '../../../../../store/helpers/entity-factory';
+import { selectPaginationState } from '../../../../../store/selectors/pagination.selectors';
+import { SetClientFilter } from '../../../../../store/actions/pagination.actions';
+import { PaginatedAction } from '../../../../../store/types/pagination.types';
 
 @Injectable()
 export class CfUserListConfigService extends ListConfig<APIResource<CfUser>> {
@@ -61,7 +70,7 @@ export class CfUserListConfigService extends ListConfig<APIResource<CfUser>> {
     noEntries: 'There are no users'
   };
   private initialised: Observable<boolean>;
-  private canEditOrgSpaceRoles$: Observable<boolean>;
+  private multiFilterConfigs: IListMultiFilterConfig[];
 
   manageUserAction: IListAction<APIResource<CfUser>> = {
     action: (user: APIResource<CfUser>) => {
@@ -88,7 +97,7 @@ export class CfUserListConfigService extends ListConfig<APIResource<CfUser>> {
     description: `Change Roles`,
   };
 
-  private createManagerUsersUrl(user: APIResource<CfUser> = null): string {
+  private createManagerUsersUrl(): string {
     let route = `/cloud-foundry/${this.cfUserService.activeRouteCfOrgSpace.cfGuid}`;
     if (this.activeRouteCfOrgSpace.orgGuid) {
       route += `/organizations/${this.activeRouteCfOrgSpace.orgGuid}`;
@@ -106,12 +115,23 @@ export class CfUserListConfigService extends ListConfig<APIResource<CfUser>> {
     private router: Router,
     private activeRouteCfOrgSpace: ActiveRouteCfOrgSpace,
     private userPerms: CurrentUserPermissionsService,
+    userHasRoles: (user: CfUser) => boolean = (user: CfUser): boolean => {
+      return userHasRole(user, 'organizations') ||
+        userHasRole(user, 'spaces') ||
+        userHasRole(user, 'managed_organizations') ||
+        userHasRole(user, 'managed_spaces') ||
+        userHasRole(user, 'audited_organizations') ||
+        userHasRole(user, 'audited_spaces') ||
+        userHasRole(user, 'billing_managed_organizations');
+    },
     org$?: Observable<EntityInfo<APIResource<IOrganization>>>,
     space$?: Observable<EntityInfo<APIResource<ISpace>>>,
   ) {
     super();
 
     this.assignColumnConfig(org$, space$);
+
+    this.assignMultiConfig();
 
     this.initialised = waitForCFPermissions(store, activeRouteCfOrgSpace.cfGuid).pipe(
       switchMap(cf => // `cf` needed to create the second observable
@@ -121,11 +141,54 @@ export class CfUserListConfigService extends ListConfig<APIResource<CfUser>> {
         )
       ),
       tap(([cf, action]) => {
-        this.dataSource = new CfUserDataSourceService(store, action, this);
+        this.dataSource = new CfUserDataSourceService(store, action, this, userHasRoles);
+
+        this.initialiseMultiFilter(action);
       }),
       map(([cf, action]) => cf && cf.state.initialised)
     );
     this.manageMultiUserAction.visible$ = this.createCanUpdateOrgSpaceRoles();
+  }
+
+  private initialiseMultiFilter(action: PaginatedAction) {
+    this.store.select(selectPaginationState(action.entityKey, action.paginationKey)).pipe(
+      filter((pag) => !!pag),
+      first(),
+    ).subscribe(pag => {
+      const currentFilter = pag.clientPagination.filter.items[userListUserVisibleKey];
+      if (!currentFilter) {
+        this.store.dispatch(new SetClientFilter(action.entityKey, action.paginationKey, {
+          string: '',
+          items: {
+            [userListUserVisibleKey]: UserListUsersVisible.WITH_ROLE
+          }
+        }));
+      }
+    });
+  }
+
+  private assignMultiConfig = () => {
+    this.multiFilterConfigs = [
+      {
+        key: userListUserVisibleKey,
+        label: 'All Users',
+        allLabel: 'All Users',
+        list$: observableOf([
+          {
+            label: 'Users With Roles',
+            item: UserListUsersVisible.WITH_ROLE,
+            value: UserListUsersVisible.WITH_ROLE
+          },
+          {
+            label: 'Users Without Roles',
+            item: UserListUsersVisible.NO_ROLE,
+            value: UserListUsersVisible.NO_ROLE
+          }
+        ]),
+        loading$: observableOf(false),
+        select: new BehaviorSubject(UserListUsersVisible.WITH_ROLE)
+      }
+    ];
   }
 
   /**
@@ -193,7 +256,7 @@ export class CfUserListConfigService extends ListConfig<APIResource<CfUser>> {
   getGlobalActions = () => [];
   getMultiActions = () => [this.manageMultiUserAction];
   getSingleActions = () => [this.manageUserAction];
-  getMultiFiltersConfigs = () => [];
+  getMultiFiltersConfigs = () => this.multiFilterConfigs;
   getDataSource = () => this.dataSource;
   getInitialised = () => this.initialised;
 

--- a/src/frontend/app/shared/components/list/list-types/cf-users/cf-user-list-helpers.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-users/cf-user-list-helpers.ts
@@ -1,0 +1,13 @@
+import { CfUser } from '../../../../../store/types/user.types';
+
+export const userListUserVisibleKey = 'showUsers';
+
+export enum UserListUsersVisible {
+  ALL = 'all',
+  WITH_ROLE = 'withRole',
+  NO_ROLE = 'noRole'
+}
+
+export const userHasRole = (user: CfUser, roleProperty: string): boolean => {
+  return !!user[roleProperty] && !!user[roleProperty].length;
+};

--- a/src/frontend/app/shared/components/list/list-types/services-wall/service-instances-wall-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/services-wall/service-instances-wall-list-config.service.ts
@@ -5,10 +5,9 @@ import { Store } from '@ngrx/store';
 import { CurrentUserPermissionsService } from '../../../../../core/current-user-permissions.service';
 import { ListView } from '../../../../../store/actions/list.actions';
 import { AppState } from '../../../../../store/app-state';
-import { CfOrgSpaceDataService } from '../../../../data-services/cf-org-space-service.service';
+import { CfOrgSpaceDataService, createCfOrgSpaceFilterConfig } from '../../../../data-services/cf-org-space-service.service';
 import { ServiceActionHelperService } from '../../../../data-services/service-action-helper.service';
 import { defaultPaginationPageSizeOptionsCards, ListViewTypes } from '../../list.component.types';
-import { createListFilterConfig } from '../../list.helper';
 import { cfOrgSpaceFilter } from '../app/cf-apps-data-source';
 import { CfServiceInstancesListConfigBase } from '../cf-services/cf-service-instances-list-config.base';
 import { ServiceInstanceCardComponent } from './service-instance-card/service-instance-card.component';
@@ -43,9 +42,9 @@ export class ServiceInstancesWallListConfigService extends CfServiceInstancesLis
   ) {
     super(store, datePipe, currentUserPermissionsService, serviceActionHelperService);
     const multiFilterConfigs = [
-      createListFilterConfig('cf', 'Cloud Foundry', this.cfOrgSpaceService.cf),
-      createListFilterConfig('org', 'Organization', this.cfOrgSpaceService.org),
-      createListFilterConfig('space', 'Space', this.cfOrgSpaceService.space),
+      createCfOrgSpaceFilterConfig('cf', 'Cloud Foundry', this.cfOrgSpaceService.cf),
+      createCfOrgSpaceFilterConfig('org', 'Organization', this.cfOrgSpaceService.org),
+      createCfOrgSpaceFilterConfig('space', 'Space', this.cfOrgSpaceService.space),
     ];
 
     const transformEntities = [{ type: 'filter', field: 'entity.name' }, cfOrgSpaceFilter];

--- a/src/frontend/app/shared/components/list/list.component.html
+++ b/src/frontend/app/shared/components/list/list.component.html
@@ -16,7 +16,7 @@
           <div class="list-component__header__left--multi-filters" [hidden]="(!(hasRows$ | async) && !filter) || (isAddingOrSelecting$ | async)">
             <mat-form-field *ngFor="let multiFilterConfig of multiFilterConfigs" [floatLabel]="'never'">
               <mat-select id="{{multiFilterConfig.key}}" matInput [(value)]="multiFilters[multiFilterConfig.key]" [disabled]="(dataSource.isLoadingPage$ | async) || (multiFilterConfig.loading$ | async) || !(multiFilterConfig.list$ | async) || !(multiFilterConfig.list$ | async).length" (selectionChange)="multiFilterConfig.select.next($event.value)">
-                <mat-option>All</mat-option>
+                <mat-option>{{ multiFilterConfig.allLabel || 'All' }}</mat-option>
                 <mat-option *ngFor="let selectItem of multiFilterConfig.list$ | async" [value]="selectItem.value">
                   {{selectItem.label}}
                 </mat-option>

--- a/src/frontend/app/shared/components/list/list.component.types.ts
+++ b/src/frontend/app/shared/components/list/list.component.types.ts
@@ -92,6 +92,7 @@ export interface IListConfig<T> {
 export interface IListMultiFilterConfig {
   key: string;
   label: string;
+  allLabel?: string;
   list$: Observable<IListMultiFilterConfigItem[]>;
   loading$: Observable<boolean>;
   select: BehaviorSubject<any>;

--- a/src/frontend/app/shared/components/list/list.helper.ts
+++ b/src/frontend/app/shared/components/list/list.helper.ts
@@ -1,27 +1,10 @@
 import { Subscription } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 import { entityFactory } from '../../../store/helpers/entity-factory';
-import { CfOrgSpaceItem } from '../../data-services/cf-org-space-service.service';
 import { EntityMonitorFactory } from '../../monitors/entity-monitor.factory.service';
 import { PaginationMonitor } from '../../monitors/pagination-monitor';
 import { PaginationMonitorFactory } from '../../monitors/pagination-monitor.factory';
 import { TableRowStateManager } from './list-table/table-row/table-row-state-manager';
-
-export function createListFilterConfig(key: string, label: string, cfOrgSpaceItem: CfOrgSpaceItem) {
-  return {
-    key: key,
-    label: label,
-    ...cfOrgSpaceItem,
-    list$: cfOrgSpaceItem.list$.pipe(map((entities: any[]) => {
-      return entities.map(entity => ({
-        label: entity.name,
-        item: entity,
-        value: entity.guid
-      }));
-    })),
-  };
-}
 
 export type ListRowStateSetUpManager = (
   paginationMonitor: PaginationMonitor<any>,

--- a/src/frontend/app/shared/data-services/cf-org-space-service.service.ts
+++ b/src/frontend/app/shared/data-services/cf-org-space-service.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, OnDestroy, Optional } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { BehaviorSubject, combineLatest, Observable, Subscription, of as observableOf } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, of as observableOf, Subscription } from 'rxjs';
 import { distinctUntilChanged, filter, first, map, startWith, switchMap, tap, withLatestFrom } from 'rxjs/operators';
 
 import { IOrganization, ISpace } from '../../core/cf-api.types';
@@ -17,6 +17,21 @@ import { selectPaginationState } from '../../store/selectors/pagination.selector
 import { APIResource } from '../../store/types/api.types';
 import { EndpointModel } from '../../store/types/endpoint.types';
 import { PaginationMonitorFactory } from '../monitors/pagination-monitor.factory';
+
+export function createCfOrgSpaceFilterConfig(key: string, label: string, cfOrgSpaceItem: CfOrgSpaceItem) {
+  return {
+    key: key,
+    label: label,
+    ...cfOrgSpaceItem,
+    list$: cfOrgSpaceItem.list$.pipe(map((entities: any[]) => {
+      return entities.map(entity => ({
+        label: entity.name,
+        item: entity,
+        value: entity.guid
+      }));
+    })),
+  };
+}
 
 export interface CfOrgSpaceItem<T = any> {
   list$: Observable<T[]>;

--- a/src/frontend/app/shared/data-services/cf-user.service.ts
+++ b/src/frontend/app/shared/data-services/cf-user.service.ts
@@ -210,6 +210,12 @@ export class CfUserService {
       this.populatedArray(this.filterByOrg(orgGuid, user.spaces));
   }
 
+  hasSpaceRoles(user: CfUser, spaceGuid: string): boolean {
+    return this.populatedArray(filterEntitiesByGuid(spaceGuid, user.audited_spaces)) ||
+      this.populatedArray(filterEntitiesByGuid(spaceGuid, user.managed_spaces)) ||
+      this.populatedArray(filterEntitiesByGuid(spaceGuid, user.spaces));
+  }
+
   getUserRoleInOrg = (
     userGuid: string,
     orgGuid: string,

--- a/src/test-e2e/cloud-foundry/cf-level/cf-users-list-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/cf-level/cf-users-list-e2e.spec.ts
@@ -1,8 +1,8 @@
-import { setupCfUserTableTests } from '../users-list-e2e.helper';
+import { CfUserTableTestLevel, setupCfUserTableTests } from '../users-list-e2e.helper';
 import { CfTopLevelPage } from './cf-top-level-page.po';
 
 describe('Cf Users List -', () => {
-  setupCfUserTableTests(true, (cfGuid) => {
+  setupCfUserTableTests(CfUserTableTestLevel.Cf, (cfGuid) => {
     const cfPage = CfTopLevelPage.forEndpoint(cfGuid);
     cfPage.navigateTo();
     cfPage.waitForPageOrChildPage();

--- a/src/test-e2e/cloud-foundry/org-level/org-users-list-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/org-level/org-users-list-e2e.spec.ts
@@ -1,8 +1,8 @@
-import { setupCfUserTableTests } from '../users-list-e2e.helper';
+import { CfUserTableTestLevel, setupCfUserTableTests } from '../users-list-e2e.helper';
 import { CfOrgLevelPage } from './cf-org-level-page.po';
 
 describe('Org Users List -', () => {
-  setupCfUserTableTests(false, (cfGuid, orgGuid) => {
+  setupCfUserTableTests(CfUserTableTestLevel.Org, (cfGuid, orgGuid) => {
     const orgPage = CfOrgLevelPage.forEndpoint(cfGuid, orgGuid);
     orgPage.navigateTo();
     orgPage.waitForPageOrChildPage();

--- a/src/test-e2e/cloud-foundry/space-level/space-users-list-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/space-level/space-users-list-e2e.spec.ts
@@ -1,8 +1,8 @@
-import { setupCfUserTableTests } from '../users-list-e2e.helper';
+import { CfUserTableTestLevel, setupCfUserTableTests } from '../users-list-e2e.helper';
 import { CfSpaceLevelPage } from './cf-space-level-page.po';
 
 describe('Space Users List -', () => {
-  setupCfUserTableTests(false, (cfGuid, orgGuid, spaceGuid) => {
+  setupCfUserTableTests(CfUserTableTestLevel.Space, (cfGuid, orgGuid, spaceGuid) => {
     const spacePage = CfSpaceLevelPage.forEndpoint(cfGuid, orgGuid, spaceGuid);
     spacePage.navigateTo();
     spacePage.waitForPageOrChildPage();

--- a/src/test-e2e/cloud-foundry/users-list-e2e.helper.ts
+++ b/src/test-e2e/cloud-foundry/users-list-e2e.helper.ts
@@ -8,6 +8,12 @@ import { ConsoleUserType, E2EHelpers } from '../helpers/e2e-helpers';
 import { extendE2ETestTime } from '../helpers/extend-test-helpers';
 import { CFUsersListComponent, UserRoleChip } from '../po/cf-users-list.po';
 
+export enum CfUserTableTestLevel {
+  Cf = 1,
+  Org = 2,
+  Space = 3
+}
+
 export function setUpTestOrgSpaceE2eTest(
   orgName: string,
   spaceName: string,
@@ -74,7 +80,8 @@ export function setUpTestOrgSpaceUserRoles(
 }
 
 const customOrgSpacesLabel = E2EHelpers.e2eItemPrefix + (process.env.CUSTOM_APP_LABEL || process.env.USER) + '-cf-users';
-export function setupCfUserTableTests(cfLevel = true, navToUserTableFn: (cfGuid, orgGuid, spaceGuid) => promise.Promise<any>) {
+export function setupCfUserTableTests(
+  cfLevel: CfUserTableTestLevel, navToUserTableFn: (cfGuid, orgGuid, spaceGuid) => promise.Promise<any>) {
 
   const orgName = E2EHelpers.createCustomName(customOrgSpacesLabel);
   const spaceName = E2EHelpers.createCustomName(customOrgSpacesLabel);
@@ -107,8 +114,8 @@ export function setupCfUserTableTests(cfLevel = true, navToUserTableFn: (cfGuid,
     const userRowIndex = 0;
 
     let orgUserChip: UserRoleChip;
-    const testOrgName = cfLevel ? orgName : null;
-    const testSpaceName = cfLevel ? spaceName : null;
+    const testOrgName = cfLevel === CfUserTableTestLevel.Cf ? orgName : null;
+    const testSpaceName = cfLevel === CfUserTableTestLevel.Cf ? spaceName : null;
 
     beforeAll(() => {
       usersTable.waitUntilShown();
@@ -138,23 +145,31 @@ export function setupCfUserTableTests(cfLevel = true, navToUserTableFn: (cfGuid,
       spaceManagerChip.remove();
     });
 
-    it('Check org pills are present, can be removed and then remove', () => {
-      const orgBillingManagerChip = usersTable.getPermissionChip(userRowIndex, testOrgName, null, true, 'Billing Manager');
-      orgBillingManagerChip.check(true);
-      orgBillingManagerChip.remove();
-      const orgAuditorChip = usersTable.getPermissionChip(userRowIndex, testOrgName, null, true, 'Auditor');
-      orgAuditorChip.check(true);
-      orgAuditorChip.remove();
-      const orgManagerChip = usersTable.getPermissionChip(userRowIndex, testOrgName, null, true, 'Manager');
-      orgManagerChip.check(true);
-      orgManagerChip.remove();
-    });
+    // If we're at space level, as soon as the space roles are removed the user is not visible
 
-    it('Check org user pill can now be removed and remove it', () => {
-      // Requires all previous tests
-      orgUserChip.check(true);
-      orgUserChip.remove();
-    });
+    if (cfLevel === CfUserTableTestLevel.Space) {
+      it('Check user is not visible if they have no space roles', () => {
+        usersTable.empty.waitUntilShown('`No users` message');
+      });
+    } else {
+      it('Check org pills are present, can be removed and then remove', () => {
+        const orgBillingManagerChip = usersTable.getPermissionChip(userRowIndex, testOrgName, null, true, 'Billing Manager');
+        orgBillingManagerChip.check(true);
+        orgBillingManagerChip.remove();
+        const orgAuditorChip = usersTable.getPermissionChip(userRowIndex, testOrgName, null, true, 'Auditor');
+        orgAuditorChip.check(true);
+        orgAuditorChip.remove();
+        const orgManagerChip = usersTable.getPermissionChip(userRowIndex, testOrgName, null, true, 'Manager');
+        orgManagerChip.check(true);
+        orgManagerChip.remove();
+      });
+
+      it('Check org user pill can now be removed and remove it', () => {
+        // Requires all previous tests
+        orgUserChip.check(true);
+        orgUserChip.remove();
+      });
+    }
   });
 
   afterAll(() => cfHelper.deleteOrgIfExisting(cfGuid, orgName));

--- a/src/test-e2e/po/component.po.ts
+++ b/src/test-e2e/po/component.po.ts
@@ -32,10 +32,10 @@ export class Component {
   }
 
   // Pass an optional description to help when debugging test issues
-  waitUntilShown(description = 'Element'): promise.Promise<void> {
+  waitUntilShown(elementDescription = 'Element'): promise.Promise<void> {
     return browser.wait(until.presenceOf(this.locator), 5000,
-      description + ' taking too long to appear in the DOM').then(() => {
-        return browser.wait(until.visibilityOf(this.locator), 5000, description + ' not visible timing out').then(v => {
+      elementDescription + ' taking too long to appear in the DOM').then(() => {
+        return browser.wait(until.visibilityOf(this.locator), 5000, elementDescription + ' not visible timing out').then(v => {
           // Slight delay for animations
           return browser.driver.sleep(100);
         });


### PR DESCRIPTION
- Show a drop down filter on CF/Org/Space Users table
- Filter changes users shown in one of three ways
  - Show all users
  - [Default] Show users with roles .. with respect to context (at org level only show users with roles in that org and not other orgs, etc)
  - Show users with no roles... again with respect to context
- Does not include the users table shown in the manage user steppers (to be removed in subsequent PR)
- Fixes #3075