### PR TITLE
Fix CF-Level Metrics permissions check

### DIFF
--- a/src/frontend/app/shared/components/list/list-types/cf-cells/cf-cells-data-source.ts
+++ b/src/frontend/app/shared/components/list/list-types/cf-cells/cf-cells-data-source.ts
@@ -1,7 +1,7 @@
 import { Store } from '@ngrx/store';
 import { map } from 'rxjs/operators';
 
-import { FetchCFMetricsPaginatedAction, MetricQueryConfig } from '../../../../../store/actions/metrics.actions';
+import { FetchCFCellMetricsPaginatedAction, MetricQueryConfig } from '../../../../../store/actions/metrics.actions';
 import { AppState } from '../../../../../store/app-state';
 import { entityFactory } from '../../../../../store/helpers/entity-factory';
 import { IMetrics, IMetricVectorResult } from '../../../../../store/types/base-metric.types';
@@ -19,7 +19,7 @@ export class CfCellsDataSource
   static cellDeploymentPath = 'metric.bosh_deployment';
 
   constructor(store: Store<AppState>, cfGuid: string, listConfig: IListConfig<IMetricVectorResult<IMetricCell>>) {
-    const action = new FetchCFMetricsPaginatedAction(
+    const action = new FetchCFCellMetricsPaginatedAction(
       cfGuid,
       cfGuid,
       new MetricQueryConfig('firehose_value_metric_rep_unhealthy_cell', {}),

--- a/src/frontend/app/store/actions/metrics.actions.ts
+++ b/src/frontend/app/store/actions/metrics.actions.ts
@@ -102,7 +102,7 @@ export class FetchCFCellMetricsAction extends MetricsAction {
     public query: MetricQueryConfig,
     queryType: MetricQueryType = MetricQueryType.QUERY,
     isSeries = true) {
-    super(cfGuid + '-' + cellId, cfGuid, query, `${MetricsAction.getBaseMetricsURL()}/cf`, null, queryType, isSeries);
+    super(cfGuid + '-' + cellId, cfGuid, query, `${MetricsAction.getBaseMetricsURL()}/cf/cells`, null, queryType, isSeries);
   }
 }
 

--- a/src/jetstream/plugins/metrics/cloud_foundry.go
+++ b/src/jetstream/plugins/metrics/cloud_foundry.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"errors"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -27,11 +28,8 @@ var (
 
 // Metrics endpoints - non-admin - for a Cloud Foundry Application
 func (m *MetricsSpecification) getCloudFoundryAppMetrics(c echo.Context) error {
-
 	// We need to go and fetch the CF App, to make sure that the user is permitted to access it
-
 	// We'll do this synchronously here for now - this can be done optimistically in parallel in the future
-
 	// Use the passthrough mechanism to get the App metadata from Cloud Foundry
 	appID := c.Param("appId")
 	prometheusOp := c.Param("op")
@@ -122,7 +120,46 @@ func getEchoURL(c echo.Context) url.URL {
 
 // Metrics API endpoints - admin - for a Cloud Foundry deployment
 func (m *MetricsSpecification) getCloudFoundryMetrics(c echo.Context) error {
+	userGUID, err := m.portalProxy.GetSessionStringValue(c, "user_id")
+	if err != nil {
+		return errors.New("Could not find session user_id")
+	}
 	cnsiList := strings.Split(c.Request().Header().Get("x-cap-cnsi-list"), ",")
+	// User must be an admin of the Cloud Foundry
+	// Check each in the list and if any is not, then return an error
+	canAccessMetrics := true
+	for _, endpointID := range cnsiList {
+		// Get token for the UserID and EndpointID
+		token, exists := m.portalProxy.GetCNSITokenRecord(endpointID, userGUID)
+		if !exists {
+			// Could not get a token for the user
+			canAccessMetrics = false
+			break
+		} else {
+			userTokenInfo, err := m.portalProxy.GetUserTokenInfo(token.AuthToken)
+			if err == nil {
+				// Do they have they admin scope for Cloud Foundry?
+				isAdmin := strings.Contains(strings.Join(userTokenInfo.Scope, ""), m.portalProxy.GetConfig().CFAdminIdentifier)
+				if !isAdmin {
+					canAccessMetrics = false
+					break
+				}
+			} else {
+				// Could not decode the user's token to determine if they are an admin, so default is that they are not
+				canAccessMetrics = false
+				break
+			}
+		}
+	}
+
+	// Only proceed if the user is an Cloud Foundry admin of all of the endpoints we are requesting metrics for
+	if !canAccessMetrics {
+		log.Warn("NOT an ADMIN")
+		return interfaces.NewHTTPShadowError(
+			http.StatusUnauthorized,
+			"You must be a Cloud Foundry admin to access CF-level metrics",
+			"You must be a Cloud Foundry admin to access CF-level metrics")
+	}
 
 	return m.makePrometheusRequest(c, cnsiList, "")
 }

--- a/src/jetstream/plugins/metrics/cloud_foundry.go
+++ b/src/jetstream/plugins/metrics/cloud_foundry.go
@@ -154,7 +154,6 @@ func (m *MetricsSpecification) getCloudFoundryMetrics(c echo.Context) error {
 
 	// Only proceed if the user is an Cloud Foundry admin of all of the endpoints we are requesting metrics for
 	if !canAccessMetrics {
-		log.Warn("NOT an ADMIN")
 		return interfaces.NewHTTPShadowError(
 			http.StatusUnauthorized,
 			"You must be a Cloud Foundry admin to access CF-level metrics",

--- a/src/jetstream/plugins/metrics/main.go
+++ b/src/jetstream/plugins/metrics/main.go
@@ -98,14 +98,16 @@ func (m *MetricsSpecification) GetMiddlewarePlugin() (interfaces.MiddlewarePlugi
 
 // AddAdminGroupRoutes adds the admin routes for this plugin to the Echo server
 func (m *MetricsSpecification) AddAdminGroupRoutes(echoContext *echo.Group) {
-	echoContext.GET("/metrics/cf/:op", m.getCloudFoundryMetrics)
 	echoContext.GET("/metrics/kubernetes/:podName/:op", m.getPodMetrics)
 }
 
 // AddSessionGroupRoutes adds the session routes for this plugin to the Echo server
 func (m *MetricsSpecification) AddSessionGroupRoutes(echoContext *echo.Group) {
 	echoContext.GET("/metrics/cf/app/:appId/:op", m.getCloudFoundryAppMetrics)
+
+	// Note: User needs to be an admin of the given Cloud Foundry to retrieve metrics
 	echoContext.GET("/metrics/cf/cells/:op", m.getCloudFoundryCellMetrics)
+	echoContext.GET("/metrics/cf/:op", m.getCloudFoundryMetrics)
 }
 
 func (m *MetricsSpecification) GetType() string {


### PR DESCRIPTION
Fixes these issues:

- fixes: #3322: Metrics: API does not return an error response correctly
- fixes: #3323 : Metrics: Admin endpoint should be gated on CF Admin status
