### PR TITLE
Fix for bug causing intermittment E2E Test failures on org tests

### DIFF
--- a/src/frontend/app/features/cloud-foundry/services/cloud-foundry-endpoint.service.ts
+++ b/src/frontend/app/features/cloud-foundry/services/cloud-foundry-endpoint.service.ts
@@ -222,7 +222,8 @@ export class CloudFoundryEndpointService {
     return this.allApps$.pipe(
       filter(allApps => !!allApps),
       map(allApps => {
-        const orgSpaces = org.entity.spaces.map(s => s.metadata.guid);
+        const spaces = org.entity.spaces || [];
+        const orgSpaces = spaces.map(s => s.metadata.guid);
         return allApps.filter(a => orgSpaces.indexOf(a.entity.space_guid) !== -1);
       })
     );


### PR DESCRIPTION
Race condition can mean spaces on the entity was not set - this PR defaults it to be empty for this case.