### PR TITLE
Fix null exception after creating a space in an new org

### DIFF
--- a/src/frontend/app/core/cf-api.types.ts
+++ b/src/frontend/app/core/cf-api.types.ts
@@ -154,7 +154,7 @@ export interface IDeveloper {
   audited_spaces_url: string;
 }
 
-export interface IOrganization {
+export interface IOrganization<spaceT = APIResource<ISpace>[]> {
   name: string;
   billing_enabled?: boolean;
   quota_definition_guid?: string;
@@ -176,7 +176,7 @@ export interface IOrganization {
   space_quota_definitions_url?: string;
   guid?: string;
   cfGuid?: string;
-  spaces?: APIResource<ISpace>[];
+  spaces?: spaceT;
   private_domains?: APIResource<IPrivateDomain>[];
   quota_definition?: APIResource<IQuotaDefinition>;
 }

--- a/src/frontend/app/features/cloud-foundry/edit-organization/edit-organization-step/edit-organization-step.component.ts
+++ b/src/frontend/app/features/cloud-foundry/edit-organization/edit-organization-step/edit-organization-step.component.ts
@@ -5,6 +5,7 @@ import { Observable, Subscription } from 'rxjs';
 import { filter, map, take, tap } from 'rxjs/operators';
 
 import { IOrganization } from '../../../../core/cf-api.types';
+import { safeUnsubscribe } from '../../../../core/utils.service';
 import { StepOnNextFunction } from '../../../../shared/components/stepper/step/step.component';
 import { PaginationMonitorFactory } from '../../../../shared/monitors/pagination-monitor.factory';
 import { UpdateOrganization } from '../../../../store/actions/organization.actions';
@@ -126,6 +127,6 @@ export class EditOrganizationStepComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.fetchOrgsSub.unsubscribe();
+    safeUnsubscribe(this.fetchOrgsSub, this.orgSubscription);
   }
 }

--- a/src/frontend/app/features/cloud-foundry/services/cloud-foundry-endpoint.service.ts
+++ b/src/frontend/app/features/cloud-foundry/services/cloud-foundry-endpoint.service.ts
@@ -182,7 +182,9 @@ export class CloudFoundryEndpointService {
     this.allApps$ = pagObs.entities$.pipe(// Ensure we sub to entities to kick off fetch process
       switchMap(() => pagObs.pagination$),
       filter(pagination => !!pagination && !!pagination.pageRequests && !!pagination.pageRequests[1] && !pagination.pageRequests[1].busy),
-      switchMap(pagination => pagination.maxedResults ? observableOf(null) : pagObs.entities$)
+      switchMap(pagination => pagination.maxedResults ? observableOf(null) : pagObs.entities$),
+      publishReplay(1),
+      refCount()
     );
 
     this.loadingApps$ = pagObs.entities$.pipe(// Ensure we sub to entities to kick off fetch process

--- a/src/frontend/app/store/reducers/organization-space.reducer.ts
+++ b/src/frontend/app/store/reducers/organization-space.reducer.ts
@@ -1,22 +1,33 @@
 import { IOrganization, ISpace } from '../../core/cf-api.types';
-import { BaseSpaceAction, CREATE_SPACE_SUCCESS, DELETE_SPACE_SUCCESS } from '../actions/space.actions';
-import { APIResource } from '../types/api.types';
+import {
+  BaseSpaceAction,
+  CREATE_SPACE_SUCCESS,
+  CreateSpace,
+  DELETE_SPACE_SUCCESS,
+  DeleteSpace,
+} from '../actions/space.actions';
+import { spaceSchemaKey } from '../helpers/entity-factory';
+import { APIResource, NormalizedResponse } from '../types/api.types';
 import { APISuccessOrFailedAction } from '../types/request.types';
 
-// Note - This reducer will be updated when we address general entity relation deletion
+// Note - This reducer will be updated when we address general deletion of entities within inline lists (not paginated lists)
 export function updateOrganizationSpaceReducer() {
   return function (state: APIResource, action: APISuccessOrFailedAction) {
     switch (action.type) {
       case DELETE_SPACE_SUCCESS:
+        const deleteSpaceAction: DeleteSpace = action.apiAction as DeleteSpace;
+        return updateOrgSpaces(state, deleteSpaceAction.orgGuid, deleteSpaceAction);
       case CREATE_SPACE_SUCCESS:
-        const spaceAction: BaseSpaceAction = action.apiAction as BaseSpaceAction;
-        return deleteOrgSpaces(state, spaceAction.orgGuid, spaceAction);
+        const createSpaceAction: CreateSpace = action.apiAction as CreateSpace;
+        const response: NormalizedResponse = action.response as NormalizedResponse;
+        const space = response.entities[spaceSchemaKey][response.result[0]];
+        return updateOrgSpaces(state, createSpaceAction.orgGuid, createSpaceAction, space);
     }
     return state;
   };
 }
 
-function deleteOrgSpaces(state: APIResource, orgGuid: string, spaceAction: BaseSpaceAction) {
+function updateOrgSpaces(state: APIResource, orgGuid: string, spaceAction: BaseSpaceAction, newSpace?: APIResource<ISpace>) {
   if (!orgGuid) {
     return state;
   }
@@ -30,14 +41,17 @@ function deleteOrgSpaces(state: APIResource, orgGuid: string, spaceAction: BaseS
   orgGuids.forEach(currentGuid => {
     const org: APIResource<IOrganization> = state[currentGuid];
     if (currentGuid === orgGuid) {
-      let newSpaces: APIResource<ISpace>[] = null;
-      if (spaceAction.removeEntityOnDelete) {
-        const spaceIndex = org.entity.spaces.findIndex(space => {
-          return typeof (space) === 'string' ? space === spaceAction.guid : space.metadata.guid === spaceAction.guid;
-        });
-        if (spaceIndex >= 0) {
-          newSpaces = [...org.entity.spaces];
-          newSpaces.splice(spaceIndex, 1);
+      const newSpaces: (APIResource<ISpace> | string)[] = [...org.entity.spaces];
+      if (newSpace) {
+        newSpaces.push(newSpace.metadata.guid);
+      } else {
+        if (spaceAction.removeEntityOnDelete) {
+          const spaceIndex = org.entity.spaces.findIndex(space => {
+            return typeof (space) === 'string' ? space === spaceAction.guid : space.metadata.guid === spaceAction.guid;
+          });
+          if (spaceIndex >= 0) {
+            newSpaces.splice(spaceIndex, 1);
+          }
         }
       }
       const newOrg = {

--- a/src/frontend/app/store/reducers/organization-space.reducer.ts
+++ b/src/frontend/app/store/reducers/organization-space.reducer.ts
@@ -9,62 +9,81 @@ import {
 import { spaceSchemaKey } from '../helpers/entity-factory';
 import { APIResource, NormalizedResponse } from '../types/api.types';
 import { APISuccessOrFailedAction } from '../types/request.types';
-
+import { IRequestEntityTypeState } from '../app-state';
+type entityOrgType = APIResource<IOrganization<string[]>>;
 // Note - This reducer will be updated when we address general deletion of entities within inline lists (not paginated lists)
 export function updateOrganizationSpaceReducer() {
-  return function (state: APIResource, action: APISuccessOrFailedAction) {
+  return function (state: IRequestEntityTypeState<entityOrgType>, action: APISuccessOrFailedAction<NormalizedResponse>) {
     switch (action.type) {
       case DELETE_SPACE_SUCCESS:
         const deleteSpaceAction: DeleteSpace = action.apiAction as DeleteSpace;
-        return updateOrgSpaces(state, deleteSpaceAction.orgGuid, deleteSpaceAction);
+        return removeSpaceFromOrg(state, deleteSpaceAction.orgGuid, deleteSpaceAction.guid);
       case CREATE_SPACE_SUCCESS:
-        const createSpaceAction: CreateSpace = action.apiAction as CreateSpace;
-        const response: NormalizedResponse = action.response as NormalizedResponse;
+        const createSpaceAction = action.apiAction as CreateSpace;
+        const response = action.response;
         const space = response.entities[spaceSchemaKey][response.result[0]];
-        return updateOrgSpaces(state, createSpaceAction.orgGuid, createSpaceAction, space);
+        return addSpaceToOrg(state, createSpaceAction.orgGuid, space);
     }
     return state;
   };
 }
 
-function updateOrgSpaces(state: APIResource, orgGuid: string, spaceAction: BaseSpaceAction, newSpace?: APIResource<ISpace>) {
-  if (!orgGuid) {
-    return state;
-  }
+function addSpaceToOrg(
+  state: IRequestEntityTypeState<entityOrgType>,
+  orgGuid: string,
+  newSpace: APIResource<ISpace>
+) {
+  const orgToModify = getOrg(state, orgGuid);
+  const newSpaces = [
+    ...orgToModify.entity.spaces,
+    newSpace.metadata.guid
+  ];
+  const mergedOrg = applySpacesToOrg(orgToModify, newSpaces);
+  return {
+    ...state,
+    [orgGuid]: mergedOrg
+  };
+}
 
-  const orgGuids = Object.keys(state);
-  if (orgGuids.indexOf(orgGuid) === -1) {
-    return state;
-  }
-
-  const newState = {};
-  orgGuids.forEach(currentGuid => {
-    const org: APIResource<IOrganization> = state[currentGuid];
-    if (currentGuid === orgGuid) {
-      const newSpaces: (APIResource<ISpace> | string)[] = [...org.entity.spaces];
-      if (newSpace) {
-        newSpaces.push(newSpace.metadata.guid);
-      } else {
-        if (spaceAction.removeEntityOnDelete) {
-          const spaceIndex = org.entity.spaces.findIndex(space => {
-            return typeof (space) === 'string' ? space === spaceAction.guid : space.metadata.guid === spaceAction.guid;
-          });
-          if (spaceIndex >= 0) {
-            newSpaces.splice(spaceIndex, 1);
-          }
-        }
-      }
-      const newOrg = {
-        ...org,
-        entity: {
-          ...org.entity,
-          spaces: newSpaces
-        }
-      };
-      newState[currentGuid] = newOrg;
-    } else {
-      newState[currentGuid] = org;
+function removeSpaceFromOrg(
+  state: IRequestEntityTypeState<entityOrgType>,
+  orgGuid: string,
+  spaceGuid: string
+) {
+  const orgToModify = getOrg(state, orgGuid);
+  const newSpaces = orgToModify.entity.spaces.reduce((spaceIds, spaceId) => {
+    if (spaceId !== spaceGuid) {
+      spaceIds.push(spaceId);
     }
-  });
-  return newState;
+    return spaceIds;
+  }, []);
+  const mergedOrg = applySpacesToOrg(orgToModify, newSpaces);
+  return applyModifyOrgToState(state, mergedOrg);
+}
+
+function applySpacesToOrg(org: entityOrgType, spaces: string[]): entityOrgType {
+  return {
+    ...org,
+    entity: {
+      ...org.entity,
+      spaces
+    }
+  };
+}
+
+function applyModifyOrgToState(state: IRequestEntityTypeState<entityOrgType>, org: entityOrgType) {
+  return {
+    ...state,
+    [org.metadata.guid]: org
+  };
+}
+
+function getOrg(
+  state: IRequestEntityTypeState<entityOrgType>,
+  orgGuid: string,
+) {
+  const {
+    [orgGuid]: newOrg
+  } = state;
+  return newOrg;
 }


### PR DESCRIPTION
- fixes #3326
- We previously nuked the org's spaces param when creating or deleting an org
- Validation was correctly then going to refetch this param, however waitForEntity is broken (see #2327) and emits an invalid org entity without a spaces param
- Later code takes invalid entity and tries to access spaces param
- Fix, aside from #2327, is to update org spaces param after space creation instead of nuking and waiting for validation to refetch it

Other fixes
- Found sub leak in edit org stepper
- endpoint service allApps is subbed to in many places, ensure we share