### PR TITLE
SSO E2E Tests: Fix login page detection - different with SCF than PCFDEV

### DIFF
--- a/src/test-e2e/login/sso-login.po.ts
+++ b/src/test-e2e/login/sso-login.po.ts
@@ -21,7 +21,9 @@ export class SSOLoginPage {
 
   isUAALoginPage(): promise.Promise<boolean> {
     const welcome = element(by.css('.island > h1'));
-    return welcome.getText().then(text => text === 'Welcome!');
+    return welcome.getText().then(text => {
+      return text.indexOf('Welcome') === 0;
+    });
   }
 
   getTitle() {

--- a/src/test-e2e/login/sso-login.po.ts
+++ b/src/test-e2e/login/sso-login.po.ts
@@ -21,9 +21,7 @@ export class SSOLoginPage {
 
   isUAALoginPage(): promise.Promise<boolean> {
     const welcome = element(by.css('.island > h1'));
-    return welcome.getText().then(text => {
-      return text.indexOf('Welcome') === 0;
-    });
+    return welcome.getText().then(text => text.indexOf('Welcome') === 0);
   }
 
   getTitle() {


### PR DESCRIPTION
The SSO E2E tests need updating - we were detecting the login page by looking for the text "Welcome!".

This text can change depending on the CF being used - for SCF, it is "Welcome to scf!".

Tests now just look for text starting with "Welcome"