### PR TITLE
Fix filter panel size on services and marketplace pages

### DIFF
--- a/src/frontend/app/features/service-catalog/service-catalog-page/service-catalog-page.component.html
+++ b/src/frontend/app/features/service-catalog/service-catalog-page/service-catalog-page.component.html
@@ -2,4 +2,4 @@
   <h1>Services Marketplace</h1>
 </app-page-header>
 <app-cf-endpoints-missing></app-cf-endpoints-missing>
-<app-list *ngIf="!!(cloudFoundryService.hasRegisteredCFEndpoints$ | async) && !!(cloudFoundryService.hasConnectedCFEndpoints$ | async)"></app-list>
+<app-list class="marketplace" *ngIf="!!(cloudFoundryService.hasRegisteredCFEndpoints$ | async) && !!(cloudFoundryService.hasConnectedCFEndpoints$ | async)"></app-list>

--- a/src/frontend/app/features/service-catalog/service-catalog-page/service-catalog-page.component.theme.scss
+++ b/src/frontend/app/features/service-catalog/service-catalog-page/service-catalog-page.component.theme.scss
@@ -1,0 +1,9 @@
+// For the Services Catalog, reduce the size of the filter and sort
+.marketplace {
+  .list-component__header__right-filter {
+    width: 140px;
+  }
+  .list-component__header__right-sort {
+    width: 120px;
+  }
+}

--- a/src/frontend/app/features/services/services-wall/services-wall.component.html
+++ b/src/frontend/app/features/services/services-wall/services-wall.component.html
@@ -23,4 +23,4 @@
 }"></app-no-content-message>
 </ng-template>
 
-<app-list [noEntries]="noEntries" [noEntriesForCurrentFilter]="noEntriesForCurrentFilter" *ngIf="!!(cloudFoundryService.hasRegisteredCFEndpoints$ | async) && !!(cloudFoundryService.hasConnectedCFEndpoints$ | async)"></app-list>
+<app-list class="services-wall" [noEntries]="noEntries" [noEntriesForCurrentFilter]="noEntriesForCurrentFilter" *ngIf="!!(cloudFoundryService.hasRegisteredCFEndpoints$ | async) && !!(cloudFoundryService.hasConnectedCFEndpoints$ | async)"></app-list>

--- a/src/frontend/app/features/services/services-wall/services-wall.component.theme.scss
+++ b/src/frontend/app/features/services/services-wall/services-wall.component.theme.scss
@@ -1,0 +1,9 @@
+// For the Services Wall, reduce the size of the filter and sort
+.services-wall {
+  .list-component__header__right-filter {
+    width: 140px;
+  }
+  .list-component__header__right-sort {
+    width: 120px;
+  }
+}

--- a/src/frontend/sass/_all-theme.scss
+++ b/src/frontend/sass/_all-theme.scss
@@ -37,6 +37,8 @@
 @import '../app/shared/components/metrics-chart/metrics-chart.component.theme';
 @import '../app/shared/components/metrics-range-selector/metrics-range-selector.component.theme';
 @import '../app/features/applications/application-wall/application-wall.component.theme';
+@import '../app/features/services/services-wall/services-wall.component.theme';
+@import '../app/features/service-catalog/service-catalog-page/service-catalog-page.component.theme';
 @import '../app/shared/components/multiline-title/multiline-title.component.theme';
 @import './components/mat-tabs.theme';
 @import './components/text-status.theme';


### PR DESCRIPTION
Fixes #3343 - Marketplace and Services - filter bar does not shrink like it does on the app wall