### PR TITLE
Fixes double requests when single cf connected for lists with cf filter

### DIFF
--- a/src/frontend/app/shared/components/list/data-sources-controllers/list-data-source.ts
+++ b/src/frontend/app/shared/components/list/data-sources-controllers/list-data-source.ts
@@ -1,4 +1,5 @@
 import { DataSource } from '@angular/cdk/table';
+import { SortDirection } from '@angular/material';
 import { Store } from '@ngrx/store';
 import { schema } from 'normalizr';
 import {
@@ -11,8 +12,9 @@ import {
   Subscription,
 } from 'rxjs';
 import { tag } from 'rxjs-spy/operators';
-import { first, publishReplay, refCount, tap, distinctUntilChanged, map, filter } from 'rxjs/operators';
+import { distinctUntilChanged, filter, first, map, publishReplay, refCount, tap } from 'rxjs/operators';
 
+import { ListFilter, ListSort } from '../../../../store/actions/list.actions';
 import { MetricsAction } from '../../../../store/actions/metrics.actions';
 import { SetResultCount } from '../../../../store/actions/pagination.actions';
 import { AppState } from '../../../../store/app-state';
@@ -29,8 +31,6 @@ import {
 } from './list-data-source-types';
 import { getDataFunctionList } from './local-filtering-sorting';
 import { LocalListController } from './local-list-controller';
-import { SortDirection } from '@angular/material';
-import { ListSort, ListFilter } from '../../../../store/actions/list.actions';
 
 
 export class DataFunctionDefinition {

--- a/src/frontend/app/shared/components/list/list-types/app/cf-apps-data-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/app/cf-apps-data-source.ts
@@ -1,7 +1,7 @@
 import { Store } from '@ngrx/store';
-import { Observable, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { tag } from 'rxjs-spy/operators/tag';
-import { debounceTime, distinctUntilChanged, map, withLatestFrom, filter, switchMap } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, filter, map, switchMap, withLatestFrom } from 'rxjs/operators';
 
 import { DispatchSequencer, DispatchSequencerAction } from '../../../../../core/dispatch-sequencer';
 import { cfOrgSpaceFilter, getRowMetadata } from '../../../../../features/cloud-foundry/cf.helpers';
@@ -17,7 +17,6 @@ import {
   spaceSchemaKey,
 } from '../../../../../store/helpers/entity-factory';
 import { createEntityRelationKey } from '../../../../../store/helpers/entity-relations/entity-relations.types';
-import { selectPaginationState } from '../../../../../store/selectors/pagination.selectors';
 import { APIResource } from '../../../../../store/types/api.types';
 import { PaginationParam } from '../../../../../store/types/pagination.types';
 import { createCfOrSpaceMultipleFilterFn } from '../../../../data-services/cf-org-space-service.service';
@@ -38,7 +37,6 @@ export class CfAppsDataSource extends ListDataSource<APIResource> {
   public static paginationKey = 'applicationWall';
   private subs: Subscription[];
   public action: GetAllApplications;
-  public initialised$: Observable<boolean>;
 
 
   constructor(
@@ -47,9 +45,11 @@ export class CfAppsDataSource extends ListDataSource<APIResource> {
     transformEntities?: any[],
     paginationKey = CfAppsDataSource.paginationKey,
     seedPaginationKey = CfAppsDataSource.paginationKey,
+    startingCfGuid?: string
   ) {
     const syncNeeded = paginationKey !== seedPaginationKey;
     const action = createGetAllAppAction(paginationKey);
+    action.endpointGuid = startingCfGuid;
 
     const dispatchSequencer = new DispatchSequencer(store);
 
@@ -77,17 +77,6 @@ export class CfAppsDataSource extends ListDataSource<APIResource> {
       listConfig,
       destroy: () => this.subs.forEach(sub => sub.unsubscribe())
     });
-
-    // Reapply the cf guid to the action. Normally this is done via reapplying the selection to the filter... however this is too slow
-    // for maxedResult world
-    this.initialised$ = store.select(selectPaginationState(action.entityKey, action.paginationKey)).pipe(
-      map(pagination => {
-        if (pagination && pagination.clientPagination) {
-          action.endpointGuid = pagination.clientPagination.filter.items.cf;
-        }
-        return true;
-      })
-    );
 
     this.action = action;
 

--- a/src/frontend/app/shared/components/list/list.component.html
+++ b/src/frontend/app/shared/components/list/list.component.html
@@ -97,7 +97,7 @@
             </button>
           </div>
           <button id="app-list-refresh-button" mat-icon-button *ngIf="dataSource.refresh" [disabled]="(dataSource.isLoadingPage$ | async) || (isAddingOrSelecting$ | async)" (click)="refresh()">
-            <mat-icon class="refresh-icon" [ngClass]="{refreshing: (isRefreshing$ | async)}" aria-label="Refresh list data">refresh</mat-icon>
+            <mat-icon class="refresh-icon" [ngClass]="{refreshing: isRefreshing}" aria-label="Refresh list data">refresh</mat-icon>
           </button>
         </div>
 
@@ -105,7 +105,7 @@
     </div>
     <div class="refresh-button__no-header" *ngIf="dataSource.refresh && !(hasControls$ | async) && (!(hasRowsOrIsFiltering$ | async) && noEntries)">
       <button id="app-list-refresh-button" mat-mini-fab *ngIf="!(isAddingOrSelecting$ | async)" [disabled]="dataSource.isLoadingPage$ | async" (click)="refresh()">
-        <mat-icon class="refresh-icon" [ngClass]="{refreshing: (isRefreshing$ | async)}" aria-label="Refresh list data">refresh</mat-icon>
+        <mat-icon class="refresh-icon" [ngClass]="{refreshing: isRefreshing}" aria-label="Refresh list data">refresh</mat-icon>
       </button>
     </div>
     <div class="list-component__body">

--- a/src/frontend/app/shared/components/list/list.component.ts
+++ b/src/frontend/app/shared/components/list/list.component.ts
@@ -18,16 +18,17 @@ import { MatPaginator, PageEvent, SortDirection } from '@angular/material';
 import { Store } from '@ngrx/store';
 import { schema as normalizrSchema } from 'normalizr';
 import {
+  asapScheduler,
   BehaviorSubject,
   combineLatest as observableCombineLatest,
+  isObservable,
   Observable,
   of as observableOf,
-  Subscription,
   queueScheduler,
-  isObservable,
-  asapScheduler,
+  Subscription,
 } from 'rxjs';
 import {
+  combineLatest,
   debounceTime,
   distinctUntilChanged,
   filter,
@@ -37,18 +38,17 @@ import {
   publishReplay,
   refCount,
   startWith,
-  switchMap,
+  subscribeOn,
   takeWhile,
   tap,
-  withLatestFrom,
-  combineLatest,
   throttleTime,
-  subscribeOn,
+  withLatestFrom,
 } from 'rxjs/operators';
 
 import { ListFilter, ListPagination, ListSort, SetListViewAction } from '../../../store/actions/list.actions';
 import { AppState } from '../../../store/app-state';
 import { entityFactory } from '../../../store/helpers/entity-factory';
+import { ActionState } from '../../../store/reducers/api-request-reducer/types';
 import { getListStateObservables } from '../../../store/reducers/list.reducer';
 import { EntityMonitor } from '../../monitors/entity-monitor';
 import { ListView } from './../../../store/actions/list.actions';
@@ -59,16 +59,13 @@ import {
   defaultPaginationPageSizeOptionsCards,
   defaultPaginationPageSizeOptionsTable,
   IGlobalListAction,
-  IListAction,
   IListConfig,
-  IListMultiFilterConfig,
   IMultiListAction,
   IOptionalAction,
   ListConfig,
   ListViewTypes,
   MultiFilterManager,
 } from './list.component.types';
-import { RequestInfoState, ActionState } from '../../../store/reducers/api-request-reducer/types';
 
 
 @Component({
@@ -189,7 +186,7 @@ export class ListComponent<T> implements OnInit, OnChanges, OnDestroy, AfterView
   isFiltering$: Observable<boolean>;
   noRowsNotFiltering$: Observable<boolean>;
   showProgressBar$: Observable<boolean>;
-  isRefreshing$: Observable<boolean>;
+  public isRefreshing = false;
 
 
 
@@ -514,16 +511,11 @@ export class ListComponent<T> implements OnInit, OnChanges, OnDestroy, AfterView
     this.showProgressBar$ = this.dataSource.isLoadingPage$.pipe(
       startWith(true),
       combineLatest(canShowLoading$),
-      map(([loading, canShowLoading]) => loading && canShowLoading),
+      map(([loading, canShowLoading]) => loading && canShowLoading && !this.isRefreshing),
       distinctUntilChanged(),
       throttleTime(100, queueScheduler, { leading: true, trailing: true }),
     );
 
-    this.isRefreshing$ = this.dataSource.isLoadingPage$.pipe(
-      withLatestFrom(canShowLoading$, this.showProgressBar$),
-      map(([loading, canShowLoading, showProgressBar]) => !canShowLoading && loading && !showProgressBar),
-      distinctUntilChanged()
-    );
   }
 
   ngAfterViewInit() {
@@ -605,6 +597,7 @@ export class ListComponent<T> implements OnInit, OnChanges, OnDestroy, AfterView
 
   public refresh() {
     if (this.dataSource.refresh) {
+      this.isRefreshing = true;
       this.dataSource.refresh();
       this.dataSource.isLoadingPage$.pipe(
         tap(isLoading => {
@@ -613,7 +606,7 @@ export class ListComponent<T> implements OnInit, OnChanges, OnDestroy, AfterView
           }
         }),
         takeWhile(isLoading => isLoading)
-      ).subscribe();
+      ).subscribe(null, null, () => this.isRefreshing = false);
     }
   }
 

--- a/src/frontend/app/store/actions/application.actions.ts
+++ b/src/frontend/app/store/actions/application.actions.ts
@@ -6,8 +6,7 @@ import { EntityInlineParentAction } from '../helpers/entity-relations/entity-rel
 import { pick } from '../helpers/reducer.helper';
 import { ActionMergeFunction } from '../types/api.types';
 import { PaginatedAction, PaginationParam } from '../types/pagination.types';
-import { ICFAction } from '../types/request.types';
-import { CFStartAction } from '../types/request.types';
+import { CFStartAction, ICFAction } from '../types/request.types';
 import { AppMetadataTypes } from './app-metadata.actions';
 
 export const GET_ALL = '[Application] Get all';

--- a/src/test-e2e/application/application-delete-e2e.spec.ts
+++ b/src/test-e2e/application/application-delete-e2e.spec.ts
@@ -1,6 +1,5 @@
 import { ApplicationsPage } from '../applications/applications.po';
 import { e2e } from '../e2e';
-import { CFHelpers } from '../helpers/cf-helpers';
 import { ConsoleUserType } from '../helpers/e2e-helpers';
 import { SideNavigation, SideNavMenuItem } from '../po/side-nav.po';
 import { ApplicationE2eHelper } from './application-e2e-helpers';
@@ -13,7 +12,6 @@ describe('Application Delete', function () {
   let appWall: ApplicationsPage;
   let applicationE2eHelper: ApplicationE2eHelper;
   let cfGuid, app;
-  let cfHelper: CFHelpers;
   let testAppName;
 
   beforeAll(() => {
@@ -26,7 +24,6 @@ describe('Application Delete', function () {
       .connectAllEndpoints(ConsoleUserType.admin)
       .getInfo(ConsoleUserType.admin);
     applicationE2eHelper = new ApplicationE2eHelper(setup);
-    cfHelper = new CFHelpers(setup);
   });
 
   beforeEach(() => nav.goto(SideNavMenuItem.Applications));
@@ -76,7 +73,7 @@ describe('Application Delete', function () {
       expect(appWall.isActivePage()).toBeTruthy();
 
       // We created the app after the wall loaded, so refresh to make sure app wall shows the new app
-      appWall.appList.refresh();
+      appWall.appList.header.refresh();
 
       appWall.appList.header.setSearchText(testAppName);
       expect(appWall.appList.getTotalResults()).toBe(1);

--- a/src/test-e2e/application/application-e2e-helpers.ts
+++ b/src/test-e2e/application/application-e2e-helpers.ts
@@ -1,9 +1,9 @@
-import { E2EConfigCloudFoundry } from '../e2e.types';
 import { browser, promise } from 'protractor';
 
 import { IApp, IRoute, ISpace } from '../../frontend/app/core/cf-api.types';
 import { APIResource } from '../../frontend/app/store/types/api.types';
 import { e2e, E2ESetup } from '../e2e';
+import { E2EConfigCloudFoundry } from '../e2e.types';
 import { CFHelpers } from '../helpers/cf-helpers';
 import { CFRequestHelpers } from '../helpers/cf-request-helpers';
 import { E2EHelpers } from '../helpers/e2e-helpers';
@@ -23,7 +23,7 @@ export class ApplicationE2eHelper {
   static createApplicationName = (isoTime?: string, postFix?: string): string =>
     E2EHelpers.createCustomName(customAppLabel + (postFix || ''), isoTime).toLowerCase()
   static createRouteName = (isoTime?: string): string =>
-    E2EHelpers.createCustomName('route-' + customAppLabel, isoTime).toLowerCase().replace(/[-:.]+/g, '')
+    CFHelpers.cleanRouteHost(E2EHelpers.createCustomName('route-' + customAppLabel, isoTime).toLowerCase())
 
   /**
    * Get default sanitized URL name for App
@@ -170,7 +170,7 @@ export class ApplicationE2eHelper {
   createApp(cfGuid: string, orgName: string, spaceName: string, appName: string, endpoint: E2EConfigCloudFoundry) {
     return browser.driver.wait(
       this.cfHelper.addOrgIfMissingForEndpointUsers(cfGuid, endpoint, orgName)
-        .then(org => this.cfHelper.addSpaceIfMissingForEndpointUsers(cfGuid, org.metadata.guid, org.entity.name, spaceName, endpoint))
+        .then(org => this.cfHelper.addSpaceIfMissingForEndpointUsers(cfGuid, org.metadata.guid, spaceName, endpoint))
         .then(space => {
           expect(space).not.toBeNull();
           return promise.all([

--- a/src/test-e2e/applications/application-wall-e2e.spec.ts
+++ b/src/test-e2e/applications/application-wall-e2e.spec.ts
@@ -62,8 +62,8 @@ describe('Application Wall Tests -', () => {
     defaultCf = e2e.secrets.getDefaultCFEndpoint();
     endpointGuid = e2e.helper.getEndpointGuid(e2e.info, defaultCf.name);
 
-    browser.wait(
-      cfHelper.addOrgIfMissingForEndpointUsers(endpointGuid, defaultCf, orgName, true)
+    return browser.wait(
+      cfHelper.addOrgIfMissingForEndpointUsers(endpointGuid, defaultCf, orgName, false)
         .then((org: APIResource<IOrganization>) => {
           const spaceName1 = E2EHelpers.createCustomName(customOrgSpacesLabel) + '-1';
           const spaceName2 = E2EHelpers.createCustomName(customOrgSpacesLabel) + '-2';
@@ -147,7 +147,7 @@ describe('Application Wall Tests -', () => {
   describe('No Pages -', () => {
     const orgName = E2EHelpers.createCustomName(customOrgSpacesLabel) + '-no-pages';
     beforeAll(() => {
-      setup(orgName, [], false);
+      return setup(orgName, [], false);
     });
 
     beforeAll(() => {
@@ -192,7 +192,7 @@ describe('Application Wall Tests -', () => {
 
     beforeAll(() => {
       appNames = createAppNames(3);
-      setup(orgName, appNames, true);
+      return setup(orgName, appNames, true);
     }, timeAllowed);
 
     beforeAll(() => {

--- a/src/test-e2e/applications/application-wall-e2e.spec.ts
+++ b/src/test-e2e/applications/application-wall-e2e.spec.ts
@@ -68,8 +68,8 @@ describe('Application Wall Tests -', () => {
           const spaceName1 = E2EHelpers.createCustomName(customOrgSpacesLabel) + '-1';
           const spaceName2 = E2EHelpers.createCustomName(customOrgSpacesLabel) + '-2';
           return promise.all([
-            cfHelper.addSpaceIfMissingForEndpointUsers(endpointGuid, org.metadata.guid, org.entity.name, spaceName1, defaultCf, true),
-            cfHelper.addSpaceIfMissingForEndpointUsers(endpointGuid, org.metadata.guid, org.entity.name, spaceName2, defaultCf, true),
+            cfHelper.addSpaceIfMissingForEndpointUsers(endpointGuid, org.metadata.guid, spaceName1, defaultCf, true),
+            cfHelper.addSpaceIfMissingForEndpointUsers(endpointGuid, org.metadata.guid, spaceName2, defaultCf, true),
           ]);
         })
         .then(([s1, s2]) => {

--- a/src/test-e2e/cloud-foundry/org-level/org-spaces-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/org-level/org-spaces-e2e.spec.ts
@@ -38,7 +38,6 @@ describe('Org Spaces List -', () => {
         return cfHelper.addSpaceIfMissingForEndpointUsers(
           endpointGuid,
           org.metadata.guid,
-          org.entity.name,
           name,
           defaultCf,
           true);
@@ -50,7 +49,6 @@ describe('Org Spaces List -', () => {
     return promise.all(spaceNames.map(name => cfHelper.addSpaceIfMissingForEndpointUsers(
       endpointGuid,
       org.metadata.guid,
-      org.entity.name,
       name,
       defaultCf,
       true)));
@@ -107,8 +105,6 @@ describe('Org Spaces List -', () => {
     beforeAll(() => {
       setup(orgName, [], false);
     });
-
-    beforeEach(navToOrgSpaces);
 
     it('Should show no entities message', () => {
       expect(spaceList.isDisplayed()).toBeTruthy();

--- a/src/test-e2e/cloud-foundry/organizations-spaces-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/organizations-spaces-e2e.spec.ts
@@ -3,12 +3,12 @@ import { browser } from 'protractor';
 import { e2e } from '../e2e';
 import { CFHelpers } from '../helpers/cf-helpers';
 import { ConsoleUserType } from '../helpers/e2e-helpers';
+import { extendE2ETestTime } from '../helpers/extend-test-helpers';
 import { ConfirmDialogComponent } from '../po/confirm-dialog';
 import { ListComponent } from '../po/list.po';
 import { MetaCard, MetaCardTitleType } from '../po/meta-card.po';
 import { StepperComponent } from '../po/stepper.po';
 import { CfTopLevelPage } from './cf-level/cf-top-level-page.po';
-import { extendE2ETestTime } from '../helpers/extend-test-helpers';
 
 describe('CF - Manage Organizations and Spaces', () => {
 
@@ -135,13 +135,13 @@ describe('CF - Manage Organizations and Spaces', () => {
       // Go to org tab
       const cardView = cloudFoundry.goToOrgView();
       const list = new ListComponent();
-      list.refresh();
+      list.header.refresh();
       cardView.cards.findCardByTitle(testOrgName, MetaCardTitleType.CUSTOM, true).then(org => {
         org.click();
 
         cloudFoundry.subHeader.clickItem('Spaces');
         cardView.cards.waitUntilShown();
-        list.refresh();
+        list.header.refresh();
 
         // Add space
         // Click the add button to add a space
@@ -192,7 +192,7 @@ describe('CF - Manage Organizations and Spaces', () => {
       cloudFoundry.subHeader.clickItem('Spaces');
       cardView.cards.waitUntilShown();
       const list = new ListComponent();
-      list.refresh();
+      list.header.refresh();
 
       // Add space
       // Click the add button to add a space

--- a/src/test-e2e/cloud-foundry/space-level/space-routes-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/space-level/space-routes-e2e.spec.ts
@@ -16,7 +16,7 @@ describe('Space Routes List -', () => {
   let defaultCf: E2EConfigCloudFoundry;
   let endpointGuid: string;
   let defaultOrgGuid: string;
-  let spaceGuid: string;
+  let createdSpaceGuid: string;
   const routesList = new ListComponent();
 
   const timeAllowed = 50000;
@@ -61,7 +61,7 @@ describe('Space Routes List -', () => {
         })
         .catch(error => { throw new Error(`Failed to create space: ${error.toString()}`); })
         .then((space: APIResource<ISpace>) => {
-          spaceGuid = space.metadata.guid;
+          createdSpaceGuid = space.metadata.guid;
           if (!routeHosts || !routeHosts.length) {
             return promise.fullyResolved(space);
           }
@@ -76,8 +76,8 @@ describe('Space Routes List -', () => {
               const domainGuid = domains[0].metadata.guid;
               // Chain the creation of the routes to ensure there's a nice sequential 'created_at' value to be used for sort tests
               const promises = orderImportant ?
-                chainCreateRoute(spaceGuid, domainGuid, routeHosts) :
-                concurrentCreateRoute(spaceGuid, domainGuid, routeHosts);
+                chainCreateRoute(createdSpaceGuid, domainGuid, routeHosts) :
+                concurrentCreateRoute(createdSpaceGuid, domainGuid, routeHosts);
 
               return promises.then(() => space);
             });
@@ -88,7 +88,7 @@ describe('Space Routes List -', () => {
   }
 
   function navToSpaceRoutes() {
-    const spacePage = CfSpaceLevelPage.forEndpoint(endpointGuid, defaultOrgGuid, spaceGuid);
+    const spacePage = CfSpaceLevelPage.forEndpoint(endpointGuid, defaultOrgGuid, createdSpaceGuid);
     spacePage.navigateTo();
     spacePage.waitForPageOrChildPage();
     spacePage.loadingIndicator.waitUntilNotShown();

--- a/src/test-e2e/cloud-foundry/space-level/space-routes-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/space-level/space-routes-e2e.spec.ts
@@ -1,0 +1,258 @@
+import { browser, promise } from 'protractor';
+
+import { ISpace } from '../../../frontend/app/core/cf-api.types';
+import { APIResource } from '../../../frontend/app/store/types/api.types';
+import { e2e } from '../../e2e';
+import { E2EConfigCloudFoundry } from '../../e2e.types';
+import { CFHelpers } from '../../helpers/cf-helpers';
+import { ConsoleUserType, E2EHelpers } from '../../helpers/e2e-helpers';
+import { ListComponent } from '../../po/list.po';
+import { CfSpaceLevelPage } from './cf-space-level-page.po';
+
+const customRouteLabel = E2EHelpers.e2eItemPrefix + (process.env.CUSTOM_APP_LABEL || process.env.USER) + '-space-route-test';
+
+describe('Space Routes List -', () => {
+  let cfHelper: CFHelpers;
+  let defaultCf: E2EConfigCloudFoundry;
+  let endpointGuid: string;
+  let defaultOrgGuid: string;
+  let spaceGuid: string;
+  const routesList = new ListComponent();
+
+  const timeAllowed = 50000;
+
+  function createRouteHosts(count: number): string[] {
+    const routeHosts = [];
+    for (let i = 0; i < count; i++) {
+      routeHosts.push(CFHelpers.cleanRouteHost(E2EHelpers.createCustomName(customRouteLabel + i)));
+    }
+    return routeHosts;
+  }
+
+  function chainCreateRoute(spaceGuid: string, domainGuid: string, routeHosts: string[]): promise.Promise<any> {
+    return routeHosts.reduce((promiseChain, host) => {
+      return promiseChain.then(() => {
+        // Ensure there's a gap so that the 'created_at' is different
+        browser.sleep(1100);
+        return cfHelper.addRoute(endpointGuid, spaceGuid, domainGuid, host);
+      });
+    }, promise.fullyResolved(''));
+  }
+
+  function concurrentCreateRoute(spaceGuid: string, domainGuid: string, routeHosts: string[]): promise.Promise<any> {
+    return promise.all(routeHosts.map(host => cfHelper.addRoute(endpointGuid, spaceGuid, domainGuid, host)));
+  }
+
+  function setup(spaceName: string, routeHosts: string[], orderImportant: boolean) {
+    defaultCf = e2e.secrets.getDefaultCFEndpoint();
+    endpointGuid = e2e.helper.getEndpointGuid(e2e.info, defaultCf.name);
+    const defaultOrgGuidP = CFHelpers.cachedDefaultOrgGuid ?
+      promise.fullyResolved<string>(CFHelpers.cachedDefaultOrgGuid) : cfHelper.fetchDefaultOrgGuid();
+    browser.wait(
+      defaultOrgGuidP
+        .then(orgGuid => {
+          defaultOrgGuid = orgGuid;
+          return cfHelper.addSpaceIfMissingForEndpointUsers(
+            endpointGuid,
+            orgGuid,
+            spaceName,
+            defaultCf,
+            true);
+        })
+        .catch(error => { throw new Error(`Failed to create space: ${error.toString()}`); })
+        .then((space: APIResource<ISpace>) => {
+          spaceGuid = space.metadata.guid;
+          if (!routeHosts || !routeHosts.length) {
+            return promise.fullyResolved(space);
+          }
+
+          return cfHelper
+            .fetchDomains(endpointGuid)
+            .catch(error => { throw new Error(`Failed to fetch domains: ${error.toString()}`); })
+            .then(domains => {
+              if (!domains || !domains.length) {
+                throw Error('At least one domain is required to create test routes');
+              }
+              const domainGuid = domains[0].metadata.guid;
+              // Chain the creation of the routes to ensure there's a nice sequential 'created_at' value to be used for sort tests
+              const promises = orderImportant ?
+                chainCreateRoute(spaceGuid, domainGuid, routeHosts) :
+                concurrentCreateRoute(spaceGuid, domainGuid, routeHosts);
+
+              return promises.then(() => space);
+            });
+        })
+        .then(navToSpaceRoutes)
+
+    );
+  }
+
+  function navToSpaceRoutes() {
+    const spacePage = CfSpaceLevelPage.forEndpoint(endpointGuid, defaultOrgGuid, spaceGuid);
+    spacePage.navigateTo();
+    spacePage.waitForPageOrChildPage();
+    spacePage.loadingIndicator.waitUntilNotShown();
+    spacePage.goToRoutesTab();
+    expect(routesList.isCardsView()).toBeFalsy();
+  }
+
+  function tearDown(spaceName: string) {
+    expect(spaceName).not.toBeNull();
+    browser.wait(cfHelper.deleteSpaceIfExisting(endpointGuid, defaultOrgGuid, spaceName));
+  }
+
+  beforeAll(() => {
+    const e2eSetup = e2e.setup(ConsoleUserType.admin)
+      .clearAllEndpoints()
+      .registerDefaultCloudFoundry()
+      .connectAllEndpoints(ConsoleUserType.admin)
+      .loginAs(ConsoleUserType.admin)
+      .getInfo();
+    cfHelper = new CFHelpers(e2eSetup);
+  });
+
+  describe('No Pages -', () => {
+    const spaceName = E2EHelpers.createCustomName(customRouteLabel) + '-no-pages';
+    beforeAll(() => {
+      setup(spaceName, [], false);
+    });
+
+    it('Should show no entities message', () => {
+      expect(routesList.isDisplayed()).toBeTruthy();
+      routesList.empty.getDefault().waitUntilShown();
+      expect(routesList.empty.getDefault().getComponent().getText()).toBe('There are no routes');
+      expect(routesList.table.getRowCount()).toBe(0);
+    });
+
+    afterAll(() => tearDown(spaceName));
+  });
+
+  describe('Single Page -', () => {
+    const spaceName = E2EHelpers.createCustomName(customRouteLabel) + '-1-page';
+
+    let routeHosts;
+
+    function testSortBy() {
+
+      let expectedOrder: string[];
+      routesList.table.getTableData().then(rows => {
+        const originalOrder = rows.map(row => row['route']);
+        expectedOrder = new Array(originalOrder.length);
+        for (let i = 0; i < originalOrder.length; i++) {
+          expectedOrder[originalOrder.length - i - 1] = originalOrder[i];
+        }
+      });
+
+      routesList.table.toggleSort('Creation Date');
+
+      routesList.table.getTableData().then(rows => {
+        const newOrder = rows.map(row => row['route']);
+        expect(expectedOrder).toEqual(newOrder);
+      });
+    }
+
+    beforeAll(() => {
+      routeHosts = createRouteHosts(3);
+      setup(spaceName, routeHosts, true);
+      expect(routesList.getTotalResults()).toBeLessThanOrEqual(5);
+      expect(routesList.pagination.isDisplayed()).toBeFalsy();
+    }, timeAllowed);
+
+    afterAll(() => tearDown(spaceName), timeAllowed);
+
+    it('sort by creation', () => {
+      testSortBy();
+    });
+
+    it('single page pagination settings', () => {
+      expect(routesList.pagination.isDisplayed()).toBeFalsy();
+    });
+
+  });
+
+  describe('Multi Page -', () => {
+    const spaceName = E2EHelpers.createCustomName(customRouteLabel) + '-multi-page';
+
+    let routeHosts;
+
+    beforeAll(() => {
+      routeHosts = createRouteHosts(7);
+      setup(spaceName, routeHosts, true);
+      expect(routesList.getTotalResults()).toBeGreaterThanOrEqual(routeHosts.length);
+    }, timeAllowed);
+
+    afterAll(() => tearDown(spaceName), timeAllowed);
+
+    function testStartingPosition() {
+      // General expects for all tests in this section
+      expect(routesList.getTotalResults()).toBeLessThan(80);
+      expect(routesList.pagination.isPresent()).toBeTruthy();
+
+      expect(routesList.table.getRowCount()).toBe(5);
+      expect(routesList.pagination.getPageSize()).toEqual('5');
+      expect(routesList.pagination.getTotalResults()).toBeGreaterThan(5);
+      expect(routesList.pagination.getTotalResults()).toBeLessThanOrEqual(7);
+
+      expect(routesList.pagination.getNavFirstPage().getComponent().isEnabled()).toBeFalsy();
+      expect(routesList.pagination.getNavPreviousPage().getComponent().isEnabled()).toBeFalsy();
+      expect(routesList.pagination.getNavNextPage().getComponent().isEnabled()).toBeTruthy();
+      expect(routesList.pagination.getNavLastPage().getComponent().isEnabled()).toBeTruthy();
+    }
+
+    beforeEach(testStartingPosition, timeAllowed);
+
+    afterEach(testStartingPosition, timeAllowed);
+
+    it('Initial Pagination Values', () => { });
+
+    it('Next and Previous Page', () => {
+      routesList.pagination.getNavNextPage().getComponent().click();
+      // routesList.waitForLoadingIndicator();
+      // routesList.waitForNoLoadingIndicator();
+
+      expect(routesList.pagination.getNavFirstPage().getComponent().isEnabled()).toBeTruthy();
+      expect(routesList.pagination.getNavPreviousPage().getComponent().isEnabled()).toBeTruthy();
+      expect(routesList.pagination.getNavNextPage().getComponent().isEnabled()).toBeFalsy();
+      expect(routesList.pagination.getNavLastPage().getComponent().isEnabled()).toBeFalsy();
+
+      routesList.pagination.getNavPreviousPage().getComponent().click();
+    });
+
+    it('Last and First Page', () => {
+      routesList.pagination.getNavLastPage().getComponent().click();
+
+      expect(routesList.pagination.getNavFirstPage().getComponent().isEnabled()).toBeTruthy();
+      expect(routesList.pagination.getNavPreviousPage().getComponent().isEnabled()).toBeTruthy();
+      expect(routesList.pagination.getNavNextPage().getComponent().isEnabled()).toBeFalsy();
+      expect(routesList.pagination.getNavLastPage().getComponent().isEnabled()).toBeFalsy();
+
+      routesList.pagination.getNavFirstPage().getComponent().click();
+    });
+
+    it('Change Page Size', () => {
+
+      routesList.pagination.setPageSize('80');
+      expect(routesList.table.getRowCount()).toBeGreaterThan(5);
+
+      expect(routesList.pagination.getNavFirstPage().getComponent().isEnabled()).toBeFalsy();
+      expect(routesList.pagination.getNavPreviousPage().getComponent().isEnabled()).toBeFalsy();
+      expect(routesList.pagination.getNavNextPage().getComponent().isEnabled()).toBeFalsy();
+      expect(routesList.pagination.getNavLastPage().getComponent().isEnabled()).toBeFalsy();
+
+      routesList.pagination.setPageSize('5');
+      expect(routesList.table.getRowCount()).toBe(5);
+
+    });
+
+    xit('Refresh animation', () => {
+      // Refresh icon animation stops before we can check it's started. Need to simulate slower http requests
+      // browser.driver.setNetworkConnection(4); // Fails with `network connection must be enabled`
+      browser.waitForAngularEnabled(false);
+      routesList.header.getRefreshListButton().click();
+      routesList.header.waitForRefreshing();
+      routesList.header.waitForNotRefreshing();
+      browser.waitForAngularEnabled(true);
+    });
+
+  });
+});

--- a/src/test-e2e/cloud-foundry/users-list-e2e.helper.ts
+++ b/src/test-e2e/cloud-foundry/users-list-e2e.helper.ts
@@ -55,7 +55,7 @@ export function setUpTestOrgSpaceUserRoles(
   return cfHelper.addOrgIfMissingForEndpointUsers(cfGuid, defaultCf, orgName)
     .then(org => {
       orgGuid = org.metadata.guid;
-      return cfHelper.addSpaceIfMissingForEndpointUsers(cfGuid, org.metadata.guid, orgName, spaceName, defaultCf, true);
+      return cfHelper.addSpaceIfMissingForEndpointUsers(cfGuid, org.metadata.guid, spaceName, defaultCf, true);
     })
     .then(space => spaceGuid = space.metadata.guid)
     .then(() => cfHelper.addOrgUserRole(cfGuid, orgGuid, userName))

--- a/src/test-e2e/po/list.po.ts
+++ b/src/test-e2e/po/list.po.ts
@@ -111,6 +111,10 @@ export class ListTableComponent extends Component {
   toggleSort(headerTitle: string): promise.Promise<any> {
     return this.locator.element(by.cssContainingText('mat-header-row app-table-cell', headerTitle)).click();
   }
+
+  getRowCount(): promise.Promise<number> {
+    return this.getRows().count();
+  }
 }
 
 // Page Object for the List Card View
@@ -181,8 +185,11 @@ export class ListCardComponent extends Component {
 // List Header (filter/search bar)
 export class ListHeaderComponent extends Component {
 
+  listLocator: ElementFinder;
+
   constructor(locator: ElementFinder) {
     super(locator.element(by.css('.list-component__header')));
+    this.listLocator = locator;
   }
 
   private getFilterSection(): ElementFinder {
@@ -269,6 +276,29 @@ export class ListHeaderComponent extends Component {
 
   getRefreshListButton(): ElementFinder {
     return this.getRightHeaderSection().element(by.css('#app-list-refresh-button'));
+  }
+
+  getRefreshListButtonAnimated(): ElementFinder {
+    return this.getRefreshListButton().element(by.css('.refresh-icon.refreshing'));
+  }
+
+  refresh() {
+    this.getRefreshListButton().click();
+    return this.waitForNotRefreshing();
+  }
+
+  isRefreshing(): promise.Promise<boolean> {
+    return this.getRefreshListButton().element(by.css('.refresh-icon')).getCssValue('animation-play-state').then(state =>
+      state === 'running'
+    );
+  }
+
+  waitForRefreshing(): promise.Promise<any> {
+    return browser.wait(until.visibilityOf(this.getRefreshListButtonAnimated()), 5000);
+  }
+
+  waitForNotRefreshing(): promise.Promise<any> {
+    return browser.wait(until.invisibilityOf(this.getRefreshListButtonAnimated()), 10000);
   }
 
   getCardListViewToggleButton(): ElementFinder {
@@ -415,10 +445,20 @@ export class ListComponent extends Component {
     return this.hasClass('list-component__cards', listElement);
   }
 
-  refresh() {
-    this.locator.element(by.id('app-list-refresh-button')).click();
-    const refreshIcon = element(by.css('.refresh-icon.refreshing'));
-    return browser.wait(until.invisibilityOf(refreshIcon), 10000);
+  private getLoadingIndicator(): ElementFinder {
+    return this.locator.element(by.css('.list-component > mat-progress-bar'));
+  }
+
+  isLoading(): promise.Promise<boolean> {
+    return this.locator.element(by.css('.list-component > mat-progress-bar')).isPresent();
+  }
+
+  waitForLoadingIndicator(): promise.Promise<any> {
+    return browser.wait(until.visibilityOf(this.getLoadingIndicator()), 1000);
+  }
+
+  waitForNoLoadingIndicator(): promise.Promise<any> {
+    return browser.wait(until.invisibilityOf(this.getLoadingIndicator()), 10000);
   }
 
   getTotalResults(): promise.Promise<number> {


### PR DESCRIPTION
Loading indicator fixes are now in https://github.com/cloudfoundry-incubator/stratos/pull/3363.

- Fixes double requests when single cf connected (previously there was 1 before cf automatically selected, 1 after... we now ensure initial state is correct so first call has automatically selected cf)
- New e2e test for non-local space routes list
- Prep for e2e loading/refresh indicator tests