### PR TITLE
Don't show cell metrics when they're not available

### DIFF
--- a/src/frontend/packages/core/src/core/endpoints.service.spec.ts
+++ b/src/frontend/packages/core/src/core/endpoints.service.spec.ts
@@ -1,14 +1,19 @@
-import { CoreModule } from './core.module';
-import { TestBed, inject } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
+import { createBasicStoreModule } from '../../test-framework/store-test-helper';
+import { PaginationMonitorFactory } from '../shared/monitors/pagination-monitor.factory';
+import { CoreModule } from './core.module';
 import { EndpointsService } from './endpoints.service';
 import { UtilsService } from './utils.service';
-import { createBasicStoreModule } from '../../test-framework/store-test-helper';
 
 describe('EndpointsService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [EndpointsService, UtilsService],
+      providers: [
+        EndpointsService,
+        UtilsService,
+        PaginationMonitorFactory
+      ],
       imports: [
         CoreModule,
         createBasicStoreModule(),

--- a/src/frontend/packages/core/src/core/endpoints.service.ts
+++ b/src/frontend/packages/core/src/core/endpoints.service.ts
@@ -1,20 +1,26 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { combineLatest as observableCombineLatest, Observable } from 'rxjs';
-import { filter, first, map, skipWhile, withLatestFrom } from 'rxjs/operators';
+import { combineLatest as observableCombineLatest, Observable, of } from 'rxjs';
+import { filter, first, map, skipWhile, switchMap, withLatestFrom } from 'rxjs/operators';
 
+import { FetchCFCellMetricsPaginatedAction, MetricQueryConfig } from '../../../store/src/actions/metrics.actions';
 import { RouterNav } from '../../../store/src/actions/router.actions';
 import { AppState, IRequestEntityTypeState } from '../../../store/src/app-state';
+import { entityFactory } from '../../../store/src/helpers/entity-factory';
 import { AuthState } from '../../../store/src/reducers/auth.reducer';
+import { getPaginationObservables } from '../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import {
   endpointEntitiesSelector,
   endpointsEntityRequestDataSelector,
   endpointStatusSelector,
 } from '../../../store/src/selectors/endpoint.selectors';
+import { IMetrics } from '../../../store/src/types/base-metric.types';
 import { EndpointModel, EndpointState } from '../../../store/src/types/endpoint.types';
 import { EndpointHealthCheck, endpointHealthChecks } from '../../endpoints-health-checks';
 import { getEndpointType } from '../features/endpoints/endpoint-helpers';
+import { PaginationMonitorFactory } from '../shared/monitors/pagination-monitor.factory';
+import { MetricQueryType } from '../shared/services/metrics-range-selector.types';
 import { UserService } from './user.service';
 
 
@@ -40,7 +46,8 @@ export class EndpointsService implements CanActivate {
 
   constructor(
     private store: Store<AppState>,
-    private userService: UserService
+    private userService: UserService,
+    private paginationMonitorFactory: PaginationMonitorFactory
   ) {
     this.endpoints$ = store.select(endpointEntitiesSelector);
     this.haveRegistered$ = this.endpoints$.pipe(map(endpoints => !!Object.keys(endpoints).length));
@@ -114,11 +121,41 @@ export class EndpointsService implements CanActivate {
       }));
   }
 
-  hasMetrics(endpointId: string) {
+  hasMetrics(endpointId: string): Observable<boolean> {
     return this.store.select(endpointsEntityRequestDataSelector(endpointId)).pipe(
       filter(endpoint => !!endpoint),
       map(endpoint => endpoint.metricsAvailable),
       first()
+    );
+  }
+
+  hasCellMetrics(endpointId: string): Observable<boolean> {
+    return this.hasMetrics(endpointId).pipe(
+      switchMap(hasMetrics => {
+        if (!hasMetrics) {
+          return of(false);
+        }
+
+        // Check that we successfully retrieve some stats. If the metric is unknown an empty list is returned
+        const action = new FetchCFCellMetricsPaginatedAction(
+          endpointId,
+          endpointId,
+          new MetricQueryConfig('firehose_value_metric_rep_unhealthy_cell', {}),
+          MetricQueryType.QUERY
+        );
+        return getPaginationObservables<IMetrics>({
+          store: this.store,
+          action,
+          paginationMonitor: this.paginationMonitorFactory.create(
+            action.paginationKey,
+            entityFactory(action.entityKey)
+          )
+        }).entities$.pipe(
+          filter(entities => !!entities && !!entities.length),
+          map(entities => !!entities.find(entity => !!entity.data.result.length)),
+          first()
+        );
+      })
     );
   }
 

--- a/src/frontend/packages/core/src/core/entity-favorite-star/entity-favorite-star.component.spec.ts
+++ b/src/frontend/packages/core/src/core/entity-favorite-star/entity-favorite-star.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BaseTestModulesNoShared } from '../../../test-framework/cloud-foundry-endpoint-service.helper';
 import { ConfirmationDialogService } from '../../shared/components/confirmation-dialog.service';
+import { PaginationMonitorFactory } from '../../shared/monitors/pagination-monitor.factory';
 import { EntityFavoriteStarComponent } from './entity-favorite-star.component';
 
 describe('EntityFavoriteStarComponent', () => {
@@ -11,7 +12,8 @@ describe('EntityFavoriteStarComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       providers: [
-        ConfirmationDialogService
+        ConfirmationDialogService,
+        PaginationMonitorFactory
       ],
       declarations: [
       ],

--- a/src/frontend/packages/core/src/features/cloud-foundry/tabs/cloud-foundry-cells/cloud-foundry-cells.component.html
+++ b/src/frontend/packages/core/src/features/cloud-foundry/tabs/cloud-foundry-cells/cloud-foundry-cells.component.html
@@ -1,1 +1,4 @@
-<app-list></app-list>
+<app-list *ngIf="hasCellMetrics$ | async; else noCells"></app-list>
+<ng-template #noCells>
+  Cell information for this Cloud Foundry cannot be found.
+</ng-template>

--- a/src/frontend/packages/core/src/features/cloud-foundry/tabs/cloud-foundry-cells/cloud-foundry-cells.component.spec.ts
+++ b/src/frontend/packages/core/src/features/cloud-foundry/tabs/cloud-foundry-cells/cloud-foundry-cells.component.spec.ts
@@ -1,11 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { BaseTestModules } from '../../../../../test-framework/cloud-foundry-endpoint-service.helper';
+import { createBasicStoreModule } from '../../../../../test-framework/store-test-helper';
 import {
   CfCellsListConfigService,
 } from '../../../../shared/components/list/list-types/cf-cells/cf-cells-list-config.service';
-import { BaseTestModules } from '../../../../../test-framework/cloud-foundry-endpoint-service.helper';
-import { createBasicStoreModule } from '../../../../../test-framework/store-test-helper';
-import { ActiveRouteCfCell } from '../../cf-page.types';
+import { ActiveRouteCfCell, ActiveRouteCfOrgSpace } from '../../cf-page.types';
+import { CloudFoundryEndpointService } from '../../services/cloud-foundry-endpoint.service';
 import { CloudFoundryCellsComponent } from './cloud-foundry-cells.component';
 
 describe('CloudFoundryCellsComponent', () => {
@@ -27,7 +28,9 @@ describe('CloudFoundryCellsComponent', () => {
             cfGuid: 'cfGuid',
             cellId: 'cellId'
           }),
-        }
+        },
+        CloudFoundryEndpointService,
+        ActiveRouteCfOrgSpace
       ],
     })
       .compileComponents();

--- a/src/frontend/packages/core/src/features/cloud-foundry/tabs/cloud-foundry-cells/cloud-foundry-cells.component.ts
+++ b/src/frontend/packages/core/src/features/cloud-foundry/tabs/cloud-foundry-cells/cloud-foundry-cells.component.ts
@@ -1,10 +1,13 @@
 import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
 
+import { EndpointsService } from '../../../../core/endpoints.service';
 import {
   CfCellsListConfigService,
 } from '../../../../shared/components/list/list-types/cf-cells/cf-cells-list-config.service';
 import { ListConfig } from '../../../../shared/components/list/list.component.types';
 import { getActiveRouteCfCellProvider } from '../../cf.helpers';
+import { CloudFoundryEndpointService } from '../../services/cloud-foundry-endpoint.service';
 
 @Component({
   selector: 'app-cloud-foundry-cells',
@@ -18,4 +21,10 @@ import { getActiveRouteCfCellProvider } from '../../cf.helpers';
     getActiveRouteCfCellProvider,
   ]
 })
-export class CloudFoundryCellsComponent { }
+export class CloudFoundryCellsComponent {
+  hasCellMetrics$: Observable<boolean>;
+
+  constructor(endpointService: EndpointsService, cfEndpointService: CloudFoundryEndpointService) {
+    this.hasCellMetrics$ = endpointService.hasCellMetrics(cfEndpointService.cfGuid);
+  }
+}

--- a/src/frontend/packages/core/src/shared/components/list/list-types/app-instance/cf-app-instances-config.service.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/app-instance/cf-app-instances-config.service.ts
@@ -4,6 +4,12 @@ import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { combineLatest, filter, map, switchMap } from 'rxjs/operators';
 
+import { DeleteApplicationInstance } from '../../../../../../../store/src/actions/application.actions';
+import { FetchApplicationMetricsAction, MetricQueryConfig } from '../../../../../../../store/src/actions/metrics.actions';
+import { AppState } from '../../../../../../../store/src/app-state';
+import { entityFactory, metricSchemaKey } from '../../../../../../../store/src/helpers/entity-factory';
+import { IMetricMatrixResult, IMetrics } from '../../../../../../../store/src/types/base-metric.types';
+import { IMetricApplication } from '../../../../../../../store/src/types/metric.types';
 import { EndpointsService } from '../../../../../core/endpoints.service';
 import { EntityServiceFactory } from '../../../../../core/entity-service-factory.service';
 import { UtilsService } from '../../../../../core/utils.service';
@@ -18,12 +24,6 @@ import { ListAppInstance } from './app-instance-types';
 import { CfAppInstancesDataSource } from './cf-app-instances-data-source';
 import { TableCellCfCellComponent } from './table-cell-cf-cell/table-cell-cf-cell.component';
 import { TableCellUsageComponent } from './table-cell-usage/table-cell-usage.component';
-import { IMetricMatrixResult, IMetrics } from '../../../../../../../store/src/types/base-metric.types';
-import { IMetricApplication } from '../../../../../../../store/src/types/metric.types';
-import { DeleteApplicationInstance } from '../../../../../../../store/src/actions/application.actions';
-import { AppState } from '../../../../../../../store/src/app-state';
-import { FetchApplicationMetricsAction, MetricQueryConfig } from '../../../../../../../store/src/actions/metrics.actions';
-import { metricSchemaKey, entityFactory } from '../../../../../../../store/src/helpers/entity-factory';
 
 export function createAppInstancesMetricAction(appGuid: string, cfGuid: string): FetchApplicationMetricsAction {
   return new FetchApplicationMetricsAction(
@@ -193,7 +193,7 @@ export class CfAppInstancesConfigService implements IListConfig<ListAppInstance>
     entityServiceFactory: EntityServiceFactory
   ) {
 
-    this.initialised$ = this.endpointsService.hasMetrics(appService.cfGuid).pipe(
+    this.initialised$ = this.endpointsService.hasCellMetrics(appService.cfGuid).pipe(
       map(hasMetrics => {
         if (hasMetrics) {
           this.columns.splice(1, 0, this.cfCellColumn);


### PR DESCRIPTION
- Handle case where metrics is available for the cf however the `firehose_value_metric_rep_unhealthy_cell` metric is not
- So..
  - don't show the cell column in the app instances table
  - show an appropriate message in the cf cells page (as requested we don't hide the tab)