### PR TITLE
When no space quota has been assigned fall back on more realistive quota

### DIFF
--- a/src/frontend/packages/core/src/features/cloud-foundry/edit-space/edit-space.component.spec.ts
+++ b/src/frontend/packages/core/src/features/cloud-foundry/edit-space/edit-space.component.spec.ts
@@ -6,6 +6,7 @@ import {
   generateTestCfEndpointServiceProvider,
 } from '../../../../test-framework/cloud-foundry-endpoint-service.helper';
 import { ActiveRouteCfOrgSpace } from '../cf-page.types';
+import { CloudFoundryOrganizationService } from '../services/cloud-foundry-organization.service';
 import { EditSpaceStepComponent } from './edit-space-step/edit-space-step.component';
 import { EditSpaceComponent } from './edit-space.component';
 
@@ -17,7 +18,7 @@ describe('EditSpaceComponent', () => {
     TestBed.configureTestingModule({
       declarations: [EditSpaceComponent, EditSpaceStepComponent],
       imports: [...BaseTestModules],
-      providers: [ActiveRouteCfOrgSpace, generateTestCfEndpointServiceProvider(), TabNavService]
+      providers: [ActiveRouteCfOrgSpace, generateTestCfEndpointServiceProvider(), TabNavService, CloudFoundryOrganizationService]
     })
       .compileComponents();
   }));

--- a/src/frontend/packages/core/src/features/cloud-foundry/services/cloud-foundry-organization.service.ts
+++ b/src/frontend/packages/core/src/features/cloud-foundry/services/cloud-foundry-organization.service.ts
@@ -32,17 +32,14 @@ import { ActiveRouteCfOrgSpace } from '../cf-page.types';
 import { getOrgRolesString } from '../cf.helpers';
 import { CloudFoundryEndpointService } from './cloud-foundry-endpoint.service';
 
-export const createQuotaDefinition = (orgGuid: string): APIResource<IQuotaDefinition> => ({
-  entity: {
-    memory_limit: -1,
-    app_instance_limit: -1,
-    instance_memory_limit: -1,
-    name: 'None assigned',
-    organization_guid: orgGuid,
-    total_services: -1,
-    total_routes: -1
-  },
-  metadata: null
+export const createQuotaDefinition = (orgGuid: string): IQuotaDefinition => ({
+  memory_limit: -1,
+  app_instance_limit: -1,
+  instance_memory_limit: -1,
+  name: 'None assigned',
+  organization_guid: orgGuid,
+  total_services: -1,
+  total_routes: -1
 });
 
 @Injectable()

--- a/src/frontend/packages/core/src/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-spaces/tabs/cloud-foundry-space-summary/cloud-foundry-space-summary.component.html
+++ b/src/frontend/packages/core/src/features/cloud-foundry/tabs/cloud-foundry-organizations/cloud-foundry-organization-spaces/tabs/cloud-foundry-space-summary/cloud-foundry-space-summary.component.html
@@ -36,14 +36,14 @@
         <app-tile *ngIf="cfEndpointService.appsPagObs.hasEntities$ | async">
           <app-card-number-metric icon="content_copy" label="App Instances"
             value="{{ (cfSpaceService.appInstances$ | async) }}"
-            limit="{{ (cfSpaceService.quotaDefinition$ | async)?.entity.app_instance_limit}}"></app-card-number-metric>
+            limit="{{ (cfSpaceService.quotaDefinition$ | async)?.app_instance_limit}}"></app-card-number-metric>
         </app-tile>
         <app-tile>
           <app-card-number-metric
             link="/cloud-foundry/{{cfSpaceService.cfGuid}}/organizations/{{cfSpaceService.orgGuid}}/spaces/{{cfSpaceService.spaceGuid}}/routes"
             iconFont="stratos-icons" icon="network_route" label="Routes"
             value="{{ (cfSpaceService.routes$ | async)?.length }}"
-            limit="{{ (cfSpaceService.quotaDefinition$ | async)?.entity.total_routes}}"></app-card-number-metric>
+            limit="{{ (cfSpaceService.quotaDefinition$ | async)?.total_routes}}"></app-card-number-metric>
         </app-tile>
       </app-tile-group>
 
@@ -59,7 +59,7 @@
             link="/cloud-foundry/{{cfSpaceService.cfGuid}}/organizations/{{cfSpaceService.orgGuid}}/spaces/{{cfSpaceService.spaceGuid}}/service-instances"
             iconFont="stratos-icons" icon="service" label="Service Instances"
             value="{{ (cfSpaceService.serviceInstancesCount$ | async)}}"
-            limit="{{ (cfSpaceService.quotaDefinition$ | async)?.entity.total_services }}"></app-card-number-metric>
+            limit="{{ (cfSpaceService.quotaDefinition$ | async)?.total_services }}"></app-card-number-metric>
         </app-tile>
         <app-tile *ngIf="(cfSpaceService.userProvidedServiceInstancesCount$ | async) > 0">
           <app-card-number-metric iconFont="stratos-icons" icon="service" label="User Service Instances"
@@ -68,7 +68,7 @@
         <app-tile *ngIf="cfEndpointService.appsPagObs.hasEntities$ | async">
           <app-card-number-metric icon="memory" label="Memory Usage" units="mb"
             value="{{ (cfSpaceService.totalMem$ | async) }}"
-            limit="{{ (cfSpaceService.quotaDefinition$ | async)?.entity.memory_limit }}"></app-card-number-metric>
+            limit="{{ (cfSpaceService.quotaDefinition$ | async)?.memory_limit }}"></app-card-number-metric>
         </app-tile>
       </app-tile-group>
 

--- a/src/frontend/packages/core/src/shared/components/cards/card-cf-space-details/card-cf-space-details.component.html
+++ b/src/frontend/packages/core/src/shared/components/cards/card-cf-space-details/card-cf-space-details.component.html
@@ -10,10 +10,11 @@
             {{ (cfSpaceService.userRole$ | async) }}
           </app-metadata-item>
           <app-metadata-item label="Quota Definition Name">
-            {{ (cfSpaceService.quotaDefinition$ | async)?.entity.name }}
+            {{ (cfSpaceService.quotaDefinition$ | async)?.name }}
           </app-metadata-item>
           <app-metadata-item label="Provision Paid Services">
-            <app-boolean-indicator [isTrue]="(cfSpaceService.quotaDefinition$ | async)?.non_basic_services_allowed" type="yes-no">
+            <app-boolean-indicator [isTrue]="(cfSpaceService.quotaDefinition$ | async)?.non_basic_services_allowed"
+              type="yes-no">
             </app-boolean-indicator>
           </app-metadata-item>
         </div>

--- a/src/frontend/packages/core/src/shared/components/cards/card-cf-space-details/card-cf-space-details.component.ts
+++ b/src/frontend/packages/core/src/shared/components/cards/card-cf-space-details/card-cf-space-details.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit } from '@angular/core';
-
-import { CloudFoundrySpaceService } from '../../../../features/cloud-foundry/services/cloud-foundry-space.service';
+import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+
+import { CloudFoundrySpaceService } from '../../../../features/cloud-foundry/services/cloud-foundry-space.service';
 
 @Component({
   selector: 'app-card-cf-space-details',

--- a/src/frontend/packages/core/src/shared/components/list/list-types/cf-orgs/cf-org-card/cf-org-card.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/cf-orgs/cf-org-card/cf-org-card.component.ts
@@ -25,7 +25,7 @@ import { createQuotaDefinition } from '../../../../../../features/cloud-foundry/
 import { CfUserService } from '../../../../../data-services/cf-user.service';
 import { EntityMonitorFactory } from '../../../../../monitors/entity-monitor.factory.service';
 import { PaginationMonitorFactory } from '../../../../../monitors/pagination-monitor.factory';
-import { StratosStatus, ComponentEntityMonitorConfig } from '../../../../../shared.types';
+import { ComponentEntityMonitorConfig, StratosStatus } from '../../../../../shared.types';
 import { ConfirmationDialogConfig } from '../../../../confirmation-dialog.config';
 import { ConfirmationDialogService } from '../../../../confirmation-dialog.service';
 import { MetaCardMenuItem } from '../../../list-cards/meta-card/meta-card-base/meta-card.component';
@@ -128,7 +128,7 @@ export class CfOrgCardComponent extends CardCell<APIResource<IOrganization>> imp
 
   setValues = (role: string, apps: APIResource<IApp>[]) => {
     this.userRolesInOrg = role;
-    const quotaDefinition = this.row.entity.quota_definition || createQuotaDefinition(this.orgGuid);
+    const quotaDefinition = this.row.entity.quota_definition || { entity: createQuotaDefinition(this.orgGuid), metadata: null };
 
     if (apps) {
       this.setAppsDependentCounts(apps);

--- a/src/frontend/packages/core/src/shared/components/list/list-types/cf-spaces/cf-space-card/cf-space-card.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/cf-spaces/cf-space-card/cf-space-card.component.ts
@@ -28,7 +28,7 @@ import { SpaceQuotaHelper } from '../../../../../../features/cloud-foundry/servi
 import { CfUserService } from '../../../../../data-services/cf-user.service';
 import { EntityMonitorFactory } from '../../../../../monitors/entity-monitor.factory.service';
 import { PaginationMonitorFactory } from '../../../../../monitors/pagination-monitor.factory';
-import { StratosStatus, ComponentEntityMonitorConfig } from '../../../../../shared.types';
+import { ComponentEntityMonitorConfig, StratosStatus } from '../../../../../shared.types';
 import { ConfirmationDialogConfig } from '../../../../confirmation-dialog.config';
 import { ConfirmationDialogService } from '../../../../confirmation-dialog.service';
 import { MetaCardMenuItem } from '../../../list-cards/meta-card/meta-card-base/meta-card.component';
@@ -140,14 +140,15 @@ export class CfSpaceCardComponent extends CardCell<APIResource<ISpace>> implemen
 
   setValues = (roles: string, apps: APIResource<IApp>[]) => {
     this.userRolesInSpace = roles;
-    const quotaDefinition = this.row.entity.space_quota_definition || createQuotaDefinition(this.orgGuid);
+    const quotaDefinition = this.row.entity.space_quota_definition ?
+      this.row.entity.space_quota_definition.entity : createQuotaDefinition(this.orgGuid);
     if (apps) {
       this.setAppsDependentCounts(apps);
       this.memoryTotal = this.cfEndpointService.getMetricFromApps(apps, 'memory');
-      this.normalisedMemoryUsage = this.memoryTotal / quotaDefinition.entity.memory_limit * 100;
+      this.normalisedMemoryUsage = this.memoryTotal / quotaDefinition.memory_limit * 100;
     }
-    this.appInstancesLimit = truthyIncludingZeroString(quotaDefinition.entity.app_instance_limit);
-    this.memoryLimit = truthyIncludingZeroString(quotaDefinition.entity.memory_limit);
+    this.appInstancesLimit = truthyIncludingZeroString(quotaDefinition.app_instance_limit);
+    this.memoryLimit = truthyIncludingZeroString(quotaDefinition.memory_limit);
   }
 
   ngOnDestroy = () => this.subscriptions.forEach(p => p.unsubscribe());


### PR DESCRIPTION
- before, if no space quota was found, a rough match for the default quota was used
- this missed the `paid service plan` property
- now, before falling back on the 'infinite' quota, try to use the more realistive org quota
- fixes #3532