### PR TITLE
Ensure the loading indicator and the refresh button animated at the correct time.

### DIFF
--- a/src/frontend/app/shared/components/list/list.component.html
+++ b/src/frontend/app/shared/components/list/list.component.html
@@ -97,7 +97,7 @@
             </button>
           </div>
           <button id="app-list-refresh-button" mat-icon-button *ngIf="dataSource.refresh" [disabled]="(dataSource.isLoadingPage$ | async) || (isAddingOrSelecting$ | async)" (click)="refresh()">
-            <mat-icon class="refresh-icon" [ngClass]="{refreshing: isRefreshing}" aria-label="Refresh list data">refresh</mat-icon>
+            <mat-icon class="refresh-icon" [ngClass]="{refreshing: (isRefreshing$ | async)}" aria-label="Refresh list data">refresh</mat-icon>
           </button>
         </div>
 
@@ -105,7 +105,7 @@
     </div>
     <div class="refresh-button__no-header" *ngIf="dataSource.refresh && !(hasControls$ | async) && (!(hasRowsOrIsFiltering$ | async) && noEntries)">
       <button id="app-list-refresh-button" mat-mini-fab *ngIf="!(isAddingOrSelecting$ | async)" [disabled]="dataSource.isLoadingPage$ | async" (click)="refresh()">
-        <mat-icon class="refresh-icon" [ngClass]="{refreshing: isRefreshing}" aria-label="Refresh list data">refresh</mat-icon>
+        <mat-icon class="refresh-icon" [ngClass]="{refreshing: (isRefreshing$ | async)}" aria-label="Refresh list data">refresh</mat-icon>
       </button>
     </div>
     <div class="list-component__body">

--- a/src/frontend/app/shared/components/list/list.component.ts
+++ b/src/frontend/app/shared/components/list/list.component.ts
@@ -598,7 +598,6 @@ export class ListComponent<T> implements OnInit, OnChanges, OnDestroy, AfterView
 
   public refresh() {
     if (this.dataSource.refresh) {
-      this.isRefreshing = true;
       this.dataSource.refresh();
       this.dataSource.isLoadingPage$.pipe(
         tap(isLoading => {
@@ -607,7 +606,7 @@ export class ListComponent<T> implements OnInit, OnChanges, OnDestroy, AfterView
           }
         }),
         takeWhile(isLoading => isLoading)
-      ).subscribe(null, null, () => this.isRefreshing = false);
+      );
     }
   }
 

--- a/src/frontend/app/shared/components/list/list.component.ts
+++ b/src/frontend/app/shared/components/list/list.component.ts
@@ -499,34 +499,33 @@ export class ListComponent<T> implements OnInit, OnChanges, OnDestroy, AfterView
       distinctUntilChanged(),
       pairwise(),
       map(([oldLoading, newLoading]) =>
-        !oldLoading && newLoading
+        oldLoading !== newLoading
       ),
-      startWith(true),
+      startWith(true)
     );
 
     const hasFilterChangedSinceLastLoading$ = loadingHasChanged$.pipe(
       filter(hasChanged => hasChanged),
       withLatestFrom(this.dataSource.pagination$),
       pairwise(),
-      map(([[hasChanged, oldPage], [newHasChanged, newPage]]) =>
+      map(([[hasChanged, oldPage], [newHasChanged, newPage]]) => [oldPage, newPage]),
+      map(([oldPage, newPage]) =>
         oldPage.currentPage !== newPage.currentPage ||
         oldPage.clientPagination.filter !== newPage.clientPagination.filter ||
         oldPage.params !== newPage.params
       ),
-      startWith(true),
-      tap(hasChanged => console.log(hasChanged, 'hasChanged'))
+      startWith(true)
     );
 
     this.isRefreshing$ = observableCombineLatest(hasFilterChangedSinceLastLoading$, this.dataSource.isLoadingPage$).pipe(
       map(([hasChanged, loading]) => !hasChanged && loading),
-      tap(console.log)
+      startWith(false)
     );
 
     this.showProgressBar$ = this.dataSource.isLoadingPage$.pipe(
       withLatestFrom(this.isRefreshing$),
       map(([loading, isRefreshing]) => !isRefreshing && loading),
       distinctUntilChanged(),
-      tap((showProgress) => console.log(showProgress, 'showProgress')),
       startWith(true),
     );
   }

--- a/src/frontend/app/shared/components/list/list.component.ts
+++ b/src/frontend/app/shared/components/list/list.component.ts
@@ -508,7 +508,7 @@ export class ListComponent<T> implements OnInit, OnChanges, OnDestroy, AfterView
       filter(hasChanged => hasChanged),
       withLatestFrom(this.dataSource.pagination$),
       pairwise(),
-      map(([[hasChanged, oldPage], [newHasChanged, newPage]]) => [oldPage, newPage]),
+      map(([oldData, newData]) => [oldData[1], newData[1]]),
       map(([oldPage, newPage]) =>
         oldPage.currentPage !== newPage.currentPage ||
         oldPage.clientPagination.filter !== newPage.clientPagination.filter ||

--- a/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-create-pagination.ts
+++ b/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-create-pagination.ts
@@ -58,10 +58,9 @@ function mergePaginationSections(
   seedPagination: PaginationEntityState,
   defaultState: PaginationEntityState
 ) {
-  const currentClientPagination = spreadClientPagination(currentPagination.clientPagination);
   const seedClientPagination = spreadClientPagination(seedPagination.clientPagination);
   return {
-    ...currentClientPagination,
+    ...currentPagination.clientPagination,
     totalResults: seedClientPagination.totalResults,
     currentPage: getCurrentPage(currentPagination, seedPagination)
   };

--- a/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-set-client-page-size.ts
+++ b/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-set-client-page-size.ts
@@ -1,13 +1,12 @@
 import { SetClientPageSize } from '../../actions/pagination.actions';
 import { PaginationEntityState } from '../../types/pagination.types';
-import { spreadClientPagination } from './pagination-reducer.helper';
 
 export function paginationSetClientPageSize(state: PaginationEntityState, action: SetClientPageSize) {
   return {
     ...state,
     error: false,
     clientPagination: {
-      ...spreadClientPagination(state.clientPagination),
+      ...state.clientPagination,
       pageSize: action.pageSize
     }
   };

--- a/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-set-client-page.ts
+++ b/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-set-client-page.ts
@@ -1,13 +1,12 @@
 import { SetClientPage } from '../../actions/pagination.actions';
 import { PaginationEntityState } from '../../types/pagination.types';
-import { spreadClientPagination } from './pagination-reducer.helper';
 
 export function paginationSetClientPage(state: PaginationEntityState, action: SetClientPage) {
   return {
     ...state,
     error: false,
     clientPagination: {
-      ...spreadClientPagination(state.clientPagination),
+      ...state.clientPagination,
       currentPage: action.pageNumber
     }
   };

--- a/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-set-result-count.ts
+++ b/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-set-result-count.ts
@@ -1,6 +1,5 @@
 import { SetResultCount } from '../../actions/pagination.actions';
 import { PaginationEntityState } from '../../types/pagination.types';
-import { spreadClientPagination } from './pagination-reducer.helper';
 
 export function paginationSetResultCount(state: PaginationEntityState, action: SetResultCount) {
   if (state.totalResults === action.count && state.clientPagination.totalResults === action.count) {
@@ -11,7 +10,7 @@ export function paginationSetResultCount(state: PaginationEntityState, action: S
     error: false,
     totalResults: action.count,
     clientPagination: {
-      ...spreadClientPagination(state.clientPagination),
+      ...state.clientPagination,
       totalResults: action.count
     }
   };

--- a/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-success.ts
+++ b/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-success.ts
@@ -1,5 +1,4 @@
 import { PaginationEntityState } from '../../types/pagination.types';
-import { spreadClientPagination } from './pagination-reducer.helper';
 
 export function paginationSuccess(state: PaginationEntityState, action): PaginationEntityState {
   const { apiAction, response, result } = action;
@@ -26,7 +25,7 @@ export function paginationSuccess(state: PaginationEntityState, action): Paginat
     pageCount: totalPages,
     totalResults,
     clientPagination: {
-      ...spreadClientPagination(state.clientPagination),
+      ...state.clientPagination,
       totalResults
     }
   };


### PR DESCRIPTION
The top blue loading indicator should show:

1) When fetching a page that isn't in the cache
1a) When changing page
2) When a search or filter change makes the list fetch new data from the backend
	This happens in two cases:
		1) On a none-local list.
		2) On a list that is currently showing the "too many entities" message. See https://github.com/cloudfoundry-incubator/stratos/issues/2895

The refresh button should animate:
1) When clicking on the refresh button
2) When we poll for data (i.e. a fetch has been requested but the page number and params haven't changed) - see the application instance table for an example of polling refreshes.

With one CF connected the apps list loads twice, this is fixed here https://github.com/cloudfoundry-incubator/stratos/pull/3313.

fixes #3305 
