### PR TITLE
Fix 'unknown locale' error message when viewing service plans

### DIFF
--- a/src/frontend/packages/core/src/shared/components/add-service-instance/select-plan-step/select-plan-step.component.ts
+++ b/src/frontend/packages/core/src/shared/components/add-service-instance/select-plan-step/select-plan-step.component.ts
@@ -1,5 +1,4 @@
-import { registerLocaleData, TitleCasePipe } from '@angular/common';
-import localeFr from '@angular/common/locales/fr';
+import { TitleCasePipe } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -25,27 +24,27 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 
+import {
+  SetCreateServiceInstanceCFDetails,
+  SetCreateServiceInstanceServicePlan,
+} from '../../../../../../store/src/actions/create-service-instance.actions';
+import { AppState } from '../../../../../../store/src/app-state';
+import { selectCreateServiceInstance } from '../../../../../../store/src/selectors/create-service-instance.selectors';
+import { APIResource } from '../../../../../../store/src/types/api.types';
 import { IServicePlan } from '../../../../core/cf-api-svc.types';
+import { safeUnsubscribe } from '../../../../core/utils.service';
+import {
+  canShowServicePlanCosts,
+  getServicePlanAccessibilityCardStatus,
+  getServicePlanName,
+  populateServicePlanExtraTyped,
+} from '../../../../features/service-catalog/services-helper';
+import { CardStatus } from '../../../shared.types';
 import { StepOnNextResult } from '../../stepper/step/step.component';
 import { CreateServiceInstanceHelperServiceFactory } from '../create-service-instance-helper-service-factory.service';
 import { CreateServiceInstanceHelper } from '../create-service-instance-helper.service';
 import { CsiModeService } from '../csi-mode.service';
 import { NoServicePlansComponent } from '../no-service-plans/no-service-plans.component';
-import { APIResource, EntityInfo } from '../../../../../../store/src/types/api.types';
-import { AppState } from '../../../../../../store/src/app-state';
-import {
-  SetCreateServiceInstanceCFDetails,
-  SetCreateServiceInstanceServicePlan
-} from '../../../../../../store/src/actions/create-service-instance.actions';
-import { selectCreateServiceInstance } from '../../../../../../store/src/selectors/create-service-instance.selectors';
-import { CardStatus } from '../../../shared.types';
-import {
-  populateServicePlanExtraTyped,
-  getServicePlanAccessibilityCardStatus,
-  getServicePlanName,
-  canShowServicePlanCosts
-} from '../../../../features/service-catalog/services-helper';
-import { safeUnsubscribe } from '../../../../core/utils.service';
 
 @Component({
   selector: 'app-select-plan-step',
@@ -76,8 +75,6 @@ export class SelectPlanStepComponent implements OnDestroy {
     private modeService: CsiModeService
 
   ) {
-    registerLocaleData(localeFr);
-
     this.stepperForm = new FormGroup({
       servicePlans: new FormControl('', Validators.required),
     });

--- a/src/frontend/packages/core/src/shared/components/list/list-types/service-plans/service-plans-list-config.service.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/service-plans/service-plans-list-config.service.ts
@@ -24,8 +24,6 @@ import {
 
 
 /**
- * Service instance list shown for `service / service instances` component
- *
  * @export
  */
 @Injectable()

--- a/src/frontend/packages/core/src/shared/components/service-plan-price/service-plan-price.component.ts
+++ b/src/frontend/packages/core/src/shared/components/service-plan-price/service-plan-price.component.ts
@@ -1,7 +1,10 @@
+import { registerLocaleData } from '@angular/common';
+import localeFr from '@angular/common/locales/fr';
 import { Component, Input } from '@angular/core';
 
-import { IServicePlan, IServicePlanCost } from '../../../core/cf-api-svc.types';
 import { APIResource } from '../../../../../store/src/types/api.types';
+import { IServicePlan, IServicePlanCost } from '../../../core/cf-api-svc.types';
+
 
 @Component({
   selector: 'app-service-plan-price',
@@ -11,6 +14,10 @@ import { APIResource } from '../../../../../store/src/types/api.types';
 export class ServicePlanPriceComponent {
 
   @Input() servicePlan: APIResource<IServicePlan>;
+
+  constructor() {
+    registerLocaleData(localeFr);
+  }
 
   /*
  * Pick the first country listed in the amount object. It's unclear whether there could be a different number of these depending on


### PR DESCRIPTION
To reproduce..
- View the service's service plan table using a cost with amount in EUR
  - Alternatively update..
  - `src/frontend/packages/core/src/shared/components/list/list-types/service-plans/table-cell-service-plan-price/table-cell-service-plan-price.component.html`
    Remove if from `app-service-plan-price`
  - `src/frontend/packages/core/src/shared/components/service-plan-price/service-plan-price.component.ts`
    Update service plan property with 
```
private s;
  @Input() set servicePlan(a: APIResource<IServicePlan>) {
    a.entity.extraTyped = {
      costs: [
        {
          amount: {
            eur: 48
          },
          unit: 'Monthly'
        }
      ],
      displayName: 'noop plan display name',
      bullets: [
        '2GB storage',
        '50 concurrent connections'
      ]
    };
    this.s = a;
  }
  get servicePlan() {
    return this.s;
  }
```
- Exception `Missing locale data for the locale "fr".` is thrown when viewing service plans table

Fixes #3431
This didn't happen on the create service stepper due to the locale being registered there.
Also didn't happen if visiting the service plan table after the stepper

See https://angular.io/guide/i18n#i18n-pipes for more info


