### PR TITLE
Fix exception when generating unknown endpoint type details

### DIFF
--- a/src/frontend/packages/core/src/features/endpoints/endpoint-helpers.ts
+++ b/src/frontend/packages/core/src/features/endpoints/endpoint-helpers.ts
@@ -156,11 +156,20 @@ export function getEndpointTypes() {
 }
 
 export function getEndpointType(type: string, subType: string): EndpointTypeConfig {
-  return getEndpointTypeByKey(createEndpointKey(type, subType));
+  return getEndpointTypeByKey(createEndpointKey(type, subType)) || getDefaultEndpointTypeConfig(type, subType);
 }
 
 function getEndpointTypeByKey(key: string): EndpointTypeConfig {
   return endpointTypesMap[key];
+}
+
+function getDefaultEndpointTypeConfig(type: string, subType?: string): EndpointTypeConfig {
+  return {
+    label: 'Unknown',
+    type,
+    subType,
+    doesNotSupportConnect: true
+  };
 }
 
 export function getIconForEndpoint(type: string, subType: string): EndpointIcon {


### PR DESCRIPTION
Returns a default 'unknown' state that can be used to render the endpoint details safely.