### PR TITLE
Fix auto select of single items in multi filter list

### DIFF
--- a/src/frontend/app/shared/components/list/list.component.html
+++ b/src/frontend/app/shared/components/list/list.component.html
@@ -28,7 +28,7 @@
           <div class="list-component__header__left--multi-filters" [hidden]="(!(hasRows$ | async) && !filter) || (isAddingOrSelecting$ | async)">
             <ng-container *ngFor="let multiFilterManager of multiFilterManagers; first as isFirst">
               <mat-form-field *ngIf="!isFirst || !(multiFilterManager.hasOneItem$ | async)" [floatLabel]="'never'">
-                <mat-select id="{{multiFilterManager.filterKey}}" matInput [(value)]="multiFilterManager.initialValue" [disabled]="!(multiFilterManager.filterIsReady$ | async)" (selectionChange)="multiFilterManager.selectItem($event.value)">
+                <mat-select id="{{multiFilterManager.filterKey}}" matInput [(value)]="multiFilterManager.value" [disabled]="!(multiFilterManager.filterIsReady$ | async)" (selectionChange)="multiFilterManager.selectItem($event.value)">
                   <mat-option>{{ multiFilterManager.allLabel }}</mat-option>
                   <mat-option *ngFor="let selectItem of multiFilterManager.filterItems$ | async" [value]="selectItem.value">
                     {{selectItem.label}}

--- a/src/frontend/app/shared/components/list/list.component.types.ts
+++ b/src/frontend/app/shared/components/list/list.component.types.ts
@@ -162,7 +162,7 @@ export class MultiFilterManager<T> {
   public filterItems$: Observable<IListMultiFilterConfigItem[]>;
   public hasItems$: Observable<boolean>;
   public hasOneItem$: Observable<boolean>;
-  public initialValue: string;
+  public value: string;
 
   public filterKey: string;
   public allLabel: string;
@@ -200,15 +200,16 @@ export class MultiFilterManager<T> {
     );
   }
 
-  public applyInitialValue(multiFilters: {}) {
-    const initialValue = multiFilters[this.multiFilterConfig.key];
-    if (initialValue) {
-      this.initialValue = initialValue;
-      this.selectItem(initialValue);
+  public applyValue(multiFilters: {}) {
+    const value = multiFilters[this.multiFilterConfig.key];
+    if (value) {
+      this.value = value;
+      this.selectItem(value);
     }
   }
 
   public selectItem(itemValue: string) {
     this.multiFilterConfig.select.next(itemValue);
+    this.value = itemValue;
   }
 }


### PR DESCRIPTION
- when an cf is selected with a single org that org is automatically selected
- same goes for an org selecting it's single space
- this was broken after the pr which hides the cf filter if there's only one filter