### PR TITLE
Concourse Release Pipeline: Fix incorrect Helm Chart URL

### DIFF
--- a/deploy/ci/tasks/dev-releases/make-release.yml
+++ b/deploy/ci/tasks/dev-releases/make-release.yml
@@ -123,7 +123,7 @@ run:
       fi
 
       # Update Helm Repository
-      helm repo index ./ ${MERGE_INDEX} --url https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download/${RELEASE_VERSION}/
+      helm repo index ./ ${MERGE_INDEX} --url https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download/${VERSION}/
       cp index.yaml ${HELM_REPO}
       cd ${HELM_REPO}
       set +x


### PR DESCRIPTION
Fixes an issue where the URL for the Helm Chart is incorrect when we promote the RC to a final release.