### PR TITLE
quote cidr blocks for loadBalancerSourceRanges

### DIFF
--- a/deploy/kubernetes/console/templates/service.yaml
+++ b/deploy/kubernetes/console/templates/service.yaml
@@ -33,7 +33,7 @@ spec:
 {{- if .Values.console.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
   {{- range $cidr := .Values.console.service.loadBalancerSourceRanges }}
-    - {{ $cidr }}
+    - {{ $cidr | quote }}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
Quoting the cidr ranges makes `loadBalancerSourceRanges` more intuitive to use, without it users need to enclose cidrs in single and double quotes (`loadBalancerSourceRanges: [ '"1.2.3.4/32"' ]`). 

## Motivation and Context
fixes #3485

## How Has This Been Tested?
ran `helm install ./console -f values.yml --set env.UAA_HOST=uaa.mydomain --set env.DOMAIN=mydomain --version 2.3.0`

values file:

```
env:
  UAA_PORT: 2793
kube:
  external_console_https_port: 443
services:
  loadbalanced: true
console:
  service:
    loadBalancerSourceRanges: [ 1.2.3.4/32 ]
```

checked that console is functional (connects to CF backend) and that source range has been applied to cloud provider (AWS) load balancer.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message