### PR TITLE
Fix missing org/space in cell app instances list

### DIFF
--- a/src/frontend/packages/core/src/shared/components/list/list-types/cf-cell-apps/cf-cell-apps-list-config.service.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/cf-cell-apps/cf-cell-apps-list-config.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 
+import { ListView } from '../../../../../../../store/src/actions/list.actions';
+import { AppState } from '../../../../../../../store/src/app-state';
+import { APIResource } from '../../../../../../../store/src/types/api.types';
 import { IApp, ISpace } from '../../../../../core/cf-api.types';
 import { EntityServiceFactory } from '../../../../../core/entity-service-factory.service';
 import { ActiveRouteCfCell } from '../../../../../features/cloud-foundry/cf-page.types';
@@ -8,9 +11,6 @@ import { ITableColumn } from '../../list-table/table.types';
 import { ListViewTypes } from '../../list.component.types';
 import { BaseCfListConfig } from '../base-cf/base-cf-list-config';
 import { CfCellApp, CfCellAppsDataSource } from './cf-cell-apps-source';
-import { ListView } from '../../../../../../../store/src/actions/list.actions';
-import { AppState } from '../../../../../../../store/src/app-state';
-import { APIResource } from '../../../../../../../store/src/types/api.types';
 
 @Injectable()
 export class CfCellAppsListConfigService extends BaseCfListConfig<CfCellApp> {
@@ -57,7 +57,10 @@ export class CfCellAppsListConfigService extends BaseCfListConfig<CfCellApp> {
       cellFlex: '1',
       cellDefinition: {
         getAsyncLink: (value: APIResource<IApp>) => {
-          const spaceEntity = value.entity.space as APIResource<ISpace>;
+          const spaceEntity = value ? value.entity.space as APIResource<ISpace> : null;
+          if (!spaceEntity) {
+            return;
+          }
           const cf = `/cloud-foundry/${value.entity.cfGuid}/`;
           const org = `organizations/${spaceEntity.entity.organization.metadata.guid}`;
           const space = `/spaces/${spaceEntity.metadata.guid}/summary`;
@@ -74,8 +77,8 @@ export class CfCellAppsListConfigService extends BaseCfListConfig<CfCellApp> {
       cellFlex: '1',
       cellDefinition: {
         getAsyncLink: (value: APIResource<IApp>) => {
-          const space = value.entity.space as APIResource<ISpace>;
-          return `/cloud-foundry/${value.entity.cfGuid}/organizations/${space.entity.organization.metadata.guid}/summary`;
+          const space = value ? value.entity.space as APIResource<ISpace> : null;
+          return space ? `/cloud-foundry/${value.entity.cfGuid}/organizations/${space.entity.organization.metadata.guid}/summary` : null;
         },
         asyncValue: {
           pathToObs: 'appEntityService',


### PR DESCRIPTION
- fixes #3536
- we still should merge #3546, until then add a falsey check to guard against incomplete entities
- rough explanation..
  - we're trying to access the space entity of an application
  - we have the application already however it's missing the space
  - we're validating the app entity, discover the missing space and associate it with the app
  - however entity service has emitted a version of the app already sans space
  - this causes an exception and incomplete information on screen