### PR TITLE
Ensure an empty errorResponse gets picked up as a jetstream error

### DIFF
--- a/src/frontend/app/core/jetstream.helpers.ts
+++ b/src/frontend/app/core/jetstream.helpers.ts
@@ -9,6 +9,6 @@ export interface JetStreamError {
 export function isJetStreamError(obj): JetStreamError {
   return obj &&
     obj.error && obj.error.status && obj.error.statusCode &&
-    obj.errorResponse ?
+    'errorResponse' in obj ?
     obj as JetStreamError : null;
 }


### PR DESCRIPTION
In some rare cases the jetstream returns an error message with a null errorResponse. I've changed the check to check that the errorResponse key exists rather than check that it is a truthy.