### PR TITLE
Don't stop and start PCF Dev each time before/after tests

### DIFF
--- a/deploy/ci/automation/cfallinonetest.sh
+++ b/deploy/ci/automation/cfallinonetest.sh
@@ -61,10 +61,7 @@ set +e
 # Kill the docker container
 docker kill $CONTAINER_ID
 
-# Pause the PCF Dev instance for now
-echo "Suspending PCF Dev"
-cf pcfdev suspend
-cf pcfdev status
+echo "All done"
 
 # Return exit code form the e2e tests
 exit $RET

--- a/deploy/ci/automation/cfdockercomposetest.sh
+++ b/deploy/ci/automation/cfdockercomposetest.sh
@@ -69,10 +69,7 @@ fi
 docker-compose -f docker-compose.development.yml down
 popd
 
-# Pause the PCF Dev instance for now
-echo "Suspending PCF Dev"
-cf pcfdev suspend
-cf pcfdev status
+echo "All done"
 
 # Return exit code form the e2e tests
 exit $RET

--- a/deploy/ci/automation/cfpushtest.sh
+++ b/deploy/ci/automation/cfpushtest.sh
@@ -143,11 +143,7 @@ fi
 
 set +e
 
-# Pause the PCF Dev instance for now
-sleep 5
-echo "Suspending PCF Dev"
-cf pcfdev suspend
-cf pcfdev status
+echo "All done"
 
 # Return exit code form the e2e tests
 exit $RET

--- a/deploy/ci/automation/cfutils.sh
+++ b/deploy/ci/automation/cfutils.sh
@@ -60,36 +60,15 @@ if [ -z "${TEST_CONFIG_URL}" ]; then
   exit 1
 fi
 
+echo "Checking PCF Dev status"
 FULL_STATUS=$(cf pcfdev status)
 echo "$FULL_STATUS"
 
 STATUS=$(echo "$FULL_STATUS" | head -n 1)
-if [ "$STATUS" == "Not Created" ]; then
-  echo "PCF DEV not created... starting"
-  cf pcfdev start -m 10240 -c 4 -s none
-  echo "Setting PCF DEV up for E2E Tests ..."
-  "${DIRPATH}/../../tools/init-cf-for-e2e.sh"
-  # Ensure that PCF Dev's UAA is configured to allow SSO Login
-  "${DIRPATH}/init-pcfdev-uaa.sh"
-else if [ "$STATUS" == "Running" ]; then
-  echo "PCF DEV is already running"
-  else if [ "$STATUS" == "Stopped" ]; then
-    echo "PCF DEV stopped... starting"
-    cf pcfdev start
-    else if [ "$STATUS" == "Suspended" ]; then
-      echo "Resuming PCF DEV"
-      cf pcfdev resume
-      else
-        echo "Stopping and starting PCF DEV"
-        cf pcfdev stop
-        cf pcfdev start
-      fi
-    fi
-  fi
+if [ "$STATUS" != "Running" ]; then
+  echo "PCF Dev is not running... aborting"
+  exit 1
 fi
-
-# Wait 5 seconds for PCFDev
-sleep 5
 
 cf login -a https://api.local.pcfdev.io --skip-ssl-validation -u admin -p admin -o e2e -s e2e
 cf apps


### PR DESCRIPTION
Improvements to automated test scripts to not start/stop PCF Dev each time