### PR TITLE
Differentiate Disconnected Endpoint Cards

### DIFF
--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/endpoint-card/endpoint-card.component.html
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/endpoint-card/endpoint-card.component.html
@@ -1,7 +1,8 @@
 <app-page-header-events class="endpoint-warning" [endpointIds$]="endpointIds$" [simpleErrorMessage]="true">
 </app-page-header-events>
 <app-meta-card class="endpoint-card" [routerLink]="endpointLink" [appDisableRouterLink]="!endpointLink"
-  [ngClass]="{'no-link': !endpointLink }" [favorite]="favorite" [actionMenu]="cardMenu" [status$]="cardStatus$"
+  [ngClass]="{'endpoint-card--no-link': !endpointLink, 'endpoint-card--disconnected': row.connectionStatus === 'disconnected', 'endpoint-card--checking': row.connectionStatus === 'checking'}" 
+  [favorite]="favorite" [actionMenu]="cardMenu" [status$]="cardStatus$"
   [statusIcon]="false" [statusBackground]="true">
   <app-meta-card-title>
     <div class="endpoint-card__title">

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/endpoint-card/endpoint-card.component.scss
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/endpoint-card/endpoint-card.component.scss
@@ -6,8 +6,11 @@
 
 .endpoint-card {
   cursor: pointer;
+  display: block;
+  height: 100%;
   &--disconnected {
     opacity: .6;
+    transition: opacity .25s;
     &:hover {
       opacity: 1;
     }

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/endpoint-card/endpoint-card.component.scss
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/endpoint-card/endpoint-card.component.scss
@@ -6,7 +6,16 @@
 
 .endpoint-card {
   cursor: pointer;
-  &.no-link {
+  &--disconnected {
+    opacity: .6;
+    &:hover {
+      opacity: 1;
+    }
+  }
+  &--checking {
+    opacity: .6;
+  }
+  &--no-link {
     cursor: default;
   }
   &:focus {


### PR DESCRIPTION
Add NgClass directive to reduce endpoint card opacity when disconnected and checking status. Card opacity restored on hover. (#3554). Update endpoint card no-link SCSS class definition
to BEM syntax.

Signed-off-by: Kate E. Reinecke <50168367+kreinecke@users.noreply.github.com>

fixes #3554