### PR TITLE
Fix stepper height on Chrome pre v72 & Bleeding of error style in stateful-icon

### DIFF
--- a/src/frontend/packages/core/src/core/stateful-icon/stateful-icon.component.theme.scss
+++ b/src/frontend/packages/core/src/core/stateful-icon/stateful-icon.component.theme.scss
@@ -5,13 +5,16 @@
   $status-warning: map-get($status-colors, warning);
   $status-danger: map-get($status-colors, danger);
   $status-tentative: map-get($status-colors, tentative);
-  .warning {
-    color: $status-warning;
-  }
-  .error {
-    color: $status-danger;
-  }
-  .ok {
-    color: $status-success;
+
+  .stateful-icon {
+    .warning {
+      color: $status-warning;
+    }
+    .error {
+      color: $status-danger;
+    }
+    .ok {
+      color: $status-success;
+    }
   }
 }

--- a/src/frontend/packages/core/src/features/dashboard/dashboard-base/dashboard-base.component.scss
+++ b/src/frontend/packages/core/src/features/dashboard/dashboard-base/dashboard-base.component.scss
@@ -30,7 +30,7 @@ $app-sub-header-height: 48px;
     height: calc(100% - 56px);
   }
   &__content {
-    flex: auto;
+    flex: 1;
     max-height: 100%;
     overflow: auto;
     padding: 20px;


### PR DESCRIPTION
Fix stepper height on Chrome pre v72
- pre v72 the steppers don't consume the full page
- not an issue v72 or later
- change came in after merge of downstream
- fixes #3594

Fix bleed of stateful-icon colours
- the stateful-icon theme styles were beeding into others
- seen in the endpoints card when there were connectivity and red text was shown
