### PR TITLE
Fix precision in display of percent tooltip on metrics chart

### DIFF
--- a/src/frontend/app/features/applications/application/application-tabs-base/tabs/metrics-tab/metrics-tab.component.ts
+++ b/src/frontend/app/features/applications/application/application-tabs-base/tabs/metrics-tab/metrics-tab.component.ts
@@ -27,6 +27,7 @@ export class MetricsTabComponent {
           new MetricQueryConfig('firehose_container_metric_cpu_percentage')
         ),
         'CPU Usage (%)',
+        ChartDataTypes.CPU_PERCENT
       ),
       chartConfigBuilder(
         new FetchApplicationChartMetricsAction(

--- a/src/frontend/app/shared/components/metrics-chart/metrics.component.helpers.ts
+++ b/src/frontend/app/shared/components/metrics-chart/metrics.component.helpers.ts
@@ -29,7 +29,8 @@ export class MetricsChartHelpers {
   }
 }
 export enum ChartDataTypes {
-  BYTES = 'bytes'
+  BYTES = 'bytes',
+  CPU_PERCENT = 'cpu_percent',
 }
 export function getMetricsChartConfigBuilder<T = any>(getSeriesName: (result) => string) {
   return (
@@ -57,10 +58,21 @@ export function buildMetricsChartConfig<T = any>(
       getSeriesName,
       mapSeriesItemName: MetricsChartHelpers.getDateSeriesName,
       sort: MetricsChartHelpers.sortBySeriesName,
-      mapSeriesItemValue: dataType === ChartDataTypes.BYTES ? (bytes) => (bytes / 1000000).toFixed(2) : null,
+      mapSeriesItemValue: getServiceItemValueMapper(dataType),
       metricsAction,
       filterSeries: filterSeries,
     },
     MetricsChartHelpers.buildChartConfig(yAxisLabel, yAxisTickFormatter)
   ];
+}
+
+function getServiceItemValueMapper(chartDataType: ChartDataTypes) {
+  switch (chartDataType) {
+    case ChartDataTypes.BYTES:
+      return (bytes) => (bytes / 1000000).toFixed(2);
+      case ChartDataTypes.CPU_PERCENT:
+      return (percent) => parseFloat(percent).toFixed(2);
+    default:
+      return null;
+  }
 }


### PR DESCRIPTION
Fixes #3336 - Metrics Charts: CPU usage tooltip should round value 