### PR TITLE
Add service provider name to marketplace service card

### DIFF
--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.html
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.html
@@ -51,6 +51,12 @@
       <div *ngIf="!hasDocumentationUrl() && !hasSupportUrl()">-</div>
     </app-meta-card-value>
   </app-meta-card-item>
+  <app-meta-card-item>
+    <app-meta-card-key>Provider</app-meta-card-key>
+    <app-meta-card-value>
+      {{ extraInfo?.providerDisplayName || '-' }}
+    </app-meta-card-value>
+  </app-meta-card-item>
   <app-meta-card-item customStyle="column">
     <app-meta-card-key>Tags</app-meta-card-key>
     <app-meta-card-value>

--- a/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.html
+++ b/src/frontend/app/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.html
@@ -51,11 +51,9 @@
       <div *ngIf="!hasDocumentationUrl() && !hasSupportUrl()">-</div>
     </app-meta-card-value>
   </app-meta-card-item>
-  <app-meta-card-item>
+  <app-meta-card-item *ngIf="extraInfo?.providerDisplayName">
     <app-meta-card-key>Provider</app-meta-card-key>
-    <app-meta-card-value>
-      {{ extraInfo?.providerDisplayName || '-' }}
-    </app-meta-card-value>
+    <app-meta-card-value>{{ extraInfo?.providerDisplayName }}</app-meta-card-value>
   </app-meta-card-item>
   <app-meta-card-item customStyle="column">
     <app-meta-card-key>Tags</app-meta-card-key>


### PR DESCRIPTION
- Fixes #2953
- Provider is now shown on the market place service card
- The service detail card already contained this, but was optionally shown
 