### PR TITLE
Docker AIO: Custom-src folder is not copied when building

### DIFF
--- a/deploy/Dockerfile.all-in-one
+++ b/deploy/Dockerfile.all-in-one
@@ -1,12 +1,9 @@
 # Docker build for all-in-one Stratos
 FROM splatform/stratos-aio-base:opensuse as builder
 
-COPY --chown=stratos:users *.json ./
-COPY --chown=stratos:users gulpfile.js ./
-COPY --chown=stratos:users src ./src
-COPY --chown=stratos:users build ./build/
+# Ensure that we copy the custom-src folder
+COPY --chown=stratos:users . ./
 COPY --chown=stratos:users deploy/tools/generate_cert.sh generate_cert.sh
-COPY --chown=stratos:users deploy/db deploy/db
 COPY --chown=stratos:users deploy/all-in-one/config.all-in-one.properties config.properties
 
 RUN npm install \


### PR DESCRIPTION
The Docker AIO dockerfile does not copy the custom-src folder.