### PR TITLE
Remove firefox specific fade text overflow

### DIFF
--- a/src/frontend/packages/core/src/shared/components/multiline-title/multiline-title.component.scss
+++ b/src/frontend/packages/core/src/shared/components/multiline-title/multiline-title.component.scss
@@ -19,6 +19,8 @@
 // Firefox does not support multi-line text ellipsis
 // So fade out the end of the last line in the div
 // Firefox only
+// Removed via https://github.com/cloudfoundry-incubator/stratos/issues/3544
+// This is no longer fit for purpose. 
 // @media screen and (min--moz-device-pixel-ratio:0) {
 //   .app-multiline-title {
 //     // Fade

--- a/src/frontend/packages/core/src/shared/components/multiline-title/multiline-title.component.scss
+++ b/src/frontend/packages/core/src/shared/components/multiline-title/multiline-title.component.scss
@@ -19,17 +19,17 @@
 // Firefox does not support multi-line text ellipsis
 // So fade out the end of the last line in the div
 // Firefox only
-@media screen and (min--moz-device-pixel-ratio:0) {
-  .app-multiline-title {
-    // Fade
-    &::after {
-      bottom: 0;
-      content: '';
-      height: 1.2em;
-      position: absolute;
-      right: 0;
-      text-align: right;
-      width: 24px;
-    }
-  }
-}
+// @media screen and (min--moz-device-pixel-ratio:0) {
+//   .app-multiline-title {
+//     // Fade
+//     &::after {
+//       bottom: 0;
+//       content: '';
+//       height: 1.2em;
+//       position: absolute;
+//       right: 0;
+//       text-align: right;
+//       width: 24px;
+//     }
+//   }
+// }


### PR DESCRIPTION
Removing this for now.

1) It is unnecessarily clipping text in firefox - we'd need to fix it for each specific case. See #3544.
2) The colour of the fade does not change (stays the themes background colour) and, because we now change the background colour of some cards (e.g. endpoint with error), the fade is sometimes not hidden from the user.

fixes #3544