### PR TITLE
cf/spaces routes: fixed breadcrumbs path for apps

### DIFF
--- a/src/frontend/packages/core/src/shared/components/list/list-types/cf-routes/cf-routes-list-config-base.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/cf-routes/cf-routes-list-config-base.ts
@@ -47,6 +47,9 @@ export abstract class CfRoutesListConfigBase implements IListConfig<APIResource>
       columnId: CfRoutesListConfigBase.columnIdMappedApps,
       headerCell: () => 'Attached Applications',
       cellComponent: TableCellRouteAppsAttachedComponent,
+      cellConfig: {
+        breadcrumbs: 'cf',
+      },
       cellFlex: '4',
     },
     {

--- a/src/frontend/packages/core/src/shared/components/list/list-types/cf-space-routes/cf-space-routes-list-config.service.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/cf-space-routes/cf-space-routes-list-config.service.ts
@@ -51,5 +51,10 @@ export class CfSpaceRoutesListConfigService extends CfRoutesListConfigBase imple
     );
     this.getDataSource = () => this.dataSource;
     this.enableTextFilter = false;
+
+    const mappedAppsColumn = this.columns.find(column => column.columnId === CfRoutesListConfigBase.columnIdMappedApps);
+    mappedAppsColumn.cellConfig = {
+      breadcrumbs: 'space'
+    };
   }
 }


### PR DESCRIPTION
When user were navigating to apps through cf/spaces mapped routes, the
breadcrumbs was losing context from the previous path. Now it preserves
the previous path context.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

## How Has This Been Tested?

Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)