### PR TITLE
Added "remove from x" item from user's action menu

### DIFF
--- a/deploy/tools/init-cf-for-e2e.sh
+++ b/deploy/tools/init-cf-for-e2e.sh
@@ -10,6 +10,7 @@ ADMIN="admin"
 ADMIN_PASS="admin"
 USER="user"
 USER_PASS="pass"
+REMOVE_USER="e2e-remove-user"
 SKIP_LOGIN="false"
 CF_API_ENDPOINT="https://api.local.pcfdev.io"
 DEFAULT_ORG="e2e"
@@ -55,26 +56,30 @@ function createOrgSpace() {
   local ORG=$1
   local SPACE=$2
   cf delete-org $ORG -f
-  
+
   cf create-org $ORG
   cf target -o $ORG
   cf create-space $SPACE
   cf target -o $ORG -s $SPACE
-  
+
   cf set-org-role $ADMIN $ORG OrgManager
   cf set-org-role $USER $ORG OrgManager
-  
+  cf set-org-role $REMOVE_USER $ORG OrgManager
+
   cf set-space-role $ADMIN $ORG $SPACE SpaceManager
   cf set-space-role $ADMIN $ORG $SPACE SpaceDeveloper
-  
+
   cf set-space-role $USER $ORG $SPACE SpaceManager
   cf set-space-role $USER $ORG $SPACE SpaceDeveloper
+
+  cf set-space-role $REMOVE_USER $ORG $SPACE SpaceManager
+  cf set-space-role $REMOVE_USER $ORG $SPACE SpaceDeveloper
 }
 
 function cloneRepo() {
   PROJECT=$1
   REPO=$2
-  
+
   if [ ! -d "./cfpushtemp/$REPO" ]; then
     echo "Cloning: $PROJECT/$REPO"
     mkdir -p cfpushtemp
@@ -85,6 +90,7 @@ function cloneRepo() {
 }
 
 cf create-user $USER $USER_PASS
+cf create-user $REMOVE_USER $USER_PASS
 
 createOrgSpace "test-e2e" "test-e2e"
 createOrgSpace $DEFAULT_ORG $DEFAULT_SPACE

--- a/src/frontend/packages/core/src/features/cloud-foundry/cf.helpers.ts
+++ b/src/frontend/packages/core/src/features/cloud-foundry/cf.helpers.ts
@@ -34,6 +34,7 @@ import { extractActualListEntity } from '../../shared/components/list/data-sourc
 import { MultiActionListEntity } from '../../shared/monitors/pagination-monitor';
 import { PaginationMonitorFactory } from '../../shared/monitors/pagination-monitor.factory';
 import { ActiveRouteCfCell, ActiveRouteCfOrgSpace } from './cf-page.types';
+import { ISpace } from '../../core/cf-api.types';
 
 
 export interface IUserRole<T> {
@@ -160,6 +161,42 @@ export function isSpaceDeveloper(user: CfUser, spaceGuid: string): boolean {
   return hasRole(user, spaceGuid, CfUserRoleParams.SPACES);
 }
 
+export function hasRoleWithinOrg(user: CfUser, orgGuid: string): boolean {
+  return isOrgManager(user, orgGuid) ||
+    isOrgBillingManager(user, orgGuid) ||
+    isOrgAuditor(user, orgGuid) ||
+    isOrgUser(user, orgGuid);
+}
+
+export function hasRoleWithinSpace(user: CfUser, spaceGuid: string): boolean {
+  return isSpaceManager(user, spaceGuid) ||
+    isSpaceAuditor(user, spaceGuid) ||
+    isSpaceDeveloper(user, spaceGuid);
+}
+
+export function hasRoleWithin(user: CfUser, orgGuid?: string, spaceGuid?: string): boolean {
+  return hasRoleWithinOrg(user, orgGuid) || hasRoleWithinSpace(user, spaceGuid);
+}
+
+export function hasSpaceRoleWithinOrg(user: CfUser, orgGuid: string): boolean {
+  const roles = [
+    CfUserRoleParams.MANAGED_SPACES,
+    CfUserRoleParams.AUDITED_SPACES,
+    CfUserRoleParams.SPACES
+  ];
+  const orgSpaces = [];
+
+  for (const role of roles) {
+    const roleSpaces = user[role] as APIResource<ISpace>[];
+
+    orgSpaces.push(...roleSpaces.filter((space) => {
+      return space.entity.organization_guid === orgGuid;
+    }));
+  }
+
+  return orgSpaces.some((space) => hasRoleWithinSpace(user, space.metadata.guid));
+}
+
 function hasRole(user: CfUser, guid: string, roleType: string) {
   if (user[roleType]) {
     const roles = user[roleType] as APIResource[];
@@ -188,7 +225,7 @@ export function getActiveRouteCfOrgSpace(activatedRoute: ActivatedRoute) {
   return ({
     cfGuid: getIdFromRoute(activatedRoute, 'endpointId'),
     orgGuid: getIdFromRoute(activatedRoute, 'orgId'),
-    spaceGuid: getIdFromRoute(activatedRoute, 'spaceId')
+    spaceGuid: getIdFromRoute(activatedRoute, 'spaceId'),
   });
 }
 
@@ -250,6 +287,13 @@ export function canUpdateOrgSpaceRoles(
   ).pipe(
     map((checks: boolean[]) => checks.some(check => check))
   );
+}
+
+export function canUpdateOrgRoles(
+  perms: CurrentUserPermissionsService,
+  cfGuid: string,
+  orgGuid?: string): Observable<boolean> {
+  return perms.can(CurrentUserPermissions.ORGANIZATION_CHANGE_ROLES, cfGuid, orgGuid);
 }
 
 export function waitForCFPermissions(store: Store<AppState>, cfGuid: string): Observable<ICfRolesState> {
@@ -348,6 +392,23 @@ export function createCfOrgSpaceSteppersUrl(
     }
   }
   route += stepperPath;
+  return route;
+}
+
+export function createCfOrgSpaceUserRemovalUrl(
+  cfGuid: string,
+  orgGuid?: string,
+  spaceGuid?: string,
+): string {
+  let route = `/cloud-foundry/${cfGuid}`;
+  if (orgGuid) {
+    route += `/organizations/${orgGuid}`;
+    if (spaceGuid) {
+      route += `/spaces/${spaceGuid}`;
+    }
+  }
+  route += '/users/remove';
+
   return route;
 }
 

--- a/src/frontend/packages/core/src/features/cloud-foundry/cloud-foundry.module.ts
+++ b/src/frontend/packages/core/src/features/cloud-foundry/cloud-foundry.module.ts
@@ -99,6 +99,7 @@ import {
 import { UserInviteService } from './user-invites/user-invite.service';
 import { InviteUsersCreateComponent } from './users/invite-users/invite-users-create/invite-users-create.component';
 import { InviteUsersComponent } from './users/invite-users/invite-users.component';
+import { RemoveUserComponent } from './users/remove-user/remove-user.component';
 import { CfRolesService } from './users/manage-users/cf-roles.service';
 import { UsersRolesConfirmComponent } from './users/manage-users/manage-users-confirm/manage-users-confirm.component';
 import { UsersRolesModifyComponent } from './users/manage-users/manage-users-modify/manage-users-modify.component';
@@ -165,6 +166,7 @@ import { UsersRolesComponent } from './users/manage-users/manage-users.component
     InviteUsersCreateComponent,
     CloudFoundryInviteUserLinkComponent,
     CfAdminAddUserWarningComponent,
+    RemoveUserComponent,
   ],
   providers: [
     EndpointListHelper,

--- a/src/frontend/packages/core/src/features/cloud-foundry/cloud-foundry.routing.ts
+++ b/src/frontend/packages/core/src/features/cloud-foundry/cloud-foundry.routing.ts
@@ -73,6 +73,7 @@ import { CloudFoundryStacksComponent } from './tabs/cloud-foundry-stacks/cloud-f
 import { CloudFoundrySummaryTabComponent } from './tabs/cloud-foundry-summary-tab/cloud-foundry-summary-tab.component';
 import { CloudFoundryUsersComponent } from './tabs/cloud-foundry-users/cloud-foundry-users.component';
 import { InviteUsersComponent } from './users/invite-users/invite-users.component';
+import { RemoveUserComponent } from './users/remove-user/remove-user.component';
 import { UsersRolesComponent } from './users/manage-users/manage-users.component';
 
 
@@ -84,8 +85,18 @@ const usersRoles = [
     pathMatch: 'full'
   },
   {
+    path: 'users/remove',
+    component: RemoveUserComponent,
+    pathMatch: 'full'
+  },
+  {
     path: 'organizations/:orgId/users/manage',
     component: UsersRolesComponent,
+    pathMatch: 'full'
+  },
+  {
+    path: 'organizations/:orgId/users/remove',
+    component: RemoveUserComponent,
     pathMatch: 'full'
   },
   {
@@ -96,6 +107,11 @@ const usersRoles = [
   {
     path: 'organizations/:orgId/spaces/:spaceId/users/manage',
     component: UsersRolesComponent,
+    pathMatch: 'full'
+  },
+  {
+    path: 'organizations/:orgId/spaces/:spaceId/users/remove',
+    component: RemoveUserComponent,
     pathMatch: 'full'
   },
   {

--- a/src/frontend/packages/core/src/features/cloud-foundry/users/manage-users/manage-users-confirm/manage-users-confirm.component.html
+++ b/src/frontend/packages/core/src/features/cloud-foundry/users/manage-users/manage-users-confirm/manage-users-confirm.component.html
@@ -1,3 +1,3 @@
-<p>Please confirm that you would like to make the following user role changes to organization '{{orgName$ | async}}'</p>
+<p>Please confirm that you would like to make the following user role changes to organization {{orgName$ | async}}</p>
 <app-action-monitor [columns]="columns" [data$]="changes$" [entityKey]="userSchemaKey" [monitorState]="monitorState" [getCellConfig]="getCellConfig">
 </app-action-monitor>

--- a/src/frontend/packages/core/src/features/cloud-foundry/users/manage-users/manage-users-modify/manage-users-modify.component.ts
+++ b/src/frontend/packages/core/src/features/cloud-foundry/users/manage-users/manage-users-modify/manage-users-modify.component.ts
@@ -167,12 +167,18 @@ export class UsersRolesModifyComponent implements OnInit, OnDestroy {
 
     // Set the starting state of the org table
     if (this.activeRouteCfOrgSpace.orgGuid) {
-      this.store.dispatch(new UsersRolesSetOrg(this.activeRouteCfOrgSpace.orgGuid));
+      this.cfRolesService.fetchOrg(this.activeRouteCfOrgSpace.cfGuid, this.activeRouteCfOrgSpace.orgGuid).pipe(
+        first()
+      ).subscribe(org => {
+        this.store.dispatch(new UsersRolesSetOrg(this.activeRouteCfOrgSpace.orgGuid, org.entity.entity.name));
+      });
     } else {
       this.orgGuidChangedSub = this.cfRolesService.fetchOrgs(this.activeRouteCfOrgSpace.cfGuid).pipe(
         filter(orgs => orgs && !!orgs.length),
         first()
-      ).subscribe(orgs => this.store.dispatch(new UsersRolesSetOrg(orgs[0].metadata.guid)));
+      ).subscribe(orgs => {
+        this.store.dispatch(new UsersRolesSetOrg(orgs[0].metadata.guid, orgs[0].entity.name));
+      });
     }
 
     const users$: Observable<CfUserWithWarning[]> = this.store.select(selectUsersRolesPicked).pipe(

--- a/src/frontend/packages/core/src/features/cloud-foundry/users/remove-user/remove-user.component.html
+++ b/src/frontend/packages/core/src/features/cloud-foundry/users/remove-user/remove-user.component.html
@@ -1,0 +1,10 @@
+<app-page-header>
+  <span *ngIf="singleUser$ | async">Remove User: {{(singleUser$ | async).username }}</span>
+</app-page-header>
+<app-steppers cancel="{{defaultCancelUrl}}" [nextButtonProgress]="false">
+  <app-step title="Confirm" [onEnter]="confirm.onEnter" [canClose]="!applyStarted" [disablePrevious]="applyStarted"
+    [blocked]="isBlocked$ | async" [destructiveStep]="!applyStarted" [onNext]="startApply"
+    [finishButtonText]="applyStarted ? 'Close' : 'Apply'">
+    <app-manage-users-confirm #confirm></app-manage-users-confirm>
+  </app-step>
+</app-steppers>

--- a/src/frontend/packages/core/src/features/cloud-foundry/users/remove-user/remove-user.component.spec.ts
+++ b/src/frontend/packages/core/src/features/cloud-foundry/users/remove-user/remove-user.component.spec.ts
@@ -1,0 +1,63 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpModule } from '@angular/http';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { CoreModule } from '../../../../core/core.module';
+import { SharedModule } from '../../../../shared/shared.module';
+import { createBasicStoreModule } from '../../../../../test-framework/store-test-helper';
+import { CfUserServiceTestProvider } from '../../../../../test-framework/user-service-helper';
+import { ActiveRouteCfOrgSpace } from '../../cf-page.types';
+import { CfRolesService } from '../manage-users//cf-roles.service';
+import { UsersRolesConfirmComponent } from '../manage-users/manage-users-confirm/manage-users-confirm.component';
+import { RemoveUserComponent } from './remove-user.component';
+import { TabNavService } from '../../../../../tab-nav.service';
+
+describe('RemoveUserComponent', () => {
+  let component: RemoveUserComponent;
+  let fixture: ComponentFixture<RemoveUserComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CoreModule,
+        SharedModule,
+        createBasicStoreModule(),
+        NoopAnimationsModule,
+        RouterTestingModule,
+        HttpModule
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParams: { breadcrumbs: 'key' },
+              params: {}
+            }
+          }
+        },
+        ActiveRouteCfOrgSpace,
+        CfUserServiceTestProvider,
+        CfRolesService,
+        TabNavService
+      ],
+      declarations: [
+        RemoveUserComponent,
+        UsersRolesConfirmComponent,
+      ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RemoveUserComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/frontend/packages/core/src/features/cloud-foundry/users/remove-user/remove-user.component.ts
+++ b/src/frontend/packages/core/src/features/cloud-foundry/users/remove-user/remove-user.component.ts
@@ -1,0 +1,217 @@
+import { Component, OnDestroy } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { combineLatest as obsCombineLatest, Observable, of as observableOf } from 'rxjs';
+import { combineLatest, filter, first, map, startWith } from 'rxjs/operators';
+
+import {
+  UsersRolesClear,
+  UsersRolesExecuteChanges,
+  UsersRolesSetChanges,
+  UsersRolesSetUsers,
+} from '../../../../../../store/src/actions/users-roles.actions';
+import { AppState } from '../../../../../../store/src/app-state';
+import { selectUsersRoles } from '../../../../../../store/src/selectors/users-roles.selector';
+import { CfUser, IUserPermissionInOrg, IUserPermissionInSpace } from '../../../../../../store/src/types/user.types';
+import { CfRoleChange } from '../../../../../../store/src/types/users-roles.types';
+import { CurrentUserPermissions } from '../../../../core/current-user-permissions.config';
+import { CurrentUserPermissionsService } from '../../../../core/current-user-permissions.service';
+import { LoggerService } from '../../../../core/logger.service';
+import { StepOnNextFunction } from '../../../../shared/components/stepper/step/step.component';
+import { CfUserService } from '../../../../shared/data-services/cf-user.service';
+import { ActiveRouteCfOrgSpace } from '../../cf-page.types';
+import { getActiveRouteCfOrgSpaceProvider } from '../../cf.helpers';
+import { CfRolesService } from '../manage-users/cf-roles.service';
+
+@Component({
+  selector: 'app-remove-user',
+  templateUrl: './remove-user.component.html',
+  styleUrls: ['./remove-user.component.scss'],
+  providers: [
+    getActiveRouteCfOrgSpaceProvider,
+    CfUserService,
+    CfRolesService
+  ]
+})
+export class RemoveUserComponent implements OnDestroy {
+  initialUsers$: Observable<CfUser[]>;
+  singleUser$: Observable<CfUser>;
+  defaultCancelUrl: string;
+  cfGuid: string;
+  orgGuid: string;
+  spaceGuid: string;
+  applyStarted = false;
+  onlySpaces = false;
+  isBlocked$: Observable<boolean>;
+
+  constructor(
+    private store: Store<AppState>,
+    private activeRouteCfOrgSpace: ActiveRouteCfOrgSpace,
+    private cfUserService: CfUserService,
+    private cfRolesService: CfRolesService,
+    private logService: LoggerService,
+    private route: ActivatedRoute,
+    private userPerms: CurrentUserPermissionsService
+  ) {
+    this.defaultCancelUrl = this.createReturnUrl(activeRouteCfOrgSpace);
+    this.cfGuid = this.activeRouteCfOrgSpace.cfGuid;
+    this.orgGuid = this.activeRouteCfOrgSpace.orgGuid;
+    this.spaceGuid = this.activeRouteCfOrgSpace.spaceGuid;
+    this.onlySpaces = this.route.snapshot.queryParams.spaces === 'true';
+
+    const userQParam = this.route.snapshot.queryParams.user;
+    if (userQParam) {
+      this.singleUser$ = this.cfUserService.getUser(activeRouteCfOrgSpace.cfGuid, userQParam)
+        .pipe(
+          map(user => user.entity),
+          first()
+        );
+    } else {
+      this.logService.error('User param not defined');
+      return;
+    }
+
+    const cfGuid$ = this.store.select(selectUsersRoles).pipe(
+      combineLatest(this.singleUser$),
+      first()
+    );
+    // Ensure that when we arrive here directly the store is set up with all it needs
+    cfGuid$.subscribe(([usersRoles, user]) => {
+      if (!usersRoles.cfGuid || !user) {
+        this.store.dispatch(new UsersRolesSetUsers(activeRouteCfOrgSpace.cfGuid, [user]));
+      }
+    });
+
+    this.isBlocked$ = cfGuid$.pipe(
+      filter(res => !!res),
+      map(() => false),
+      startWith(true),
+    );
+
+    this.cfRolesService.existingRoles$.pipe(
+      combineLatest(this.singleUser$),
+      first(),
+    ).subscribe(([existingRoles, user]) => {
+      const orgs = existingRoles[user.guid];
+      const changes = this.getRolesChanges(user, orgs);
+
+      obsCombineLatest(...this.getChangesObservables(changes)).pipe(
+        map(([...canChanges]) => canChanges),
+        first()
+      ).subscribe((canChanges) => {
+        const allowedChanges = canChanges.filter((c) => c.can).map(c => c.change);
+        this.store.dispatch(new UsersRolesSetChanges(allowedChanges));
+      });
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.store.dispatch(new UsersRolesClear());
+  }
+
+  getChangesObservables(changes: CfRoleChange[]) {
+    return changes.map((c) => {
+      const isOrgRole = !c.spaceGuid;
+
+      if (isOrgRole) {
+        return this.userPerms.can(CurrentUserPermissions.ORGANIZATION_CHANGE_ROLES, this.cfGuid, c.orgGuid).pipe(
+          map((can) => ({ can, change: c }))
+        );
+      }
+
+      return this.userPerms.can(CurrentUserPermissions.SPACE_CHANGE_ROLES, this.cfGuid, c.orgGuid, c.spaceGuid).pipe(
+        map((can) => ({ can, change: c }))
+      );
+    });
+  }
+
+  getRolesChanges(user: CfUser, orgs) {
+    const changes = [];
+    const orgGuids = this.orgGuid ? [this.orgGuid] : Object.keys(orgs);
+
+    for (const orgGuid of orgGuids) {
+      const org: IUserPermissionInOrg = orgs[orgGuid];
+
+      changes.push(...this.getOrgRolesChanges(user, org));
+      changes.push(...this.getSpacesRolesChanges(user, org.spaces));
+    }
+
+    return changes;
+  }
+
+  getOrgRolesChanges(user: CfUser, org: IUserPermissionInOrg) {
+    const changes = [];
+
+    if (!this.spaceGuid && !this.onlySpaces) {
+      const roles = org.permissions;
+
+      for (const role of Object.keys(roles)) {
+        const assigned = roles[role];
+
+        if (assigned) {
+          changes.push({
+            userGuid: user.guid,
+            orgGuid: org.orgGuid,
+            orgName: org.name,
+            add: false,
+            role,
+          });
+        }
+      }
+    }
+
+    return changes;
+  }
+
+  getSpacesRolesChanges(user: CfUser, spaces) {
+    const changes = [];
+    const spaceGuids = this.spaceGuid ? [this.spaceGuid] : Object.keys(spaces);
+
+    for (const spaceGuid of spaceGuids) {
+      const space: IUserPermissionInSpace = spaces[spaceGuid];
+      const roles = space.permissions;
+
+      for (const role of Object.keys(roles)) {
+        const assigned = roles[role];
+
+        if (assigned) {
+          changes.push({
+            userGuid: user.guid,
+            orgGuid: space.orgGuid,
+            orgName: space.orgName,
+            spaceGuid,
+            spaceName: space.name,
+            add: false,
+            role,
+          });
+        }
+      }
+    }
+
+    return changes;
+  }
+
+  /**
+   * Determine where the return url should be. This will only apply when user visits modal directly (otherwise stepper uses previous state)
+   */
+  createReturnUrl(activeRouteCfOrgSpace: ActiveRouteCfOrgSpace): string {
+    let route = `/cloud-foundry/${activeRouteCfOrgSpace.cfGuid}`;
+    if (this.activeRouteCfOrgSpace.orgGuid) {
+      route += `/organizations/${activeRouteCfOrgSpace.orgGuid}`;
+      if (this.activeRouteCfOrgSpace.spaceGuid) {
+        route += `/spaces/${activeRouteCfOrgSpace.spaceGuid}`;
+      }
+    }
+    route += `/users`;
+    return route;
+  }
+
+  startApply: StepOnNextFunction = () => {
+    if (this.applyStarted) {
+      return observableOf({ success: true, redirect: true });
+    }
+    this.applyStarted = true;
+    this.store.dispatch(new UsersRolesExecuteChanges());
+    return observableOf({ success: true, ignoreSuccess: true });
+  }
+}

--- a/src/frontend/packages/core/src/shared/components/cf-role-checkbox/cf-role-checkbox.component.ts
+++ b/src/frontend/packages/core/src/shared/components/cf-role-checkbox/cf-role-checkbox.component.ts
@@ -36,6 +36,8 @@ export class CfRoleCheckboxComponent implements OnInit, OnDestroy {
 
   @Input() cfGuid: string;
   @Input() spaceGuid: string;
+  @Input() orgName: string;
+  @Input() spaceName: string;
   @Input() role: string;
   @Output() changed = new BehaviorSubject(false);
 
@@ -268,9 +270,9 @@ export class CfRoleCheckboxComponent implements OnInit, OnDestroy {
         this.tooltip = '';
       }
       if (this.isOrgRole) {
-        this.store.dispatch(new UsersRolesSetOrgRole(this.orgGuid, this.role, checked));
+        this.store.dispatch(new UsersRolesSetOrgRole(this.orgGuid, this.orgName, this.role, checked));
       } else {
-        this.store.dispatch(new UsersRolesSetSpaceRole(this.orgGuid, this.spaceGuid, this.role, checked));
+        this.store.dispatch(new UsersRolesSetSpaceRole(this.orgGuid, this.orgName, this.spaceGuid, this.spaceName, this.role, checked));
       }
     });
   }

--- a/src/frontend/packages/core/src/shared/components/list/list-types/cf-users-org-space-roles/cf-users-space-roles-data-source.service.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/cf-users-org-space-roles/cf-users-space-roles-data-source.service.ts
@@ -1,16 +1,23 @@
 import { Store } from '@ngrx/store';
 
+import { GetAllOrganizationSpaces } from '../../../../../../../store/src/actions/organization.actions';
+import { AppState } from '../../../../../../../store/src/app-state';
+import {
+  cfUserSchemaKey,
+  entityFactory,
+  organizationSchemaKey,
+  spaceSchemaKey,
+  spaceWithOrgKey,
+} from '../../../../../../../store/src/helpers/entity-factory';
+import { createEntityRelationKey } from '../../../../../../../store/src/helpers/entity-relations/entity-relations.types';
+import { APIResource } from '../../../../../../../store/src/types/api.types';
+import { PaginationEntityState } from '../../../../../../../store/src/types/pagination.types';
 import { ISpace } from '../../../../../core/cf-api.types';
 import { CurrentUserPermissionsService } from '../../../../../core/current-user-permissions.service';
 import { getRowMetadata } from '../../../../../features/cloud-foundry/cf.helpers';
 import { CfRolesService } from '../../../../../features/cloud-foundry/users/manage-users/cf-roles.service';
 import { ListDataSource } from '../../data-sources-controllers/list-data-source';
 import { IListConfig } from '../../list.component.types';
-import { APIResource } from '../../../../../../../store/src/types/api.types';
-import { GetAllOrganizationSpaces } from '../../../../../../../store/src/actions/organization.actions';
-import { PaginationEntityState } from '../../../../../../../store/src/types/pagination.types';
-import { AppState } from '../../../../../../../store/src/app-state';
-import { cfUserSchemaKey, entityFactory, spaceSchemaKey } from '../../../../../../../store/src/helpers/entity-factory';
 
 export class CfUsersSpaceRolesDataSourceService extends ListDataSource<APIResource<ISpace>> {
   constructor(
@@ -21,12 +28,14 @@ export class CfUsersSpaceRolesDataSourceService extends ListDataSource<APIResour
     userPerms: CurrentUserPermissionsService,
     listConfig?: IListConfig<APIResource>) {
     const paginationKey = cfUserSchemaKey + '-' + orgGuid;
-    const action = new GetAllOrganizationSpaces(paginationKey, orgGuid, cfGuid, []);
-
+    const action
+      = new GetAllOrganizationSpaces(paginationKey, orgGuid, cfGuid, [createEntityRelationKey(spaceSchemaKey, organizationSchemaKey)]);
+    action.entityKey = spaceSchemaKey;
+    action.entity = entityFactory(spaceWithOrgKey);
     super({
       store,
       action,
-      schema: entityFactory(spaceSchemaKey),
+      schema: entityFactory(spaceWithOrgKey),
       getRowUniqueId: getRowMetadata,
       paginationKey: action.paginationKey,
       isLocal: true,

--- a/src/frontend/packages/core/src/shared/components/list/list-types/cf-users-org-space-roles/table-cell-org-space-role/table-cell-org-space-role.component.html
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/cf-users-org-space-roles/table-cell-org-space-role/table-cell-org-space-role.component.html
@@ -1,1 +1,4 @@
-<app-cf-role-checkbox [cfGuid]="row.entity.cfGuid" [spaceGuid]="config.isSpace ? row.metadata.guid : ''" [role]="config.role"></app-cf-role-checkbox>
+<app-cf-role-checkbox [cfGuid]="row.entity.cfGuid"
+  [orgName]="config.isSpace ? row?.entity.organization?.entity.name : row?.entity.name"
+  [spaceName]="config.isSpace ? row?.entity.name : null" [spaceGuid]="config.isSpace ? row.metadata.guid : ''"
+  [role]="config.role"></app-cf-role-checkbox>

--- a/src/frontend/packages/core/src/shared/components/list/list-types/cf-users-org-space-roles/table-cell-select-org/table-cell-select-org.component.html
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/cf-users-org-space-roles/table-cell-select-org/table-cell-select-org.component.html
@@ -4,7 +4,8 @@
 </ng-template>
 <ng-template #manyOrgs>
   <mat-form-field>
-    <mat-select #cfSelect="ngModel" [ngModel]="selectedOrgGuid" id="selectOrgGuid" (selectionChange)="updateOrg($event.value)" required>
+    <mat-select #cfSelect="ngModel" [ngModel]="selectedOrgGuid" id="selectOrgGuid"
+      (selectionChange)="updateOrg($event.value)" required>
       <mat-option *ngFor="let org of organizations$ | async;trackBy:org?.metadata?.guid" [value]="org.metadata.guid">
         {{org.entity.name}}
       </mat-option>

--- a/src/frontend/packages/core/src/shared/components/list/list-types/cf-users/cf-user-list-config.service.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/cf-users/cf-user-list-config.service.ts
@@ -18,6 +18,10 @@ import { ActiveRouteCfOrgSpace } from '../../../../../features/cloud-foundry/cf-
 import {
   canUpdateOrgSpaceRoles,
   createCfOrgSpaceSteppersUrl,
+  createCfOrgSpaceUserRemovalUrl,
+  hasRoleWithin,
+  hasRoleWithinSpace,
+  hasSpaceRoleWithinOrg,
   waitForCFPermissions,
 } from '../../../../../features/cloud-foundry/cf.helpers';
 import { CfUserService } from './../../../../data-services/cf-user.service';
@@ -34,14 +38,21 @@ import { CfSpacePermissionCellComponent } from './cf-space-permission-cell/cf-sp
 import { CfUserDataSourceService } from './cf-user-data-source.service';
 import { userHasRole, UserListUsersVisible, userListUserVisibleKey } from './cf-user-list-helpers';
 
-const defaultUserHasRoles: (user: CfUser) => boolean = (user: CfUser): boolean => {
-  return userHasRole(user, 'organizations') ||
-    userHasRole(user, 'spaces') ||
-    userHasRole(user, 'managed_organizations') ||
+const defaultUserHasSpaceRoles: (user: CfUser) => boolean = (user: CfUser): boolean => {
+  return userHasRole(user, 'spaces') ||
     userHasRole(user, 'managed_spaces') ||
+    userHasRole(user, 'audited_spaces');
+};
+
+const defaultUserHasOrgRoles: (user: CfUser) => boolean = (user: CfUser): boolean => {
+  return userHasRole(user, 'organizations') ||
+    userHasRole(user, 'managed_organizations') ||
     userHasRole(user, 'audited_organizations') ||
-    userHasRole(user, 'audited_spaces') ||
     userHasRole(user, 'billing_managed_organizations');
+};
+
+const defaultUserHasRoles: (user: CfUser) => boolean = (user: CfUser): boolean => {
+  return defaultUserHasOrgRoles(user) || defaultUserHasSpaceRoles(user);
 };
 
 export class CfUserListConfigService extends ListConfig<APIResource<CfUser>> {
@@ -109,10 +120,80 @@ export class CfUserListConfigService extends ListConfig<APIResource<CfUser>> {
     description: `Manage roles`,
   };
 
+  removeUserActions(): IListAction<APIResource<CfUser>>[] {
+    const activeRouteCfOrgSpace = this.cfUserService.activeRouteCfOrgSpace;
+    const orgGuid = activeRouteCfOrgSpace.orgGuid;
+    const spaceGuid = activeRouteCfOrgSpace.spaceGuid;
+    const isCfContext = !orgGuid && !spaceGuid;
+
+    const action = (withSpaces?: boolean) => {
+      return (user: APIResource<CfUser>) => {
+        const queryParams = { queryParams: { user: user.entity.guid, spaces: withSpaces } };
+
+        this.store.dispatch(new UsersRolesSetUsers(activeRouteCfOrgSpace.cfGuid, [user.entity]));
+        this.router.navigate([this.createRemoveUserUrl()], queryParams);
+      };
+    };
+
+    const fromSpaces: IListAction<APIResource<CfUser>> = {
+      action: action(true),
+      label: (() => (spaceGuid) ? 'Remove from space' : 'Remove from spaces')(),
+      createVisible: (userRow$: Observable<APIResource<CfUser>>) => combineLatest(
+        userRow$,
+        this.createCanUpdateOrgSpaceRoles()
+      ).pipe(
+        map(([user, canUpdateRoles]) => {
+          if (spaceGuid) {
+            return canUpdateRoles && hasRoleWithinSpace(user.entity, spaceGuid);
+          }
+
+          if (orgGuid) {
+            return canUpdateRoles && hasSpaceRoleWithinOrg(user.entity, orgGuid);
+          }
+
+          if (isCfContext) {
+            return canUpdateRoles && defaultUserHasSpaceRoles(user.entity);
+          }
+        })
+      )
+    };
+
+    const fromOrgsSpaces: IListAction<APIResource<CfUser>> = {
+      action: action(),
+      label: (() => (orgGuid) ? 'Remove from org and spaces' : 'Remove from orgs and spaces')(),
+      createVisible: (userRow$: Observable<APIResource<CfUser>>) => combineLatest(
+        userRow$,
+        this.createCanUpdateOrgRoles()
+      ).pipe(
+        map(([user, canUpdateRoles]) => {
+          if (orgGuid) {
+            return canUpdateRoles && hasRoleWithin(user.entity, orgGuid, spaceGuid);
+          } else {
+            return canUpdateRoles && defaultUserHasOrgRoles(user.entity);
+          }
+        })
+      )
+    };
+
+    if (spaceGuid) {
+      return [fromSpaces];
+    }
+
+    return [fromOrgsSpaces, fromSpaces];
+  }
+
   protected createManagerUsersUrl(): string {
     return createCfOrgSpaceSteppersUrl(
       this.cfUserService.activeRouteCfOrgSpace.cfGuid,
       `/users/manage`,
+      this.activeRouteCfOrgSpace.orgGuid,
+      this.activeRouteCfOrgSpace.spaceGuid
+    );
+  }
+
+  protected createRemoveUserUrl(): string {
+    return createCfOrgSpaceUserRemovalUrl(
+      this.cfUserService.activeRouteCfOrgSpace.cfGuid,
       this.activeRouteCfOrgSpace.orgGuid,
       this.activeRouteCfOrgSpace.spaceGuid
     );
@@ -261,10 +342,15 @@ export class CfUserListConfigService extends ListConfig<APIResource<CfUser>> {
     this.activeRouteCfOrgSpace.orgGuid && !this.activeRouteCfOrgSpace.spaceGuid ?
       CurrentUserPermissionsChecker.ALL_SPACES : this.activeRouteCfOrgSpace.spaceGuid)
 
+  private createCanUpdateOrgRoles = () => canUpdateOrgSpaceRoles(
+    this.userPerms,
+    this.activeRouteCfOrgSpace.cfGuid,
+    this.activeRouteCfOrgSpace.orgGuid)
+
   getColumns = () => this.columns;
   getGlobalActions = () => [];
   getMultiActions = () => [this.manageMultiUserAction];
-  getSingleActions = () => [this.manageUserAction];
+  getSingleActions = () => [this.manageUserAction, ...this.removeUserActions()];
   getMultiFiltersConfigs = () => this.multiFilterConfigs;
   getDataSource = () => this.dataSource;
   getInitialised = () => this.initialised;

--- a/src/frontend/packages/core/src/shared/data-services/cf-user.service.ts
+++ b/src/frontend/packages/core/src/shared/data-services/cf-user.service.ts
@@ -157,6 +157,7 @@ export class CfUserService {
       result.push({
         name: space.entity.name as string,
         orgGuid: space.entity.organization_guid,
+        orgName: null,
         spaceGuid,
         permissions: createUserRoleInSpace(
           isSpaceManager(user, spaceGuid),

--- a/src/frontend/packages/store/src/actions/users-roles.actions.ts
+++ b/src/frontend/packages/store/src/actions/users-roles.actions.ts
@@ -21,12 +21,19 @@ export class UsersRolesSetUsers implements Action {
 
 export class UsersRolesSetOrgRole implements Action {
   type = UsersRolesActions.SetOrgRole;
-  constructor(public orgGuid: string, public role: string, public setRole: boolean) { }
+  constructor(public orgGuid: string, public orgName: string, public role: string, public setRole: boolean) { }
 }
 
 export class UsersRolesSetSpaceRole implements Action {
   type = UsersRolesActions.SetSpaceRole;
-  constructor(public orgGuid: string, public spaceGuid: string, public role: string, public setRole: boolean) { }
+  constructor(
+    public orgGuid: string,
+    public orgName: string,
+    public spaceGuid: string,
+    public spaceName: string,
+    public role: string,
+    public setRole: boolean
+  ) { }
 }
 
 export class UsersRolesClear implements Action {
@@ -41,7 +48,7 @@ export class UsersRolesClearUpdateState implements Action {
 
 export class UsersRolesSetOrg implements Action {
   type = UsersRolesActions.SetOrg;
-  constructor(public selectedOrg: string) { }
+  constructor(public orgGuid: string, public orgName: string) { }
 }
 
 export class UsersRolesSetChanges implements Action {

--- a/src/frontend/packages/store/src/types/user.types.ts
+++ b/src/frontend/packages/store/src/types/user.types.ts
@@ -111,6 +111,7 @@ export interface IUserPermissionInOrg {
 export interface IUserPermissionInSpace {
   name: string;
   orgGuid: string;
+  orgName: string;
   spaceGuid: string;
   permissions: UserRoleInSpace;
 }

--- a/src/frontend/packages/store/src/types/users-roles.types.ts
+++ b/src/frontend/packages/store/src/types/users-roles.types.ts
@@ -19,6 +19,8 @@ export class CfRoleChange {
   spaceGuid?: string;
   add: boolean;
   role: OrgUserRoleNames | SpaceUserRoleNames;
+  orgName: string;
+  spaceName?: string;
 }
 
 export class CfRoleChangeWithNames extends CfRoleChange {

--- a/src/test-e2e/cloud-foundry/cf-level/cf-users-removal-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/cf-level/cf-users-removal-e2e.spec.ts
@@ -1,0 +1,22 @@
+import { CfTopLevelPage } from './cf-top-level-page.po';
+import { CfUserRemovalTestLevel, setupCfUserRemovalTests, CfRolesRemovalLevel } from '../users-removal-e2e.helper';
+
+describe('CF - Remove user roles (only spaces)', () => {
+  setupCfUserRemovalTests(CfUserRemovalTestLevel.Cf, CfRolesRemovalLevel.Spaces, (cfGuid) => {
+    const cfPage = CfTopLevelPage.forEndpoint(cfGuid);
+    cfPage.navigateTo();
+    cfPage.waitForPageOrChildPage();
+    cfPage.loadingIndicator.waitUntilNotShown();
+    return cfPage.goToUsersTab();
+  });
+});
+
+describe('CF - Remove user roles (only orgs / spaces already gone)', () => {
+  setupCfUserRemovalTests(CfUserRemovalTestLevel.Cf, CfRolesRemovalLevel.OrgsSpaces, (cfGuid) => {
+    const cfPage = CfTopLevelPage.forEndpoint(cfGuid);
+    cfPage.navigateTo();
+    cfPage.waitForPageOrChildPage();
+    cfPage.loadingIndicator.waitUntilNotShown();
+    return cfPage.goToUsersTab();
+  });
+});

--- a/src/test-e2e/cloud-foundry/org-level/org-users-removal-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/org-level/org-users-removal-e2e.spec.ts
@@ -1,0 +1,22 @@
+import { CfOrgLevelPage } from './cf-org-level-page.po';
+import { CfUserRemovalTestLevel, setupCfUserRemovalTests, CfRolesRemovalLevel } from '../users-removal-e2e.helper';
+
+describe('CF - Org Level - Remove user roles', () => {
+  setupCfUserRemovalTests(CfUserRemovalTestLevel.Org, CfRolesRemovalLevel.OrgsSpaces, (cfGuid, orgGuid) => {
+    const orgPage = CfOrgLevelPage.forEndpoint(cfGuid, orgGuid);
+    orgPage.navigateTo();
+    orgPage.waitForPageOrChildPage();
+    orgPage.loadingIndicator.waitUntilNotShown();
+    return orgPage.goToUsersTab();
+  });
+});
+
+describe('CF - Org Level - Remove user roles (only spaces)', () => {
+  setupCfUserRemovalTests(CfUserRemovalTestLevel.Org, CfRolesRemovalLevel.Spaces, (cfGuid, orgGuid) => {
+    const orgPage = CfOrgLevelPage.forEndpoint(cfGuid, orgGuid);
+    orgPage.navigateTo();
+    orgPage.waitForPageOrChildPage();
+    orgPage.loadingIndicator.waitUntilNotShown();
+    return orgPage.goToUsersTab();
+  });
+});

--- a/src/test-e2e/cloud-foundry/remove-users-page.po.ts
+++ b/src/test-e2e/cloud-foundry/remove-users-page.po.ts
@@ -1,0 +1,31 @@
+import { Page } from '../po/page.po';
+import { ElementFinder, element, by } from 'protractor';
+import { StepperComponent } from '../po/stepper.po';
+import { ManageUsersConfirmStep } from './manage-users-page.po';
+
+export class RemoveUsersPage extends Page {
+  private locator: ElementFinder;
+  stepper: StepperComponent;
+  confirmStep = new ManageUsersConfirmStep();
+
+  static determineUrl(cfGuid: string, orgGuid?: string, spaceGuid?: string, userGuid?: string): string {
+    let url = `/cloud-foundry/${cfGuid}`;
+    if (orgGuid) {
+      url += `/organizations/${orgGuid}`;
+    }
+    if (spaceGuid) {
+      url += `/spaces/${spaceGuid}`;
+    }
+    url += '/users/remove';
+    if (userGuid) {
+      url += `?user=${userGuid}`;
+    }
+    return url;
+  }
+
+  constructor(cfGuid: string, orgGuid?: string, spaceGuid?: string, userGuid?: string) {
+    super(RemoveUsersPage.determineUrl(cfGuid, orgGuid, spaceGuid, userGuid));
+    this.locator = element(by.css('app-remove-users'));
+    this.stepper = new StepperComponent();
+  }
+}

--- a/src/test-e2e/cloud-foundry/space-level/space-users-removal-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/space-level/space-users-removal-e2e.spec.ts
@@ -1,0 +1,12 @@
+import { CfSpaceLevelPage } from './cf-space-level-page.po';
+import { setupCfUserRemovalTests, CfUserRemovalTestLevel, CfRolesRemovalLevel } from '../users-removal-e2e.helper';
+
+describe('CF - Space Level - Remove user', () => {
+  setupCfUserRemovalTests(CfUserRemovalTestLevel.Space, CfRolesRemovalLevel.Spaces, (cfGuid, orgGuid, spaceGuid) => {
+    const spacePage = CfSpaceLevelPage.forEndpoint(cfGuid, orgGuid, spaceGuid);
+    spacePage.navigateTo();
+    spacePage.waitForPageOrChildPage();
+    spacePage.loadingIndicator.waitUntilNotShown();
+    return spacePage.goToUsersTab();
+  });
+});

--- a/src/test-e2e/cloud-foundry/users-removal-e2e.helper.ts
+++ b/src/test-e2e/cloud-foundry/users-removal-e2e.helper.ts
@@ -1,0 +1,258 @@
+import { browser, promise, by, element } from 'protractor';
+import { protractor } from 'protractor/built/ptor';
+
+import { e2e } from '../e2e';
+import { CFHelpers } from '../helpers/cf-helpers';
+import { E2EHelpers } from '../helpers/e2e-helpers';
+import { CFUsersListComponent, UserRoleChip } from '../po/cf-users-list.po';
+import { setUpTestOrgSpaceE2eTest } from './users-list-e2e.helper';
+import { RemoveUsersPage } from './remove-users-page.po';
+import { StepperComponent } from '../po/stepper.po';
+
+export enum CfUserRemovalTestLevel {
+  Cf = 1,
+  Org = 2,
+  Space = 3
+}
+
+export enum CfRolesRemovalLevel {
+  OrgsSpaces = 1,
+  Spaces = 2
+}
+
+const customOrgSpacesLabel = E2EHelpers.e2eItemPrefix + (process.env.CUSTOM_APP_LABEL || process.env.USER) + '-remove-users';
+
+export function setupCfUserRemovalTests(
+  cfLevel: CfUserRemovalTestLevel,
+  removalLevel: CfRolesRemovalLevel,
+  navToUserTableFn: (cfGuid: string, orgGuid: string, spaceGuid: string) => promise.Promise<any>
+) {
+  const orgName = E2EHelpers.createCustomName(customOrgSpacesLabel);
+  const spaceName = E2EHelpers.createCustomName(customOrgSpacesLabel);
+  const userName = e2e.secrets.getDefaultCFEndpoint().creds.removeUser.username;
+
+  let removeUsersPage: RemoveUsersPage;
+  let removeUsersStepper: StepperComponent;
+  let cfHelper: CFHelpers;
+  let cfGuid: string;
+  let orgGuid: string;
+  let spaceGuid: string;
+  let userGuid: string;
+
+  beforeAll(() => {
+    setUpTestOrgSpaceE2eTest(orgName, spaceName, userName, true).then(res => {
+      cfHelper = res.cfHelper;
+      cfGuid = res.cfGuid;
+      orgGuid = res.orgGuid;
+      spaceGuid = res.spaceGuid;
+
+      return cfHelper.fetchUser(cfGuid, userName).then(user => {
+        expect(user).toBeTruthy();
+        userGuid = user.metadata.guid;
+      });
+    });
+
+    removeUsersPage = new RemoveUsersPage(cfGuid, orgGuid, spaceGuid, userGuid);
+
+    return protractor.promise.controlFlow().execute(() => {
+      return navToUserTableFn(cfGuid, orgGuid, spaceGuid);
+    });
+  });
+
+  it ('Clicks on remove menu option', () => {
+    const usersTable = new CFUsersListComponent();
+    usersTable.header.setSearchText(userName);
+    expect(usersTable.getTotalResults()).toBe(1);
+
+    if (removalLevel === CfRolesRemovalLevel.OrgsSpaces) {
+      usersTable.table.openRowActionMenuByIndex(0).clickItem('Remove from org');
+    } else {
+      usersTable.table.openRowActionMenuByIndex(0).clickItem('Remove from space');
+    }
+
+    removeUsersStepper = removeUsersPage.stepper;
+
+    // ... check button state
+    expect(removeUsersStepper.canPrevious()).toBeFalsy();
+    expect(removeUsersStepper.canCancel()).toBeTruthy();
+    expect(removeUsersStepper.canNext()).toBeTruthy();
+  });
+
+  it('Confirm roles removal', () => {
+    // confirm step
+    const confirmStep = removeUsersPage.confirmStep;
+
+    const orgTarget = `Org: ${orgName}`;
+    const spaceTarget = `Space: ${spaceName}`;
+
+    // ... initial action table state
+    let actionTableDate: any[];
+
+    if (cfLevel === CfUserRemovalTestLevel.Cf) {
+      actionTableDate = [
+        ...createReservedActionTableDate('Org: test-e2e', 'Space: test-e2e'),
+        ...createReservedActionTableDate('Org: e2e', 'Space: e2e'),
+        ...createActionTableDate(orgTarget, spaceTarget)
+      ];
+    } else {
+      actionTableDate = createActionTableDate(orgTarget, spaceTarget);
+    }
+
+    expect(confirmStep.actionTable.table.getTableData()).toEqual(actionTableDate);
+    expect(removeUsersStepper.canPrevious()).toBeFalsy();
+    expect(removeUsersStepper.canCancel()).toBeTruthy();
+    expect(removeUsersStepper.canNext()).toBeTruthy();
+
+    // apply roles removal changes
+    removeUsersStepper.next();
+
+    // Wait until all of the spinners have gone
+    const spinners = element.all(by.tagName('mat-progress-spinner'));
+    browser.wait(() => spinners.isPresent().then((present) => !present));
+
+    // ... action table state after submit
+    if (cfLevel === CfUserRemovalTestLevel.Cf) {
+      actionTableDate = [
+        ...createReservedActionTableDate('Org: test-e2e', 'Space: test-e2e', 'done'),
+        ...createReservedActionTableDate('Org: e2e', 'Space: e2e', 'done'),
+        ...createActionTableDate(orgTarget, spaceTarget, 'done')
+      ];
+    } else {
+      actionTableDate = createActionTableDate(orgTarget, spaceTarget, 'done');
+    }
+
+    expect(confirmStep.actionTable.table.getTableData()).toEqual(actionTableDate);
+    expect(removeUsersStepper.canPrevious()).toBeFalsy();
+    expect(removeUsersStepper.canCancel()).toBeFalsy();
+    expect(removeUsersStepper.canNext()).toBeTruthy();
+
+    // close
+    removeUsersStepper.next();
+    removeUsersStepper.waitUntilNotShown();
+  });
+
+  if (cfLevel !== CfUserRemovalTestLevel.Space &&
+      removalLevel === CfRolesRemovalLevel.Spaces) {
+
+    it('Shows user with org roles only', () => {
+      // user was removed from space level
+      const usersTable = new CFUsersListComponent();
+      usersTable.header.setSearchText(userName);
+
+      expect(usersTable.getTotalResults()).toBe(1);
+      expect(usersTable.getPermissions(0, false).getChipElements().count()).toBe(0);
+    });
+  } else {
+    it('Doesnt show user with roles anymore', () => {
+      const usersTable = new CFUsersListComponent();
+      usersTable.header.setSearchText(userName);
+
+      expect(usersTable.getTotalResults()).toBe(0);
+    });
+  }
+
+  function createReservedActionTableDate(orgTarget, spaceTarget, stateIcon = '') {
+    const orgActions = [
+      {
+        user: userName,
+        action: 'remove_circle\nRemove',
+        role: 'Manager',
+        target: orgTarget,
+        'column-4': stateIcon
+      },
+      {
+        user: userName,
+        action: 'remove_circle\nRemove',
+        role: 'User',
+        target: orgTarget,
+        'column-4': stateIcon
+      }
+    ];
+
+    const spaceActions = [
+      {
+        user: userName,
+        action: 'remove_circle\nRemove',
+        role: 'Manager',
+        target: spaceTarget,
+        'column-4': stateIcon
+      },
+      {
+        user: userName,
+        action: 'remove_circle\nRemove',
+        role: 'Developer',
+        target: spaceTarget,
+        'column-4': stateIcon
+      },
+    ];
+
+    // spaces were already removed (see cf-level/cf-users-removal-e2e.spec.ts),
+    // so we ignore even knowing that they would be there in a normal case (see createActionTableDate below)
+    if (removalLevel === CfRolesRemovalLevel.OrgsSpaces) {
+      return orgActions;
+    }
+
+    return spaceActions;
+  }
+
+  function createActionTableDate(orgTarget, spaceTarget, stateIcon = '') {
+    const orgActions = [
+      {
+        user: userName,
+        action: 'remove_circle\nRemove',
+        role: 'Manager',
+        target: orgTarget,
+        'column-4': stateIcon
+      },
+      {
+        user: userName,
+        action: 'remove_circle\nRemove',
+        role: 'Auditor',
+        target: orgTarget,
+        'column-4': stateIcon
+      },
+      {
+        user: userName,
+        action: 'remove_circle\nRemove',
+        role: 'User',
+        target: orgTarget,
+        'column-4': stateIcon
+      }
+    ];
+
+    const spaceActions = [
+      {
+        user: userName,
+        action: 'remove_circle\nRemove',
+        role: 'Manager',
+        target: spaceTarget,
+        'column-4': stateIcon
+      },
+      {
+        user: userName,
+        action: 'remove_circle\nRemove',
+        role: 'Developer',
+        target: spaceTarget,
+        'column-4': stateIcon
+      },
+      {
+        user: userName,
+        action: 'remove_circle\nRemove',
+        role: 'Auditor',
+        target: spaceTarget,
+        'column-4': stateIcon
+      }
+    ];
+
+    if (removalLevel === CfRolesRemovalLevel.OrgsSpaces) {
+      return [
+        ...orgActions,
+        ...spaceActions
+      ];
+    }
+
+    return spaceActions;
+  }
+
+  afterAll(() => cfHelper.deleteOrgIfExisting(cfGuid, orgName));
+}

--- a/src/test-e2e/e2e.types.ts
+++ b/src/test-e2e/e2e.types.ts
@@ -6,6 +6,7 @@ export interface E2ECred {
 export interface E2ECreds {
   admin: E2ECred;
   nonAdmin: E2ECred;
+  removeUser: E2ECred;
 }
 
 export interface E2EEndpointConfig {

--- a/src/test-e2e/secrets.yaml.example
+++ b/src/test-e2e/secrets.yaml.example
@@ -25,6 +25,9 @@ endpoints:
       nonAdmin:
         username: <CF_USER_USERNAME>
         password: <CF_USER_PASSWORD>
+      removeUser:
+        username: e2e-remove-user
+        password: <CF_USER_PASSWORD>
 
 # Skip SSL validation when talking to the backend API for test setup
 skipSSLValidation: true


### PR DESCRIPTION
## Description
It adds a "remove from org[s] and spaces" or "remove from space" items
to user's action menu making it possible to remove multiple user roles at
once.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So far the only possibility to remove user from cf, organization or space were 
by deleting each role one by one. With this it's now possible to remove all the 
roles from orgs and spaces at once.

Fixes #3378

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
E2E tests were added with a minor caveat on CF level. Since the tests has side effects, we added a special user `e2e-remove-user` that will be used for the remove scenarios. For simplicity, in the CF level scenario, we first remove only spaces and then orgs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message

## Scresnshots

![Screenshot-20190418120500-869x479](https://user-images.githubusercontent.com/188554/56370918-7bd39100-61d2-11e9-85ee-8cabec7c7029.png)
![Screenshot-20190418120527-870x429](https://user-images.githubusercontent.com/188554/56370919-7bd39100-61d2-11e9-9a95-4cd93983024e.png)
![Screenshot-20190418120548-873x695](https://user-images.githubusercontent.com/188554/56370920-7c6c2780-61d2-11e9-9d98-c95668eae31a.png)
![Screenshot-20190418120641-878x970](https://user-images.githubusercontent.com/188554/56370921-7c6c2780-61d2-11e9-9854-25dc78db3561.png)
