### PR TITLE
Helm Chart: Fix issue with loadBalancerSourceRanges

### DIFF
--- a/deploy/kubernetes/console/templates/service.yaml
+++ b/deploy/kubernetes/console/templates/service.yaml
@@ -35,7 +35,7 @@ spec:
   {{- range $cidr := .Values.console.service.loadBalancerSourceRanges }}
     - {{ $cidr }}
   {{- end }}
-{{- end }}
+{{ end }}
 {{- end }}
 {{- if .Values.console.service -}}
 {{- if .Values.console.service.externalName }}

--- a/deploy/kubernetes/console/tests/service_test.yaml
+++ b/deploy/kubernetes/console/tests/service_test.yaml
@@ -282,3 +282,17 @@ tests:
             port: 8443
             protocol: TCP
             targetPort: 443
+  - it: should support loadBalancerSourceRanges
+    set:
+      console.service.loadBalancerSourceRanges:
+        - 1.2.3.4/16
+        - 5.6.7.8/24
+    asserts:
+      - contains:
+          path: spec.loadBalancerSourceRanges
+          content:
+            1.2.3.4/16
+      - contains:
+          path: spec.loadBalancerSourceRanges
+          content:
+            5.6.7.8/24


### PR DESCRIPTION
There is a bug when loadBalancerSourceRanges are specified - the comment below gets pulled onto the end of the last line of the loadBalancerSourceRanges which causes a validation error, e.g.:

- 1.2.3.4/16
- 5.6.7.8/24# Note: HTTP Port is optional - HTTPS port is always included

Its a simple fix to ensure the comment remains on a new line.