### PR TITLE
Fix Helm Chart Automated Test

### DIFF
--- a/deploy/ci/automation/helmtest.sh
+++ b/deploy/ci/automation/helmtest.sh
@@ -46,10 +46,12 @@ function waitForHelmRelease {
     COUNT=$(kubectl get po --namespace=${NAMESPACE} | wc -l)
     kubectl get po --namespace=${NAMESPACE}
     if [ $COUNT -ge 3 ]; then
+      # COUNT includes the column header line
       READY=$(kubectl get po --namespace=${NAMESPACE} | grep "Running" | wc -l)
       COMPLETED=$(kubectl get po --namespace=${NAMESPACE} | grep "Completed" | wc -l)
       TOTAL=$(($READY + $COMPLETED))
-      if [ $TOTAL -eq $COUNT ]; then
+      EXPECTED=$(($COUNT - 1))
+      if [ $TOTAL -eq $EXPECTED ]; then
         READY1=$(kubectl get po --namespace=${NAMESPACE} | grep "3/3" | wc -l)
         READY2=$(kubectl get po --namespace=${NAMESPACE} | grep "1/1" | wc -l)
         READY=$(($READY1 + $READY2))

--- a/deploy/ci/automation/helmtest.sh
+++ b/deploy/ci/automation/helmtest.sh
@@ -48,7 +48,7 @@ function waitForHelmRelease {
     if [ $COUNT -ge 3 ]; then
       READY=$(kubectl get po --namespace=${NAMESPACE} | grep "Running" | wc -l)
       COMPLETED=$(kubectl get po --namespace=${NAMESPACE} | grep "Completed" | wc -l)
-      TOTAL=$(($READY1+ $COMPLETED))
+      TOTAL=$(($READY + $COMPLETED))
       if [ $TOTAL -eq $COUNT ]; then
         READY1=$(kubectl get po --namespace=${NAMESPACE} | grep "3/3" | wc -l)
         READY2=$(kubectl get po --namespace=${NAMESPACE} | grep "1/1" | wc -l)


### PR DESCRIPTION
A migration job was added in 2.4.0.

The Automated Helm test needs updating so it correctly detects readiness when using this Chart with the extra Job pod.