### PR TITLE
Add link to dashboard in service instance table

### DIFF
--- a/src/frontend/app/shared/components/list/list-table/app-table-cell-default/app-table-cell-default.component.html
+++ b/src/frontend/app/shared/components/list/list-table/app-table-cell-default/app-table-cell-default.component.html
@@ -1,13 +1,28 @@
 <span *ngIf="!isLink">
   <ng-container *ngTemplateOutlet="valueTemplate; context: valueContext"></ng-container>
 </span>
-<span *ngIf="isLink">
-  <a [href]="linkValue" [attr.target]="linkTarget" *ngIf="isExternalLink">
+<span *ngIf="isLink" class="link">
+  <ng-container *ngIf="showShortLink">
+    <div *ngIf="linkValue" class="link__short">
+      <a class="link__short__icon" [href]="linkValue" [attr.target]="linkTarget">
+        <mat-icon>launch</mat-icon>
+      </a>
+      <a [href]="linkValue" [attr.target]="linkTarget">View</a>
+    </div>
+    <ng-container *ngIf="!linkValue">
+      -
+    </ng-container>
+  </ng-container>
+  <ng-container *ngIf="!showShortLink">
+    <a [href]="linkValue" [attr.target]="linkTarget" *ngIf="isExternalLink">
+      external
       <ng-container *ngTemplateOutlet="valueTemplate; context: valueContext"></ng-container>
-  </a>
-  <a [routerLink]="linkValue" [attr.target]="linkTarget" *ngIf="!isExternalLink">
+    </a>
+    <a [routerLink]="linkValue" [attr.target]="linkTarget" *ngIf="!isExternalLink">
+      internal
       <ng-container *ngTemplateOutlet="valueTemplate; context: valueContext"></ng-container>
-  </a>
+    </a>
+  </ng-container>
 </span>
 
 <ng-template let-value="value" #valueTemplate>

--- a/src/frontend/app/shared/components/list/list-table/app-table-cell-default/app-table-cell-default.component.html
+++ b/src/frontend/app/shared/components/list/list-table/app-table-cell-default/app-table-cell-default.component.html
@@ -15,11 +15,9 @@
   </ng-container>
   <ng-container *ngIf="!showShortLink">
     <a [href]="linkValue" [attr.target]="linkTarget" *ngIf="isExternalLink">
-      external
       <ng-container *ngTemplateOutlet="valueTemplate; context: valueContext"></ng-container>
     </a>
     <a [routerLink]="linkValue" [attr.target]="linkTarget" *ngIf="!isExternalLink">
-      internal
       <ng-container *ngTemplateOutlet="valueTemplate; context: valueContext"></ng-container>
     </a>
   </ng-container>

--- a/src/frontend/app/shared/components/list/list-table/app-table-cell-default/app-table-cell-default.component.scss
+++ b/src/frontend/app/shared/components/list/list-table/app-table-cell-default/app-table-cell-default.component.scss
@@ -1,1 +1,17 @@
+.link {
+  &__short {
+    display: flex;
 
+    &__icon {
+      font-size: 17px;
+
+      mat-icon {
+        font-size: 16px;
+        height: 16px;
+        margin-right: 2px;
+        width: 16px;
+      }
+    }
+
+  }
+}

--- a/src/frontend/app/shared/components/list/list-table/app-table-cell-default/app-table-cell-default.component.ts
+++ b/src/frontend/app/shared/components/list/list-table/app-table-cell-default/app-table-cell-default.component.ts
@@ -34,6 +34,7 @@ export class TableCellDefaultComponent<T> extends TableCellCustom<T> implements 
   public linkValue: string;
   public linkTarget = '_self';
   public valueGenerator: (row: T) => string;
+  public showShortLink = false;
 
   public init() {
     this.setValueGenerator();
@@ -46,6 +47,10 @@ export class TableCellDefaultComponent<T> extends TableCellCustom<T> implements 
       this.linkTarget = '_blank';
     }
     this.isExternalLink = this.isLink && this.cellDefinition.externalLink;
+    this.showShortLink = this.cellDefinition.showShortLink;
+    if (this.showShortLink && !this.isExternalLink) {
+      throw Error('Short links must be external links');
+    }
   }
 
   private setSyncLink() {

--- a/src/frontend/app/shared/components/list/list-table/table.types.ts
+++ b/src/frontend/app/shared/components/list/list-table/table.types.ts
@@ -27,6 +27,7 @@ export interface ICellDefinition<T> {
   getAsyncLink?: (value) => string;
   newTab?: boolean;
   asyncValue?: ICellAsyncValue;
+  showShortLink?: boolean;
 }
 
 export type CellConfigFunction<T> = (row: T) => any;

--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-instances-list-config.base.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-instances-list-config.base.ts
@@ -77,6 +77,19 @@ export class CfServiceInstancesListConfigBase implements IListConfig<APIResource
       cellFlex: '1'
     },
     {
+      columnId: 'dashboard',
+      headerCell: () => 'Dashboard',
+      cellDefinition: {
+        // Should the value of getLink be used in a href or routerLink
+        externalLink: true,
+        // Automatically turns the cell into a link
+        getLink: (row: APIResource<IServiceInstance>) => row.entity.dashboard_url,
+        newTab: true,
+        showShortLink: true
+      },
+      cellFlex: '1'
+    },
+    {
       columnId: 'tags',
       headerCell: () => 'Tags',
       cellComponent: TableCellServiceInstanceTagsComponent,

--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-instances-list-config.base.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-instances-list-config.base.ts
@@ -80,9 +80,7 @@ export class CfServiceInstancesListConfigBase implements IListConfig<APIResource
       columnId: 'dashboard',
       headerCell: () => 'Dashboard',
       cellDefinition: {
-        // Should the value of getLink be used in a href or routerLink
         externalLink: true,
-        // Automatically turns the cell into a link
         getLink: (row: APIResource<IServiceInstance>) => row.entity.dashboard_url,
         newTab: true,
         showShortLink: true


### PR DESCRIPTION
- Adds link to table, we already show in card
- Adds functionality to basic table cell to show link as a `view` style link
- fixes #2955
  - Note -request was also to add to market place service table, however we don't appear to get the url in the service entity