### PR TITLE
Fix plugin metrics

### DIFF
--- a/src/jetstream/plugins/metrics/main.go
+++ b/src/jetstream/plugins/metrics/main.go
@@ -322,19 +322,17 @@ func (m *MetricsSpecification) UpdateMetadata(info *interfaces.Info, userGUID st
 	if metrics, ok := info.Endpoints[EndpointType]; ok {
 		for _, endpoint := range metrics {
 			// Parse out the metadata
-			var m []MetricsProviderMetadata
-			err := json.Unmarshal([]byte(endpoint.TokenMetadata), &m)
+			var meta MetricsProviderMetadata
+			err := json.Unmarshal([]byte(endpoint.TokenMetadata), &meta)
 			if err == nil {
-				for _, item := range m {
-					info := MetricsMetadata{}
-					info.EndpointGUID = endpoint.GUID
-					info.Type = item.Type
-					info.URL = item.URL
-					info.Job = item.Job
-					info.Environment = item.Environment
-					log.Debugf("Metrics provider: %+v", info)
-					metricsProviders = append(metricsProviders, info)
-				}
+				info := MetricsMetadata{}
+				info.EndpointGUID = endpoint.GUID
+				info.Type = meta.Type
+				info.URL = meta.URL
+				info.Job = meta.Job
+				info.Environment = meta.Environment
+				log.Debugf("Metrics provider: %+v", info)
+				metricsProviders = append(metricsProviders, info)
 			}
 		}
 	}
@@ -405,18 +403,16 @@ func (m *MetricsSpecification) getMetricsEndpoints(userGUID string, cnsiList []s
 			endpointsMap[endpoint.GUID] = endpoint
 		} else if endpoint.CNSIType == "metrics" {
 			// Parse out the metadata
-			var m []MetricsProviderMetadata
-			err := json.Unmarshal([]byte(endpoint.TokenMetadata), &m)
+			var meta MetricsProviderMetadata
+			err := json.Unmarshal([]byte(endpoint.TokenMetadata), &meta)
 			if err == nil {
-				for _, item := range m {
-					info := MetricsMetadata{}
-					info.EndpointGUID = endpoint.GUID
-					info.Type = item.Type
-					info.URL = item.URL
-					info.Job = item.Job
-					info.Environment = item.Environment
-					metricsProviders = append(metricsProviders, info)
-				}
+				info := MetricsMetadata{}
+				info.EndpointGUID = endpoint.GUID
+				info.Type = meta.Type
+				info.URL = meta.URL
+				info.Job = meta.Job
+				info.Environment = meta.Environment
+				metricsProviders = append(metricsProviders, info)
 			}
 		}
 	}


### PR DESCRIPTION
## Description
Plugin `metrics` store a CNSI Token with some metadata as we can see [here](https://github.com/cloudfoundry-incubator/stratos/blob/v2-master/src/jetstream/plugins/metrics/main.go#L265-L276)  those metadata are store as a k/v pairs.

But when those metadata need to be retrieve they are unmarshaled as a list of k/v pairs (see [here](https://github.com/cloudfoundry-incubator/stratos/blob/v2-master/src/jetstream/plugins/metrics/main.go#L320-L321) ) which make this plugin unusable.

## How Has This Been Tested?
This plugin doesn't include test, mainly just try to make works metrics as describe in the doc. 

I was building myself jestream part, maybe it's change from golang 1.11 which break unmarshaling a "not a list" interface. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message