### PR TITLE
Fix app state to allow start action for offline while updating

### DIFF
--- a/src/frontend/app/shared/components/application-state/application-state.service.spec.ts
+++ b/src/frontend/app/shared/components/application-state/application-state.service.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed } from '@angular/core/testing';
+
 import { ApplicationStateService } from './application-state.service';
 
 
-fdescribe('ApplicationStateService', () => {
+describe('ApplicationStateService', () => {
 
   const $translate = { instant: (label) => label };
   let cfAppStateService;

--- a/src/frontend/app/shared/components/application-state/application-state.service.spec.ts
+++ b/src/frontend/app/shared/components/application-state/application-state.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { ApplicationStateService } from './application-state.service';
 
 
-describe('ApplicationStateService', () => {
+fdescribe('ApplicationStateService', () => {
 
   const $translate = { instant: (label) => label };
   let cfAppStateService;
@@ -64,8 +64,9 @@ describe('ApplicationStateService', () => {
       const res = cfAppStateService.get(testData.summary, testData.instances);
       expect(res.indicator).toBe('warning');
       expect($translate.instant(res.label)).toBe('Offline while Updating');
-      expect(Object.keys(res.actions).length).toBe(1);
+      expect(Object.keys(res.actions).length).toBe(2);
       expect(res.actions.delete).toBe(true);
+      expect(res.actions.start).toBe(true);
     });
 
     it('Incomplete app', function () {

--- a/src/frontend/app/shared/components/application-state/application-state.service.ts
+++ b/src/frontend/app/shared/components/application-state/application-state.service.ts
@@ -54,7 +54,7 @@ export class ApplicationStateService {
       PENDING: {
         label: 'Offline while Updating',
         indicator: CardStatus.WARNING,
-        actions: 'delete'
+        actions: 'start, delete'
       },
       STAGED: {
         label: 'Offline',
@@ -187,11 +187,11 @@ export class ApplicationStateService {
   }
 
   /**
-* @description Get the application state metadata for an application based on its summary and
-* optionally its instance metadata.
-* @param {object} summary - the application summary metadata (either from summary or entity)
-* @param {object} appInstances - the application instances metadata (from the app stats API call)
-*/
+  * @description Get the application state metadata for an application based on its summary and
+  * optionally its instance metadata.
+  * @param {object} summary - the application summary metadata (either from summary or entity)
+  * @param {object} appInstances - the application instances metadata (from the app stats API call)
+  */
   get(summary: any, appInstances: any): ApplicationStateData {
     const appState: string = summary ? summary.state : 'UNKNOWN';
     const pkgState = this.getPackageState(appState, summary);


### PR DESCRIPTION
Fixes  #3332 : Check App Actions for state "offline while updating"

Ensures user can start an app when in the offline while updating state