### PR TITLE
Increase cf app instances to 2

### DIFF
--- a/manifest-docker.yml
+++ b/manifest-docker.yml
@@ -2,7 +2,7 @@ applications:
   - name: console
     docker:
       image: splatform/stratos:stable
-    instances: 1
+    instances: 2
     memory: 128M
     disk_quota: 384M
     # services:

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,6 +6,7 @@ applications:
     timeout: 180
     buildpack: https://github.com/cloudfoundry-incubator/stratos-buildpack#v2
     health-check-type: port
+    instances: 2
 #    env:
 # Override CF API endpoint URL inferred from VCAP_APPLICATION env 
 #       CF_API_URL: https://CLOUD_FOUNDRY_API_ENDPOINT


### PR DESCRIPTION
## Description

Increase cf app instances to 2, in order to avoid downtimes during diego cell evacuations

## Motivation and Context

As a stratos operator, in order to not have downtime during CF maintenance, I need to ensure stratos follows CF app best practices at https://docs.cloudfoundry.org/devguide/deploy-apps/prepare-to-deploy.html#increase-availability

## How Has This Been Tested?

Manual test. 

Documentation mentions stratos is compatible with a cluster mode
https://github.com/cloudfoundry-incubator/stratos/blob/v2-master/docs/overview.md

> Cloud Foundry Session Affinity is used to ensure that when scaling up the Console Application to multiple instances, the user is also directed to the instance which will know about them and their endpoints (since each Application instance will have its own local SQLite store).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message