### PR TITLE
Fix exception thrown on home page

### DIFF
--- a/src/frontend/packages/core/src/app.module.ts
+++ b/src/frontend/packages/core/src/app.module.ts
@@ -56,6 +56,7 @@ import { ApplicationStateService } from './shared/components/application-state/a
 import { favoritesConfigMapper } from './shared/components/favorites-meta-card/favorite-config-mapper';
 import { SharedModule } from './shared/shared.module';
 import { XSRFModule } from './xsrf.module';
+import { LoggerService } from './core/logger.service';
 
 // Create action for router navigation. See
 // - https://github.com/ngrx/platform/issues/68
@@ -130,13 +131,14 @@ export class AppModule {
     private permissionService: CurrentUserPermissionsService,
     private appStateService: ApplicationStateService,
     private store: Store<AppState>,
+    private logger: LoggerService
   ) {
     ext.init();
     // Init Auth Types and Endpoint Types provided by extensions
     initEndpointExtensions(ext);
     // Once the CF modules become an extension point, these should be moved to a CF specific module
     this.registerCfFavoriteMappers();
-    this.userFavoriteManager = new UserFavoriteManager(store);
+    this.userFavoriteManager = new UserFavoriteManager(store,  logger);
     const allFavs$ = this.userFavoriteManager.getAllFavorites();
     const recents$ = this.store.select(recentlyVisitedSelector);
     const debouncedApiRequestData$ = this.store.select(getAPIRequestDataState).pipe(debounceTime(2000));

--- a/src/frontend/packages/core/src/core/entity-favorite-star/entity-favorite-star.component.ts
+++ b/src/frontend/packages/core/src/core/entity-favorite-star/entity-favorite-star.component.ts
@@ -9,6 +9,7 @@ import { ConfirmationDialogConfig } from '../../shared/components/confirmation-d
 import { ConfirmationDialogService } from '../../shared/components/confirmation-dialog.service';
 import { favoritesConfigMapper } from '../../shared/components/favorites-meta-card/favorite-config-mapper';
 import { UserFavoriteManager } from '../user-favorite-manager';
+import { LoggerService } from '../logger.service';
 
 @Component({
   selector: 'app-entity-favorite-star',
@@ -36,8 +37,11 @@ export class EntityFavoriteStarComponent {
 
   private confirmationDialogConfig = new ConfirmationDialogConfig('Unfavorite?', '', 'Yes', true);
 
-  constructor(store: Store<AppState>, private confirmDialog: ConfirmationDialogService) {
-    this.userFavoriteManager = new UserFavoriteManager(store);
+  constructor(
+    store: Store<AppState>,
+    private confirmDialog: ConfirmationDialogService,
+    logger: LoggerService) {
+    this.userFavoriteManager = new UserFavoriteManager(store, logger);
   }
 
   public toggleFavorite(event: Event) {

--- a/src/frontend/packages/core/src/core/user-favorite-manager.ts
+++ b/src/frontend/packages/core/src/core/user-favorite-manager.ts
@@ -23,6 +23,7 @@ import {
   favoritesConfigMapper,
   TFavoriteMapperFunction,
 } from '../shared/components/favorites-meta-card/favorite-config-mapper';
+import { LoggerService } from './logger.service';
 
 export interface IFavoriteEntity {
   type: string;
@@ -51,7 +52,10 @@ export interface IHydrationResults<T extends IFavoriteMetadata = IFavoriteMetada
 }
 
 export class UserFavoriteManager {
-  constructor(private store: Store<AppState>) { }
+  constructor(
+    private store: Store<AppState>,
+    private logger: LoggerService
+    ) { }
 
   private getTypeAndID(favorite: UserFavorite<IFavoriteMetadata>) {
     const type = favorite.entityType;
@@ -122,7 +126,7 @@ export class UserFavoriteManager {
     if (!endpointFav) {
       return this.store.select(endpointEntitiesSelector).pipe(
         map(endpoints => {
-          const endpointGuid = UserFavorite.getEntityGuidFromFavoriteGuid(endpointFavoriteGuid);
+          const endpointGuid = UserFavorite.getEntityGuidFromFavoriteGuid(endpointFavoriteGuid, this.logger);
           const endpointEntity = endpoints[endpointGuid];
           return new UserFavoriteEndpoint(
             endpointGuid,

--- a/src/frontend/packages/core/src/shared/components/favorites-global-list/favorites-global-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/favorites-global-list/favorites-global-list.component.ts
@@ -9,6 +9,7 @@ import {
   fetchingFavoritesSelector,
 } from '../../../../../store/src/selectors/favorite-groups.selectors';
 import { IFavoriteEntity, IGroupedFavorites, UserFavoriteManager } from '../../../core/user-favorite-manager';
+import { LoggerService } from '../../../core/logger.service';
 
 
 interface IFavoritesInfo {
@@ -24,10 +25,10 @@ interface IFavoritesInfo {
 export class FavoritesGlobalListComponent implements OnInit {
   public favInfo$: Observable<IFavoritesInfo>;
   public favoriteGroups$: Observable<IGroupedFavorites[]>;
-  constructor(private store: Store<AppState>) { }
+  constructor(private store: Store<AppState>, private logger: LoggerService) { }
 
   ngOnInit() {
-    const manager = new UserFavoriteManager(this.store);
+    const manager = new UserFavoriteManager(this.store, this.logger);
     this.favoriteGroups$ = manager.hydrateAllFavorites().pipe(
       map(favs => this.sortFavoriteGroups(favs))
     );

--- a/src/frontend/packages/core/src/shared/components/list/list-cards/meta-card/meta-card-base/meta-card.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-cards/meta-card/meta-card-base/meta-card.component.ts
@@ -11,6 +11,7 @@ import { EntityMonitorFactory } from '../../../../../monitors/entity-monitor.fac
 import { CardStatus, ComponentEntityMonitorConfig } from '../../../../../shared.types';
 import { MetaCardItemComponent } from '../meta-card-item/meta-card-item.component';
 import { MetaCardTitleComponent } from '../meta-card-title/meta-card-title.component';
+import { LoggerService } from '../../../../../../core/logger.service';
 
 
 export interface MetaCardMenuItem {
@@ -96,7 +97,8 @@ export class MetaCardComponent {
 
   constructor(
     private entityMonitorFactory: EntityMonitorFactory,
-    store: Store<AppState>
+    store: Store<AppState>,
+    private logger: LoggerService
   ) {
     if (this.actionMenu) {
       this.actionMenu = this.actionMenu.map(element => {
@@ -106,7 +108,7 @@ export class MetaCardComponent {
         return element;
       });
     }
-    this.userFavoriteManager = new UserFavoriteManager(store);
+    this.userFavoriteManager = new UserFavoriteManager(store, logger);
   }
 
   cancelPropagation = (event) => {

--- a/src/frontend/packages/store/src/effects/user-favorites-effect.ts
+++ b/src/frontend/packages/store/src/effects/user-favorites-effect.ts
@@ -31,6 +31,7 @@ import { NormalizedResponse } from '../types/api.types';
 import { PaginatedAction } from '../types/pagination.types';
 import { WrapperRequestActionSuccess } from '../types/request.types';
 import { IFavoriteMetadata, UserFavorite, userFavoritesPaginationKey } from '../types/user-favorites.types';
+import { LoggerService } from '../../../core/src/core/logger.service';
 
 const { proxyAPIVersion } = environment;
 const favoriteUrlPath = `/pp/${proxyAPIVersion}/favorites`;
@@ -39,13 +40,16 @@ const favoriteUrlPath = `/pp/${proxyAPIVersion}/favorites`;
 @Injectable()
 export class UserFavoritesEffect {
 
+  private userFavoriteManager: UserFavoriteManager;
+
   constructor(
     private http: HttpClient,
     private actions$: Actions,
     private store: Store<AppState>,
-  ) { }
-
-  private userFavoriteManager = new UserFavoriteManager(this.store);
+    private logger: LoggerService
+  ) {
+    this.userFavoriteManager = new UserFavoriteManager(this.store, this.logger);
+  }
 
   @Effect() saveFavorite = this.actions$.ofType<SaveUserFavoriteAction>(SaveUserFavoriteAction.ACTION_TYPE).pipe(
     mergeMap(action => {

--- a/src/frontend/packages/store/src/types/user-favorites.types.ts
+++ b/src/frontend/packages/store/src/types/user-favorites.types.ts
@@ -1,6 +1,7 @@
 import { favoritesConfigMapper } from '../../../core/src/shared/components/favorites-meta-card/favorite-config-mapper';
 import { endpointSchemaKey } from '../helpers/entity-factory';
 import { EndpointModel } from './endpoint.types';
+import { LoggerService } from '../../../core/src/core/logger.service';
 
 export const userFavoritesPaginationKey = 'userFavorites';
 
@@ -78,8 +79,19 @@ export class UserFavorite<T extends IFavoriteMetadata, Y = any> implements IFavo
       .join(favoriteGuidSeparator);
   }
 
-  static getEntityGuidFromFavoriteGuid(favoriteGuid: string) {
-    return favoriteGuid.split(favoriteGuidSeparator)[0];
+  static getEntityGuidFromFavoriteGuid(favoriteGuid: string, logger: LoggerService): string {
+    const parts = favoriteGuid.split(favoriteGuidSeparator);
+    if (parts.length < 3) {
+      logger.error('Failed to determine entity guid from favorite guid: ', parts);
+      return null;
+    } else if (parts.length === 3)  {
+      return favoriteGuid.split(favoriteGuidSeparator)[0];
+    } else {
+      // cf guid may contain a hypen meaning there are more than 3 parts, so use everything prior to the 2nd to last part
+      return favoriteGuid.replace(
+        `${favoriteGuidSeparator}${parts[parts.length - 2]}${favoriteGuidSeparator}${parts[parts.length - 1]}`,
+        '');
+    }
   }
 }
 


### PR DESCRIPTION
- Only happens if there's a favourited entity in a non favourited endpoint and endpoint guid contains a hypen
- Exception was..
  ```
  core.js:1671 ERROR TypeError: Cannot read property 'cnsi_type' of undefined
    at MapSubscriber.project (user-favorite-manager.ts:129)
  ```
- PCFDev used with name of `PCF`