### PR TITLE
Add new relations table, use for connecting metrics to cf

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/cloud-foundry.module.ts
+++ b/src/frontend/packages/cloud-foundry/src/cloud-foundry.module.ts
@@ -18,7 +18,16 @@ export const cloudFoundryEndpointTypes: EndpointTypeExtensionConfig[] = [{
   homeLink: (guid) => ['/cloud-foundry', guid],
   listDetailsComponent: CfEndpointDetailsComponent,
   order: 0,
-  authTypes: [EndpointAuthTypeNames.CREDS, EndpointAuthTypeNames.SSO]
+  authTypes: [EndpointAuthTypeNames.CREDS, EndpointAuthTypeNames.SSO],
+  // getActions: <EndpointModel>() => {
+  //   return [
+  //     {
+  //       action: new Routera,
+  //       icon: '',
+  //       label: ''
+  //     }
+  //   ];
+  // }
 }];
 
 @StratosExtension({

--- a/src/frontend/packages/core/src/core/current-user-permissions.service.spec.ts
+++ b/src/frontend/packages/core/src/core/current-user-permissions.service.spec.ts
@@ -1,16 +1,18 @@
 import { TestBed } from '@angular/core/testing';
 import { StoreModule } from '@ngrx/store';
-import { CurrentUserPermissionsService } from './current-user-permissions.service';
+import { first, tap } from 'rxjs/operators';
+
+import { appReducers } from '../../../store/src/reducers.module';
+import { CFFeatureFlagTypes } from '../shared/components/cf-auth/cf-auth.types';
 import {
   CurrentUserPermissions,
   PermissionConfig,
-  PermissionTypes,
   PermissionStrings,
-  ScopeStrings
+  PermissionTypes,
+  ScopeStrings,
 } from './current-user-permissions.config';
-import { tap, first } from 'rxjs/operators';
-import { appReducers } from '../../../store/src/reducers.module';
-import { CFFeatureFlagTypes } from '../shared/components/cf-auth/cf-auth.types';
+import { CurrentUserPermissionsService } from './current-user-permissions.service';
+
 const initialState = {
   pagination: {
     application: {},
@@ -190,7 +192,6 @@ const initialState = {
             'uaa.user'
           ]
         },
-        metricsAvailable: false,
         connectionStatus: 'connected',
         registered: true
       },
@@ -230,7 +231,6 @@ const initialState = {
             'scim.write'
           ]
         },
-        metricsAvailable: false,
         connectionStatus: 'connected',
         registered: true
       }

--- a/src/frontend/packages/core/src/core/endpoints.service.ts
+++ b/src/frontend/packages/core/src/core/endpoints.service.ts
@@ -2,19 +2,15 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { combineLatest as observableCombineLatest, Observable } from 'rxjs';
-import { filter, first, map, skipWhile, withLatestFrom } from 'rxjs/operators';
+import { first, map, skipWhile, withLatestFrom } from 'rxjs/operators';
 
 import { RouterNav } from '../../../store/src/actions/router.actions';
 import { AppState, IRequestEntityTypeState } from '../../../store/src/app-state';
 import { AuthState } from '../../../store/src/reducers/auth.reducer';
-import {
-  endpointEntitiesSelector,
-  endpointsEntityRequestDataSelector,
-  endpointStatusSelector,
-} from '../../../store/src/selectors/endpoint.selectors';
+import { endpointEntitiesSelector, endpointStatusSelector } from '../../../store/src/selectors/endpoint.selectors';
 import { EndpointModel, EndpointState } from '../../../store/src/types/endpoint.types';
 import { EndpointHealthCheck, endpointHealthChecks } from '../../endpoints-health-checks';
-import { getEndpointType } from '../features/endpoints/endpoint-helpers';
+import { getEndpointHasCfMetrics, getEndpointType } from '../features/endpoints/endpoint-helpers';
 import { UserService } from './user.service';
 
 
@@ -115,11 +111,7 @@ export class EndpointsService implements CanActivate {
   }
 
   hasMetrics(endpointId: string) {
-    return this.store.select(endpointsEntityRequestDataSelector(endpointId)).pipe(
-      filter(endpoint => !!endpoint),
-      map(endpoint => endpoint.metricsAvailable),
-      first()
-    );
+    return getEndpointHasCfMetrics(endpointId, this.store);
   }
 
   doesNotHaveConnectedEndpointType(type: string): Observable<boolean> {

--- a/src/frontend/packages/core/src/core/extension/extension-types.ts
+++ b/src/frontend/packages/core/src/core/extension/extension-types.ts
@@ -2,6 +2,8 @@ import { Type } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { Schema, schema } from 'normalizr';
 
+import { IListAction } from '../../shared/components/list/list.component.types';
+
 // Allowable endpoint types
 export type EndpointType = 'cf' | 'metrics' | string;
 
@@ -36,6 +38,10 @@ interface BaseEndpointTypeConfig {
    */
   doesNotSupportConnect?: boolean;
 
+  /**
+   * // TODO: RC
+   */
+  getActions?: <T>() => IListAction<T>[];
 }
 
 /**

--- a/src/frontend/packages/core/src/features/endpoints/endpoint-helpers.ts
+++ b/src/frontend/packages/core/src/features/endpoints/endpoint-helpers.ts
@@ -2,12 +2,11 @@ import { Type } from '@angular/core';
 import { Validators } from '@angular/forms';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
-import { first, map } from 'rxjs/operators';
+import { filter, first, map } from 'rxjs/operators';
 
 import { AppState } from '../../../../store/src/app-state';
-import { endpointSchemaKey } from '../../../../store/src/helpers/entity-factory';
 import { endpointHasCfMetrics } from '../../../../store/src/reducers/system-endpoints.reducer';
-import { selectEntities } from '../../../../store/src/selectors/api.selectors';
+import { endpointsEntityRequestDataSelector } from '../../../../store/src/selectors/endpoint.selectors';
 import { EndpointModel } from '../../../../store/src/types/endpoint.types';
 import { ExtensionService } from '../../core/extension/extension-service';
 import {
@@ -188,9 +187,9 @@ export function getIconForEndpoint(type: string, subType: string): EndpointIcon 
 }
 
 export function getEndpointHasCfMetrics(endpointGuid: string, store: Store<AppState>): Observable<boolean> {
-  return store.select(selectEntities<EndpointModel>(endpointSchemaKey)).pipe(
+  return store.select(endpointsEntityRequestDataSelector(endpointGuid)).pipe(
+    filter(endpoint => !!endpoint),
     first(),
-    map(state => state[endpointGuid]),
     map(endpointHasCfMetrics)
   );
 }

--- a/src/frontend/packages/core/src/features/endpoints/endpoint-helpers.ts
+++ b/src/frontend/packages/core/src/features/endpoints/endpoint-helpers.ts
@@ -6,6 +6,7 @@ import { first, map } from 'rxjs/operators';
 
 import { AppState } from '../../../../store/src/app-state';
 import { endpointSchemaKey } from '../../../../store/src/helpers/entity-factory';
+import { endpointHasCfMetrics } from '../../../../store/src/reducers/system-endpoints.reducer';
 import { selectEntities } from '../../../../store/src/selectors/api.selectors';
 import { EndpointModel } from '../../../../store/src/types/endpoint.types';
 import { ExtensionService } from '../../core/extension/extension-service';
@@ -186,10 +187,11 @@ export function getIconForEndpoint(type: string, subType: string): EndpointIcon 
   return icon;
 }
 
-export function endpointHasMetrics(endpointGuid: string, store: Store<AppState>): Observable<boolean> {
+export function getEndpointHasCfMetrics(endpointGuid: string, store: Store<AppState>): Observable<boolean> {
   return store.select(selectEntities<EndpointModel>(endpointSchemaKey)).pipe(
     first(),
-    map(state => !!state[endpointGuid].metadata && !!state[endpointGuid].metadata.metrics)
+    map(state => state[endpointGuid]),
+    map(endpointHasCfMetrics)
   );
 }
 

--- a/src/frontend/packages/core/src/features/metrics/metrics/metrics.component.html
+++ b/src/frontend/packages/core/src/features/metrics/metrics/metrics.component.html
@@ -1,4 +1,5 @@
-<app-page-header [breadcrumbs]="breadcrumbs$ | async">{{ (metricsEndpoint$ | async)?.entity.provider.name }}</app-page-header>
+<app-page-header [breadcrumbs]="breadcrumbs$ | async">{{ (metricsEndpoint$ | async)?.entity.provider.name }}
+</app-page-header>
 
 <div *ngIf="(metricsEndpoint$ | async) as ep">
   <mat-card>
@@ -8,7 +9,8 @@
         <div>
           <div>{{ ep.entity.provider.name }}</div>
           <h2 class="metrics-url">
-            <a target="metrics" href="{{ ep.entity.provider.token_endpoint }}">{{ ep.entity.provider.token_endpoint }}</a>
+            <a target="metrics"
+              href="{{ ep.entity.provider.token_endpoint }}">{{ ep.entity.provider.token_endpoint }}</a>
           </h2>
         </div>
       </div>
@@ -24,31 +26,40 @@
   </div>
 
   <div>
-    <div *ngFor="let svc of ep.entity.endpoints" class="metric-endpoint">
+    <div *ngFor="let targetEndpoint of ep.entity.endpoints" class="metric-endpoint">
       <mat-card class="metrics-provision">
         <mat-card-content>
-          <div class="metrics-info">
-            <mat-icon fontSet="{{ ep.metadata[svc.guid].icon.font }}">{{ ep.metadata[svc.guid].icon.name }}</mat-icon>
+          <div class="metrics-info" *ngIf="ep.metadata[targetEndpoint.guid] as metadata">
+            <mat-icon fontSet="{{ metadata.icon.font }}">
+              {{ metadata.icon.name }}</mat-icon>
             <div class="metrics-metadata">
-              <div>{{ svc.name }}</div>
-              <div>{{ ep.metadata[svc.guid].type }}</div>
+              <div>{{ targetEndpoint.name }}</div>
+              <div>{{ metadata.type }}</div>
               <div class="metrics-metadata__cols">
                 <div class="metrics-metadata__two-cols">
-                  <app-metadata-item icon="link" label="Address">{{ svc.url }}</app-metadata-item>
-                  <app-metadata-item icon="history" label="Prometheus Job">{{ svc.metadata.metrics_job || 'N/A' }}</app-metadata-item>
-                  <app-metadata-item icon="history" label="Prometheus Environment">{{ svc.metadata.metrics_environment || 'N/A' }}</app-metadata-item>
+                  <app-metadata-item icon="link" label="Address">{{ targetEndpoint.metadata.fullApiEndpoint }}
+                  </app-metadata-item>
+                  <app-metadata-item icon="history" label="Prometheus Job">
+                    {{ metadata.relation.metadata?.job || 'N/A' }}
+                  </app-metadata-item>
+                  <app-metadata-item icon="history" label="Prometheus Environment">
+                    {{ metadata.relation.metadata?.environment || 'N/A' }}</app-metadata-item>
                 </div>
                 <div class="metrics-metadata__two-cols">
-                  <div class="metrics-extra" *ngIf="svc.metadata && svc.metadata.metrics_job && (jobDetails$ | async) as jobDetails">
-                    <div *ngIf="jobDetails[svc.metadata.metrics_job]">
-                      <app-metadata-item icon="help_outline" label="Exporter Health">{{
-                        jobDetails[svc.metadata.metrics_job].health | uppercase }}</app-metadata-item>
-                      <app-metadata-item icon="schedule" label="Exporter Last Scrape">{{
-                        jobDetails[svc.metadata.metrics_job].lastScrape | date:'medium' }}</app-metadata-item>
-                      <app-metadata-item icon="error_outline" label="Exporter Last Error">{{
-                        jobDetails[svc.metadata.metrics_job].lastError || 'None' }}</app-metadata-item>
+                  <ng-container *ngIf="metadata.relation.metadata?.job as job">
+                    <div class="metrics-extra" *ngIf="jobDetails$ | async as jobDetails">
+                      <div *ngIf="jobDetails[job]">
+                        <app-metadata-item icon="help_outline" label="Exporter Health">{{
+                              jobDetails[job].health | uppercase }}</app-metadata-item>
+                        <app-metadata-item icon="schedule" label="Exporter Last Scrape">{{
+                              jobDetails[job].lastScrape | date:'medium' }}
+                        </app-metadata-item>
+                        <app-metadata-item icon="error_outline" label="Exporter Last Error">{{
+                              jobDetails[job].lastError || 'None' }}</app-metadata-item>
+                      </div>
                     </div>
-                  </div>
+                  </ng-container>
+
                 </div>
               </div>
             </div>
@@ -58,5 +69,3 @@
     </div>
   </div>
 </div>
-
-

--- a/src/frontend/packages/core/src/features/metrics/metrics/metrics.component.ts
+++ b/src/frontend/packages/core/src/features/metrics/metrics/metrics.component.ts
@@ -57,13 +57,14 @@ export class MetricsComponent {
     this.store.dispatch(metricsAction);
 
     this.metricsEndpoint$ = this.metricsService.metricsEndpoints$.pipe(
-      map((ep) => ep.find((item) => item.provider.guid === metricsGuid)),
-      map((ep) => {
+      map(eps => eps.find((item) => item.provider.guid === metricsGuid)),
+      map(ep => {
         const metadata = {};
         ep.endpoints.forEach(endpoint => {
           metadata[endpoint.guid] = {
             type: getNameForEndpointType(endpoint.cnsi_type, endpoint.sub_type),
-            icon: getIconForEndpoint(endpoint.cnsi_type, endpoint.sub_type)
+            icon: getIconForEndpoint(endpoint.cnsi_type, endpoint.sub_type),
+            relation: ep.provider.relations.provides.find(provider => provider.guid === endpoint.guid)
           };
         });
         return {
@@ -88,8 +89,8 @@ export class MetricsComponent {
     );
 
     this.jobDetails$ = this.metricsEndpoint$.pipe(
-      filter(mi => !!mi && !!mi.entity.provider && !!mi.entity.provider.metadata && !!mi.entity.provider.metadata.metrics_targets),
-      map(mi => mi.entity.provider.metadata.metrics_targets),
+      filter(mi => !!mi && !!mi.entity.provider && !!mi.entity.provider.metadata && !!mi.entity.provider.metadata.cfMetricsTargets),
+      map(mi => mi.entity.provider.metadata.cfMetricsTargets),
       map((targetsData: MetricsAPITargets) => targetsData.activeTargets.reduce((mapped, t) => {
         if (t.labels && t.labels.job) {
           mapped[t.labels.job] = t;

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/base-endpoints-data-source.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/base-endpoints-data-source.ts
@@ -98,7 +98,6 @@ export class BaseEndpointsDataSource extends ListDataSource<EndpointModel> {
       getEmptyType: () => ({
         name: '',
         system_shared_token: false,
-        metricsAvailable: false,
         sso_allowed: false,
       }),
       paginationKey: GetAllEndpoints.storeKey,

--- a/src/frontend/packages/core/test-framework/store-test-helper.ts
+++ b/src/frontend/packages/core/test-framework/store-test-helper.ts
@@ -21779,7 +21779,6 @@ function getDefaultInitialTestStoreState(): AppState {
           connectionStatus: 'connected',
           registered: true,
           system_shared_token: false,
-          metricsAvailable: false
         },
       },
       metrics: {},

--- a/src/frontend/packages/store/src/effects/app.effects.ts
+++ b/src/frontend/packages/store/src/effects/app.effects.ts
@@ -3,7 +3,7 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { first, map } from 'rxjs/operators';
 
-import { endpointHasMetrics } from '../../../core/src/features/endpoints/endpoint-helpers';
+import { getEndpointHasCfMetrics } from '../../../core/src/features/endpoints/endpoint-helpers';
 import {
   createAppInstancesMetricAction,
 } from '../../../core/src/shared/components/list/list-types/app-instance/cf-app-instances-config.service';
@@ -39,7 +39,7 @@ export class AppEffects {
       const updateAction: UpdateExistingApplication = action.apiAction as UpdateExistingApplication;
       if (!!updateAction.existingApplication && updateAction.newApplication.instances > updateAction.existingApplication.instances) {
         // First check that we have a metrics endpoint associated with this cf
-        endpointHasMetrics(updateAction.endpointGuid, this.store).pipe(first()).subscribe(hasMetrics => {
+        getEndpointHasCfMetrics(updateAction.endpointGuid, this.store).pipe(first()).subscribe(hasMetrics => {
           if (hasMetrics) {
             this.store.dispatch(createAppInstancesMetricAction(updateAction.guid, updateAction.endpointGuid));
           }

--- a/src/frontend/packages/store/src/reducers/system-endpoints.reducer.ts
+++ b/src/frontend/packages/store/src/reducers/system-endpoints.reducer.ts
@@ -9,7 +9,7 @@ import {
 } from '../actions/endpoint.actions';
 import { METRIC_API_SUCCESS, MetricAPIQueryTypes, MetricsAPIActionSuccess } from '../actions/metrics-api.actions';
 import { IRequestEntityTypeState } from '../app-state';
-import { endpointConnectionStatus, EndpointModel } from '../types/endpoint.types';
+import { endpointConnectionStatus, EndpointModel, EndpointRelationTypes } from '../types/endpoint.types';
 import { GET_SYSTEM_INFO, GET_SYSTEM_INFO_SUCCESS } from './../actions/system.actions';
 
 export function systemEndpointsReducer(state: IRequestEntityTypeState<EndpointModel>, action) {
@@ -61,23 +61,21 @@ function succeedEndpointInfo(state, action) {
       newState[guid] = {
         ...newState[guid],
         ...endpointInfo,
-        metricsAvailable: endpointHasMetrics(endpointInfo)
+        metricsAvailable: endpointHasCfMetrics(endpointInfo)
       };
     });
   });
   return newState;
 }
 
-function endpointHasMetrics(endpoint: EndpointModel) {
-  if (!endpoint || !endpoint.metadata) {
-    return false;
-  }
-  return !!endpoint.metadata.metrics;
+export function endpointHasCfMetrics(endpoint: EndpointModel): boolean {
+  return endpoint && endpoint.relations ?
+    !!endpoint.relations.receives.find(relation => relation.type === EndpointRelationTypes.METRICS_CF) : false;
 }
 
 function changeEndpointConnectionStatus(state: IRequestEntityTypeState<EndpointModel>, action: {
   guid: string
-},                                      connectionStatus: endpointConnectionStatus) {
+}, connectionStatus: endpointConnectionStatus) {
   if (!action.guid) {
     return state;
   }
@@ -103,7 +101,7 @@ function updateMetricsInfo(state: IRequestEntityTypeState<EndpointModel>, action
         ...existingEndpoint,
         metadata: {
           ...existingEndpoint.metadata,
-          metrics_targets: action.data.data
+          cfMetricsTargets: action.data.data
         }
       },
     };

--- a/src/frontend/packages/store/src/reducers/system-endpoints.reducer.ts
+++ b/src/frontend/packages/store/src/reducers/system-endpoints.reducer.ts
@@ -1,4 +1,4 @@
-import { SESSION_VERIFIED, VERIFY_SESSION } from '../actions/auth.actions';
+import { VERIFY_SESSION } from '../actions/auth.actions';
 import {
   CONNECT_ENDPOINTS,
   CONNECT_ENDPOINTS_FAILED,
@@ -10,16 +10,13 @@ import {
 import { METRIC_API_SUCCESS, MetricAPIQueryTypes, MetricsAPIActionSuccess } from '../actions/metrics-api.actions';
 import { IRequestEntityTypeState } from '../app-state';
 import { endpointConnectionStatus, EndpointModel, EndpointRelationTypes } from '../types/endpoint.types';
-import { GET_SYSTEM_INFO, GET_SYSTEM_INFO_SUCCESS } from './../actions/system.actions';
+import { GET_SYSTEM_INFO } from './../actions/system.actions';
 
 export function systemEndpointsReducer(state: IRequestEntityTypeState<EndpointModel>, action) {
   switch (action.type) {
     case VERIFY_SESSION:
     case GET_SYSTEM_INFO:
       return fetchingEndpointInfo(state);
-    case SESSION_VERIFIED:
-    case GET_SYSTEM_INFO_SUCCESS:
-      return succeedEndpointInfo(state, action);
     case CONNECT_ENDPOINTS_FAILED:
     case DISCONNECT_ENDPOINTS_SUCCESS:
       return changeEndpointConnectionStatus(state, action, 'disconnected');
@@ -52,22 +49,6 @@ function fetchingEndpointInfo(state) {
   return modified ? fetchingState : state;
 }
 
-function succeedEndpointInfo(state, action) {
-  const newState = { ...state };
-  const payload = action.type === GET_SYSTEM_INFO_SUCCESS ? action.payload : action.sessionData;
-  Object.keys(payload.endpoints).forEach(type => {
-    getAllEndpointIds(newState[type], payload.endpoints[type]).forEach(guid => {
-      const endpointInfo = payload.endpoints[type][guid] as EndpointModel;
-      newState[guid] = {
-        ...newState[guid],
-        ...endpointInfo,
-        metricsAvailable: endpointHasCfMetrics(endpointInfo)
-      };
-    });
-  });
-  return newState;
-}
-
 export function endpointHasCfMetrics(endpoint: EndpointModel): boolean {
   return endpoint && endpoint.relations ?
     !!endpoint.relations.receives.find(relation => relation.type === EndpointRelationTypes.METRICS_CF) : false;
@@ -75,7 +56,7 @@ export function endpointHasCfMetrics(endpoint: EndpointModel): boolean {
 
 function changeEndpointConnectionStatus(state: IRequestEntityTypeState<EndpointModel>, action: {
   guid: string
-}, connectionStatus: endpointConnectionStatus) {
+},                                      connectionStatus: endpointConnectionStatus) {
   if (!action.guid) {
     return state;
   }

--- a/src/frontend/packages/store/src/types/auth.types.ts
+++ b/src/frontend/packages/store/src/types/auth.types.ts
@@ -48,6 +48,7 @@ export interface SessionData {
     demo: boolean,
     [pluginName: string]: boolean
   };
+  configuration?: { [key: string]: string }; ///////////
 }
 export interface Diagnostics {
   deploymentType?: string;

--- a/src/frontend/packages/store/src/types/endpoint.types.ts
+++ b/src/frontend/packages/store/src/types/endpoint.types.ts
@@ -35,7 +35,7 @@ export interface IApiEndpointInfo {
 export type endpointConnectionStatus = 'connected' | 'disconnected' | 'unknown' | 'checking';
 // export type endpointMetricsTypes = 'metrics' | 'metrics-kube' | 'kubeMetrics-cf';
 export enum EndpointRelationTypes {
-  METRICS_CF = 'metrics',
+  METRICS_CF = 'metrics-cf',
   METRICS_KUBE = 'metrics-kube',
   KUBEMETRICS_CF = 'kubeMetrics-cf'
 }
@@ -70,7 +70,6 @@ export interface EndpointModel {
   // These are generated client side when we login
   registered?: boolean;
   connectionStatus?: endpointConnectionStatus;
-  metricsAvailable: boolean;
 }
 
 // Metadata for the user connected to an endpoint

--- a/src/frontend/packages/store/src/types/endpoint.types.ts
+++ b/src/frontend/packages/store/src/types/endpoint.types.ts
@@ -33,6 +33,17 @@ export interface IApiEndpointInfo {
   User: object;
 }
 export type endpointConnectionStatus = 'connected' | 'disconnected' | 'unknown' | 'checking';
+// export type endpointMetricsTypes = 'metrics' | 'metrics-kube' | 'kubeMetrics-cf';
+export enum EndpointRelationTypes {
+  METRICS_CF = 'metrics',
+  METRICS_KUBE = 'metrics-kube',
+  KUBEMETRICS_CF = 'kubeMetrics-cf'
+}
+export interface EndpointsRelation {
+  guid: string;
+  metadata: { [key: string]: any };
+  type: EndpointRelationTypes;
+}
 export interface EndpointModel {
   api_endpoint?: IApiEndpointInfo;
   authorization_endpoint?: string;
@@ -46,11 +57,13 @@ export interface EndpointModel {
   token_endpoint?: string;
   user?: EndpointUser;
   metadata?: {
-    metrics?: string;
-    metrics_job?: string;
-    metrics_environment?: string;
-    metrics_targets?: MetricsAPITargets;
+    cfMetricsTargets?: MetricsAPITargets;
     userInviteAllowed?: 'true' | any;
+    fullApiEndpoint?: string;
+  };
+  relations?: {
+    provides: EndpointsRelation[]
+    receives: EndpointsRelation[];
   };
   system_shared_token: boolean;
   sso_allowed: boolean;

--- a/src/jetstream/auth.go
+++ b/src/jetstream/auth.go
@@ -453,11 +453,10 @@ func (p *portalProxy) DoLoginToCNSI(c echo.Context, cnsiGUID string, systemShare
 				}
 			}
 
-			// TODO: RC Test with shared endpoints/systemSharedToken
 			// Notify plugins if they support the notification interface
 			for _, plugin := range p.Plugins {
 				if notifier, ok := plugin.(interfaces.TokenNotificationPlugin); ok {
-					notifier.OnTokenNotification(&cnsiRecord, tokenRecord, consoleUserID, cnsiUser)
+					notifier.OnConnect(&cnsiRecord, tokenRecord, consoleUserID, cnsiUser)
 				}
 			}
 
@@ -700,6 +699,14 @@ func (p *portalProxy) logout(c echo.Context) error {
 	err := p.clearSession(c)
 	if err != nil {
 		log.Errorf("Unable to clear session: %v", err)
+	}
+
+	// Notify plugins if they support the notification interface
+	for _, plugin := range p.Plugins {
+		if notifier, ok := plugin.(interfaces.TokenNotificationPlugin); ok {
+			// TODO: RC check if there's anything i can actually grab
+			notifier.OnDisconnect()
+		}
 	}
 
 	// Send JSON document

--- a/src/jetstream/auth.go
+++ b/src/jetstream/auth.go
@@ -456,7 +456,7 @@ func (p *portalProxy) DoLoginToCNSI(c echo.Context, cnsiGUID string, systemShare
 			// Notify plugins if they support the notification interface
 			for _, plugin := range p.Plugins {
 				if notifier, ok := plugin.(interfaces.TokenNotificationPlugin); ok {
-					notifier.OnConnect(&cnsiRecord, tokenRecord, consoleUserID, cnsiUser)
+					notifier.OnConnect(&cnsiRecord, tokenRecord, consoleUserID)
 				}
 			}
 
@@ -704,7 +704,6 @@ func (p *portalProxy) logout(c echo.Context) error {
 	// Notify plugins if they support the notification interface
 	for _, plugin := range p.Plugins {
 		if notifier, ok := plugin.(interfaces.TokenNotificationPlugin); ok {
-			// TODO: RC check if there's anything i can actually grab
 			notifier.OnDisconnect()
 		}
 	}
@@ -1045,6 +1044,21 @@ func (p *portalProxy) GetUAAUser(userGUID string) (*interfaces.ConnectedUser, er
 func (p *portalProxy) GetCNSIUser(cnsiGUID string, userGUID string) (*interfaces.ConnectedUser, bool) {
 	user, _, ok := p.GetCNSIUserAndToken(cnsiGUID, userGUID)
 	return user, ok
+}
+
+func (p *portalProxy) GetCNSIUsers() ([]string, error) {
+	log.Debug("GetCNSIUsers")
+	tokenRepo, err := tokens.NewPgsqlTokenRepository(p.DatabaseConnectionPool)
+	if err != nil {
+		return nil, err
+	}
+
+	users, err := tokenRepo.ListUsers()
+	if err != nil {
+		return nil, err
+	}
+
+	return users, nil
 }
 
 func (p *portalProxy) GetCNSIUserAndToken(cnsiGUID string, userGUID string) (*interfaces.ConnectedUser, *interfaces.TokenRecord, bool) {

--- a/src/jetstream/cnsi.go
+++ b/src/jetstream/cnsi.go
@@ -166,6 +166,8 @@ func (p *portalProxy) unregisterCluster(c echo.Context) error {
 	ufe := userfavoritesendpoints.Constructor(p, cnsiGUID)
 	ufe.RemoveFavorites()
 
+	p.RemoveRelations(cnsiGUID)
+
 	return nil
 }
 
@@ -181,7 +183,7 @@ func (p *portalProxy) ListEndpoints() ([]*interfaces.CNSIRecord, error) {
 
 	cnsiRepo, err := cnsis.NewPostgresCNSIRepository(p.DatabaseConnectionPool)
 	if err != nil {
-		return cnsiList, fmt.Errorf("listRegisteredCNSIs: %s", err)
+		return cnsiList, fmt.Errorf("ListEndpoints: %s", err)
 	}
 
 	cnsiList, err = cnsiRepo.List(p.Config.EncryptionKeyInBytes)
@@ -278,8 +280,8 @@ func marshalClusterList(clusterList []*interfaces.ConnectedEndpoint) ([]byte, er
 	return jsonString, nil
 }
 
-func (p *portalProxy) UpdateEndointMetadata(guid string, metadata string) error {
-	log.Debug("UpdateEndointMetadata")
+func (p *portalProxy) UpdateEndpointMetadata(guid string, metadata string) error {
+	log.Debug("UpdateEndpointMetadata")
 
 	cnsiRepo, err := cnsis.NewPostgresCNSIRepository(p.DatabaseConnectionPool)
 	if err != nil {

--- a/src/jetstream/cnsi.go
+++ b/src/jetstream/cnsi.go
@@ -280,8 +280,8 @@ func marshalClusterList(clusterList []*interfaces.ConnectedEndpoint) ([]byte, er
 	return jsonString, nil
 }
 
-func (p *portalProxy) UpdateEndpointMetadata(guid string, metadata string) error {
-	log.Debug("UpdateEndpointMetadata")
+func (p *portalProxy) UpdateEndointMetadata(guid string, metadata string) error {
+	log.Debug("UpdateEndointMetadata")
 
 	cnsiRepo, err := cnsis.NewPostgresCNSIRepository(p.DatabaseConnectionPool)
 	if err != nil {
@@ -442,9 +442,19 @@ func (p *portalProxy) GetCNSITokenRecordWithDisconnected(cnsiGUID string, userGU
 
 	return tr, true
 }
-
-func (p *portalProxy) ListEndpointsByUser(userGUID string, includeShared bool) ([]*interfaces.ConnectedEndpoint, error) {
+func (p *portalProxy) ListEndpointsByUser(userGUID string) ([]*interfaces.ConnectedEndpoint, error) {
 	log.Debug("ListCEndpointsByUser")
+	return p.listEndpointsByUserAndShared(userGUID, false)
+}
+
+
+func (p *portalProxy) ListEndpointsByUserAndShared(userGUID string) ([]*interfaces.ConnectedEndpoint, error) {
+	log.Debug("ListEndpointsByUserAndShared")
+	return p.listEndpointsByUserAndShared(userGUID, true)
+}
+
+func (p *portalProxy) listEndpointsByUserAndShared(userGUID string, includeShared bool) ([]*interfaces.ConnectedEndpoint, error) {
+	log.Debug("listEndpointsByUserAndShared")
 	cnsiRepo, err := cnsis.NewPostgresCNSIRepository(p.DatabaseConnectionPool)
 	if err != nil {
 		log.Errorf(dbReferenceError, err)
@@ -470,7 +480,7 @@ func (p *portalProxy) ListEndpointsByUser(userGUID string, includeShared bool) (
 	return cnsiList, nil
 }
 
-// Uopdate the Access Token, Refresh Token and Token Expiry for a token
+// Update the Access Token, Refresh Token and Token Expiry for a token
 func (p *portalProxy) updateTokenAuth(userGUID string, t interfaces.TokenRecord) error {
 	log.Debug("updateTokenAuth")
 	tokenRepo, err := tokens.NewPgsqlTokenRepository(p.DatabaseConnectionPool)

--- a/src/jetstream/datastore/20190521141000_Relations.go
+++ b/src/jetstream/datastore/20190521141000_Relations.go
@@ -1,0 +1,27 @@
+package datastore
+
+import (
+	"database/sql"
+
+	"bitbucket.org/liamstask/goose/lib/goose"
+)
+
+func init() {
+	RegisterMigration(20190521141000, "Relations", func(txn *sql.Tx, conf *goose.DBConf) error {
+
+		createFavoritesTable := "CREATE TABLE IF NOT EXISTS relations ("
+		createFavoritesTable += "provider                  VARCHAR(255)  NOT NULL,"
+		createFavoritesTable += "type                      VARCHAR(36)   NOT NULL,"
+		createFavoritesTable += "target                    VARCHAR(255)  NOT NULL,"
+		createFavoritesTable += "metadata                  TEXT,"
+		createFavoritesTable += "last_updated              TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+		createFavoritesTable += "PRIMARY KEY (provider, target) );"
+
+		_, err := txn.Exec(createFavoritesTable)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/src/jetstream/datastore/20190521212700_ConfigSchema.go
+++ b/src/jetstream/datastore/20190521212700_ConfigSchema.go
@@ -1,0 +1,32 @@
+package datastore
+
+import (
+	"database/sql"
+
+	"bitbucket.org/liamstask/goose/lib/goose"
+)
+
+func init() {
+	RegisterMigration(20190521212700, "ConfigSchema", func(txn *sql.Tx, conf *goose.DBConf) error {
+		configTable := "CREATE TABLE IF NOT EXISTS config ("
+		configTable += "  groupName         VARCHAR(255)              NOT NULL, "
+		configTable += "  name              VARCHAR(255)              NOT NULL, "
+		configTable += "  value       			VARCHAR(255)              NOT NULL,"
+		configTable += "  last_updated      TIMESTAMP                 NOT NULL DEFAULT CURRENT_TIMESTAMP);"
+
+		_, err := txn.Exec(configTable)
+		if err != nil {
+			return err
+		}
+
+		// Add a marker to the new table so that later we know we need to migrate the old data to the new table
+		addMarker := "INSERT INTO config (groupName, name, value) VALUES ('system', '__CONFIG_MIGRATION_NEEDED', 'true')"
+
+		_, err = txn.Exec(addMarker)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/src/jetstream/datastore/20190521341000_Relations.go
+++ b/src/jetstream/datastore/20190521341000_Relations.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	RegisterMigration(20190521141000, "Relations", func(txn *sql.Tx, conf *goose.DBConf) error {
+	RegisterMigration(20190521341000, "Relations", func(txn *sql.Tx, conf *goose.DBConf) error {
 
 		createFavoritesTable := "CREATE TABLE IF NOT EXISTS relations ("
 		createFavoritesTable += "provider                  VARCHAR(255)  NOT NULL,"
@@ -18,6 +18,14 @@ func init() {
 		createFavoritesTable += "PRIMARY KEY (provider, target) );"
 
 		_, err := txn.Exec(createFavoritesTable)
+		if err != nil {
+			return err
+		}
+
+		// Add a marker to the config table so that later we know we need to add relations for existing endpoints
+		addMarker := "INSERT INTO config (groupName, name, value) VALUES ('system', '__RELATIONS_MIGRATION_NEEDED', 'true')"
+
+		_, err = txn.Exec(addMarker)
 		if err != nil {
 			return err
 		}

--- a/src/jetstream/db_config.go
+++ b/src/jetstream/db_config.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/console_config"
+	log "github.com/sirupsen/logrus"
+)
+
+
+func (p *portalProxy) GetConfigValue(group, name string) (string, error) {
+	consoleRepo, err := console_config.NewPostgresConsoleConfigRepository(p.DatabaseConnectionPool)
+	if err != nil {
+		log.Warn("Failed to connect to Database!")
+		return "", err
+	}
+	value, ok, err := consoleRepo.GetValue(group, name)
+	if err != nil || !ok {
+		return "", err
+	}
+
+	return value, nil
+}
+
+func (p *portalProxy) DeleteConfigValue(group, name string) error {
+	consoleRepo, err := console_config.NewPostgresConsoleConfigRepository(p.DatabaseConnectionPool)
+	if err != nil {
+		log.Warn("Failed to connect to Database!")
+		return err
+	}
+	err = consoleRepo.DeleteValue(group, name)
+	return err
+}

--- a/src/jetstream/go.sum
+++ b/src/jetstream/go.sum
@@ -50,6 +50,7 @@ github.com/charlievieth/fs v0.0.0-20170613215519-7dc373669fa1/go.mod h1:sAoA1zHC
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudfoundry-community/go-cfenv v1.17.0 h1:qfxEfn8qKkaHY3ZEk/Y2noY79HBASvNgmtHK9x4+6GY=
 github.com/cloudfoundry-community/go-cfenv v1.17.0/go.mod h1:2UgWvQTRXUuIZ/x3KnW6fk6CgPBhcV4UQb/UGIrUyyI=
+github.com/cloudfoundry-incubator/stratos v2.0.0-beta-001+incompatible h1:UUxNbLjhv2cfymub5yNN1tjjqYkteHBBagb4jcbXEIQ=
 github.com/cloudfoundry/bosh-cli v5.4.0+incompatible h1:KpT2PBB7nP1QnK8guXeZ/D2k7FZYAOxcveKgYTDEDBI=
 github.com/cloudfoundry/bosh-cli v5.4.0+incompatible/go.mod h1:rzIB+e1sn7wQL/TJ54bl/FemPKRhXby5BIMS3tLuWFM=
 github.com/cloudfoundry/bosh-utils v0.0.0-20190206192830-9a0affed2bf1 h1:TxcGamw+BaxXTFwZFORzkWNMCHAWjhThxnI24CLS7iE=

--- a/src/jetstream/info.go
+++ b/src/jetstream/info.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"fmt"
 
 	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/interfaces"
 	"github.com/labstack/echo"
+	log "github.com/sirupsen/logrus"
 )
 
 // Endpoint - This represents the CNSI endpoint
@@ -27,6 +29,42 @@ func (p *portalProxy) info(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, s)
+}
+
+// Add a set of endpoint relations to each endpoint via the relations table
+func (p *portalProxy) updateRelations(endpoints map[string]map[string]*interfaces.EndpointDetail) error {
+	relations, err := p.ListRelations()
+	if err != nil {
+		return fmt.Errorf("Failed to fetch relations: %v", err)
+	}
+	for _, endpointsOfType := range endpoints {
+		for _, endpoint := range endpointsOfType {
+			for _, relation := range relations {
+				if (relation.Provider == endpoint.GUID || relation.Target == endpoint.GUID) && endpoint.Relations == nil {
+					endpoint.Relations = &interfaces.EndpointRelations{
+						Provides: []interfaces.EndpointRelation{},
+						Receives: []interfaces.EndpointRelation{},
+					}
+				}
+				// Add relation to appropriate Provider/Target collection
+				if relation.Provider == endpoint.GUID {
+					endpoint.Relations.Provides = append(endpoint.Relations.Provides, interfaces.EndpointRelation{
+						Guid:         relation.Target,
+						RelationType: relation.RelationType,
+						Metadata:     relation.Metadata,
+					})
+				} else if relation.Target == endpoint.GUID {
+					endpoint.Relations.Receives = append(endpoint.Relations.Receives, interfaces.EndpointRelation{
+						Guid:         relation.Provider,
+						RelationType: relation.RelationType,
+						Metadata:     relation.Metadata,
+					})
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (p *portalProxy) getInfo(c echo.Context) (*interfaces.Info, error) {
@@ -84,6 +122,7 @@ func (p *portalProxy) getInfo(c echo.Context) (*interfaces.Info, error) {
 			Metadata:          make(map[string]string),
 			SystemSharedToken: false,
 		}
+
 		// try to get the user info for this cnsi for the user
 		cnsiUser, token, ok := p.GetCNSIUserAndToken(cnsi.GUID, userGUID)
 		if ok {
@@ -93,6 +132,11 @@ func (p *portalProxy) getInfo(c echo.Context) (*interfaces.Info, error) {
 		}
 		cnsiType := cnsi.CNSIType
 		s.Endpoints[cnsiType][cnsi.GUID] = endpoint
+	}
+
+	err = p.updateRelations(s.Endpoints)
+	if err != nil {
+		log.Warnf("Failed to add relations data to endpoints during info request: %v", err)
 	}
 
 	// Allow plugin to modify the info data

--- a/src/jetstream/info.go
+++ b/src/jetstream/info.go
@@ -92,6 +92,7 @@ func (p *portalProxy) getInfo(c echo.Context) (*interfaces.Info, error) {
 		Endpoints:    make(map[string]map[string]*interfaces.EndpointDetail),
 		CloudFoundry: p.Config.CloudFoundryInfo,
 		PluginConfig: p.Config.PluginConfig,
+		Configuration: make(map[string]string),
 	}
 
 	// Only add diagnostics information if the user is an admin
@@ -148,6 +149,8 @@ func (p *portalProxy) getInfo(c echo.Context) (*interfaces.Info, error) {
 	}
 
 	s.Plugins = p.PluginsStatus
+
+	s.Configuration["eirini"] = "true"
 
 	return s, nil
 }

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -83,7 +83,10 @@ func getEnvironmentLookup() *env.VarSet {
 	// Make environment lookup
 	envLookup := env.NewVarSet()
 
-	// Environment variables directly set trump all others
+	// Config database store topmost priority
+	envLookup.AppendSource(console_config.ConfigLookup)
+
+	// Environment variables
 	envLookup.AppendSource(os.LookupEnv)
 
 	// If running in CloudFoundry, fallback to a user provided service (if set)
@@ -143,11 +146,14 @@ func main() {
 
 	if isUpgrading {
 		log.Info("Upgrade in progress (lock file detected) ... waiting for lock file to be removed ...")
-		start(portalConfig, &portalProxy{env: envLookup}, &setupMiddleware{}, true)
+		start(portalConfig, &portalProxy{env: envLookup}, false, true)
 	}
 	// Grab the Console Version from the executable
 	portalConfig.ConsoleVersion = appVersion
 	log.Infof("Stratos Version: %s", portalConfig.ConsoleVersion)
+
+	// Initialize an empty config for the console - initially not setup
+	portalConfig.ConsoleConfig = new(interfaces.ConsoleConfig)
 
 	// Initialize the HTTP client
 	initializeHTTPClients(portalConfig.HTTPClientTimeoutInSecs, portalConfig.HTTPClientTimeoutMutatingInSecs, portalConfig.HTTPConnectionTimeoutInSecs)
@@ -241,7 +247,7 @@ func main() {
 	}()
 
 	// Initialise configuration
-	addSetupMiddleware, err := initialiseConsoleConfiguration(portalProxy)
+	needSetupMiddleware, err := initialiseConsoleConfiguration(portalProxy)
 	if err != nil {
 		log.Infof("Failed to initialise console config due to: %s", err)
 		return
@@ -273,7 +279,7 @@ func main() {
 	portalProxy.StoreDiagnostics()
 
 	// Start the back-end
-	if err := start(portalProxy.Config, portalProxy, addSetupMiddleware, false); err != nil {
+	if err := start(portalProxy.Config, portalProxy, needSetupMiddleware, false); err != nil {
 		log.Fatalf("Unable to start: %v", err)
 	}
 	log.Info("Unable to start Stratos JetStream backend")
@@ -291,61 +297,56 @@ func (portalProxy *portalProxy) GetPlugin(name string) interface{} {
 	return plugin
 }
 
-func initialiseConsoleConfiguration(portalProxy *portalProxy) (*setupMiddleware, error) {
+func initialiseConsoleConfiguration(portalProxy *portalProxy) (bool, error) {
 
-	addSetupMiddleware := new(setupMiddleware)
+	addSetupMiddleware := false
 	consoleRepo, err := console_config.NewPostgresConsoleConfigRepository(portalProxy.DatabaseConnectionPool)
 	if err != nil {
-		log.Errorf("Unable to intialise Stratos backend config due to: %+v", err)
+		log.Errorf("Unable to initialize Stratos backend config due to: %+v", err)
 		return addSetupMiddleware, err
 	}
-	isInitialised, err := consoleRepo.IsInitialised()
 
-	if err != nil || !isInitialised {
-		// Exception occurred when trying to determine
-		// if its initialised or instance isn't initialised,
-		// will attempt to initialise it from the env vars.
+	// Do this BEFORE we load the config from the database, so env var lookup at this stage
+	// looks at environment variables etc but NOT the database
+	// Migrate data from old setup table to new config table (if needed)
+	err = console_config.MigrateSetupData(portalProxy, consoleRepo)
+	if err != nil {
+		log.Warnf("Unable to initialize config environment provider: %+v", err)
+	}
 
-		consoleConfig, err := portalProxy.initialiseConsoleConfig(consoleRepo)
-		if err != nil {
-			log.Warnf("Failed to initialise Stratos config due to: %+v", err)
+	// Load config stored in the database
+	err = console_config.InitializeConfEnvProvider(consoleRepo)
+	if err != nil {
+		log.Warnf("Unable to load configuration from database: %+v", err)
+	}
 
-			addSetupMiddleware.addSetup = true
-			addSetupMiddleware.consoleRepo = consoleRepo
-			log.Info("Will add `setup` route and middleware")
+	// Now that the config DB is an env provider, we can just use the env to fetch the setup values
+	consoleConfig, err := portalProxy.initialiseConsoleConfig(portalProxy.Env(), consoleRepo)
+	if err != nil {
+		// Could not read config - this should not happen - so abort if it does
+		log.Fatalf("Unable to load console config; %+v", err)
+	}
 
-		} else {
-			showStratosConfig(consoleConfig)
-			portalProxy.Config.ConsoleConfig = consoleConfig
-			setSSOFromConfig(portalProxy, consoleConfig)
-		}
-
-	} else if err == nil && isInitialised {
-		consoleConfig, err := consoleRepo.GetConsoleConfig()
-		if err != nil {
-			log.Infof("Instance is initialised, but console_config table may contain junk data! %+v", err)
-		}
+	// We dynamically determine if we need to enter setup mode based on the configuration
+	// We need: UAA Endpoint and Console Admin Scope
+	if !consoleConfig.IsSetupComplete() {
+		addSetupMiddleware = true
+		log.Info("Will add `setup` route and middleware")
+	} else {
 		showStratosConfig(consoleConfig)
 		portalProxy.Config.ConsoleConfig = consoleConfig
-		setSSOFromConfig(portalProxy, consoleConfig)
+		portalProxy.Config.SSOLogin = consoleConfig.UseSSO
 	}
 
 	return addSetupMiddleware, nil
 }
 
-func setSSOFromConfig(portalProxy *portalProxy, configuration *interfaces.ConsoleConfig) {
-	// For SSO, override the value loaded from the config file, so that this is what we use
-	if !portalProxy.Env().IsSet("SSO_LOGIN") {
-		portalProxy.Config.SSOLogin = configuration.UseSSO
-	}
-}
-
 func showStratosConfig(config *interfaces.ConsoleConfig) {
-	log.Infof("Stratos is intialised with the following setup:")
+	log.Infof("Stratos is initialized with the following setup:")
 	log.Infof("... UAA Endpoint        : %s", config.UAAEndpoint)
 	log.Infof("... Console Client      : %s", config.ConsoleClient)
 	log.Infof("... Skip SSL Validation : %t", config.SkipSSLValidation)
-	log.Infof("... Setup Complete      : %t", config.IsSetupComplete)
+	log.Infof("... Setup Complete      : %t", config.IsSetupComplete())
 	log.Infof("... Admin Scope         : %s", config.ConsoleAdminScope)
 	log.Infof("... Use SSO Login       : %t", config.UseSSO)
 }
@@ -631,7 +632,7 @@ func initializeHTTPClients(timeout int64, timeoutMutating int64, connectionTimeo
 	httpClientMutatingSkipSSL.Timeout = time.Duration(timeoutMutating) * time.Second
 }
 
-func start(config interfaces.PortalConfig, p *portalProxy, addSetupMiddleware *setupMiddleware, isUpgrade bool) error {
+func start(config interfaces.PortalConfig, p *portalProxy, needSetupMiddleware bool, isUpgrade bool) error {
 	log.Debug("start")
 	e := echo.New()
 	e.HideBanner = true
@@ -664,7 +665,7 @@ func start(config interfaces.PortalConfig, p *portalProxy, addSetupMiddleware *s
 	e.Use(bindToEnv(retryAfterUpgradeMiddleware, p.Env()))
 
 	if !isUpgrade {
-		p.registerRoutes(e, addSetupMiddleware)
+		p.registerRoutes(e, needSetupMiddleware)
 	}
 
 	if isUpgrade {
@@ -688,7 +689,7 @@ func start(config interfaces.PortalConfig, p *portalProxy, addSetupMiddleware *s
 	if engineErr != nil {
 		engineErrStr := fmt.Sprintf("%s", engineErr)
 		if !strings.Contains(engineErrStr, "Server closed") {
-			log.Warnf("Failed to start HTTP/S server: %v+", engineErr)
+			log.Warnf("Failed to start HTTP/S server: %+v", engineErr)
 		}
 	}
 
@@ -740,7 +741,7 @@ func (p *portalProxy) getHttpClient(skipSSLValidation bool, mutating bool) http.
 	return client
 }
 
-func (p *portalProxy) registerRoutes(e *echo.Echo, addSetupMiddleware *setupMiddleware) {
+func (p *portalProxy) registerRoutes(e *echo.Echo, needSetupMiddleware bool) {
 	log.Debug("registerRoutes")
 
 	for _, plugin := range p.Plugins {
@@ -760,9 +761,8 @@ func (p *portalProxy) registerRoutes(e *echo.Echo, addSetupMiddleware *setupMidd
 	pp.Use(p.setSecureCacheContentMiddleware)
 
 	// Add middleware to block requests if unconfigured
-	if addSetupMiddleware.addSetup {
-		go p.SetupPoller(addSetupMiddleware)
-		e.Use(p.SetupMiddleware(addSetupMiddleware))
+	if needSetupMiddleware {
+		e.Use(p.SetupMiddleware())
 		pp.POST("/v1/setup", p.setupConsole)
 		pp.POST("/v1/setup/update", p.setupConsoleUpdate)
 	}

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/interfaces"
 	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/interfaces/config"
 	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/tokens"
+	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/relations"
 )
 
 // TimeoutBoundary represents the amount of time we'll wait for the database
@@ -172,6 +173,7 @@ func main() {
 	cnsis.InitRepositoryProvider(dc.DatabaseProvider)
 	tokens.InitRepositoryProvider(dc.DatabaseProvider)
 	console_config.InitRepositoryProvider(dc.DatabaseProvider)
+	relations.InitRepositoryProvider(dc.DatabaseProvider)
 
 	// Establish a Postgresql connection pool
 	var databaseConnectionPool *sql.DB
@@ -807,6 +809,14 @@ func (p *portalProxy) registerRoutes(e *echo.Echo, addSetupMiddleware *setupMidd
 	// CNSI operations
 	sessionGroup.GET("/cnsis", p.listCNSIs)
 	sessionGroup.GET("/cnsis/registered", p.listRegisteredCNSIs)
+
+	// Relations operations
+	sessionGroup.GET("/relations", p.listRelations)
+	sessionGroup.POST("/relations", p.createRelation)
+	// TODO: RC remove
+	// echoGroup.DELETE("/relations/:provider/:target", uf.delete)
+	// echoGroup.DELETE("/relations/:providerOrTarget", uf.deleteAll)
+	// echoGroup.POST("/relations/:provider/:target", r.setMetadata)
 
 	// Info
 	sessionGroup.GET("/info", p.info)

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -813,10 +813,6 @@ func (p *portalProxy) registerRoutes(e *echo.Echo, addSetupMiddleware *setupMidd
 	// Relations operations
 	sessionGroup.GET("/relations", p.listRelations)
 	sessionGroup.POST("/relations", p.createRelation)
-	// TODO: RC remove
-	// echoGroup.DELETE("/relations/:provider/:target", uf.delete)
-	// echoGroup.DELETE("/relations/:providerOrTarget", uf.deleteAll)
-	// echoGroup.POST("/relations/:provider/:target", r.setMetadata)
 
 	// Info
 	sessionGroup.GET("/info", p.info)

--- a/src/jetstream/plugins/cfappssh/app_ssh.go
+++ b/src/jetstream/plugins/cfappssh/app_ssh.go
@@ -162,7 +162,7 @@ func (cfAppSsh *CFAppSSH) appSSH(c echo.Context) error {
 		_, r, err := ws.ReadMessage()
 		if err != nil {
 			log.Error("Error reading message from web socket")
-			log.Warnf("%v+", err)
+			log.Warnf("%+v", err)
 			return err
 		}
 
@@ -293,7 +293,7 @@ func getSSHCode(authorizeEndpoint, clientID, token string, skipSSLValidation boo
 
 	resp, err := httpClientWithoutRedirects.Do(authorizeReq)
 	if resp != nil {
-		log.Infof("%v+", resp)
+		log.Infof("%+v", resp)
 	}
 	if err == nil {
 		return "", errors.New("Authorization server did not redirect with one time code")

--- a/src/jetstream/plugins/cloudfoundryhosting/main.go
+++ b/src/jetstream/plugins/cloudfoundryhosting/main.go
@@ -73,10 +73,24 @@ func ConfigInit(envLookup *env.VarSet, jetstreamConfig *interfaces.PortalConfig)
 			}
 		}
 	}
+
 }
 
 // Init creates a new CFHosting plugin
 func Init(portalProxy interfaces.PortalProxy) (interfaces.StratosPlugin, error) {
+
+	// Update Database migration status depending on app instance index and SQLite
+	if portalProxy.Env().IsSet(VCapApplication) {
+		isSQLite := portalProxy.GetConfig().DatabaseProviderName == SQLiteProviderName
+		if !isSQLite && portalProxy.Env().IsSet("CF_INSTANCE_INDEX") {
+			if appInstanceIndex, ok := portalProxy.Env().Lookup("CF_INSTANCE_INDEX"); ok {
+				if index, err := strconv.Atoi(appInstanceIndex); err == nil {
+					portalProxy.SetCanPerformMigrations(index == 0)
+				}
+			}
+		}
+	}
+
 	return &CFHosting{portalProxy: portalProxy}, nil
 }
 
@@ -138,7 +152,7 @@ func (ch *CFHosting) Init() error {
 		data := []byte(vCapApp)
 		err := json.Unmarshal(data, &appData)
 		if err != nil {
-			log.Fatalf("Could not get the Cloud Foundry API URL: %v+", err)
+			log.Fatalf("Could not get the Cloud Foundry API URL: %+v", err)
 			return nil
 		}
 
@@ -179,7 +193,7 @@ func (ch *CFHosting) Init() error {
 		cfEndpointSpec, _ := ch.portalProxy.GetEndpointTypeSpec("cf")
 		newCNSI, _, err := cfEndpointSpec.Info(appData.API, true)
 		if err != nil {
-			log.Fatalf("Could not get the info for Cloud Foundry: %v+", err)
+			log.Fatalf("Could not get the info for Cloud Foundry: %+v", err)
 			return nil
 		}
 
@@ -195,13 +209,6 @@ func (ch *CFHosting) Init() error {
 		// Not set in the environment and failed to read from the Secrets file
 		// CHECK is this necessary to set here?
 		ch.portalProxy.GetConfig().ConsoleConfig.SkipSSLValidation = ch.portalProxy.Env().MustBool("SKIP_SSL_VALIDATION")
-
-		// Save to Console DB
-		err = ch.portalProxy.SaveConsoleConfig(ch.portalProxy.GetConfig().ConsoleConfig, nil)
-		if err != nil {
-			log.Fatalf("Failed to save console configuration due to %s", err)
-			return fmt.Errorf("Failed to save console configuration due to %s", err)
-		}
 
 		if !ch.portalProxy.Env().IsSet(SkipAutoRegister) {
 			log.Info("Setting AUTO_REG_CF_URL config to ", appData.API)

--- a/src/jetstream/plugins/metrics/main.go
+++ b/src/jetstream/plugins/metrics/main.go
@@ -334,7 +334,7 @@ func createMetricsMetadataFromTokenMetadata(tokenMetadata string, endpointGuid s
 			info.URL = item.URL
 			info.Job = item.Job
 			info.Environment = item.Environment
-			log.Infof("Metrics provider: %+v", info) // TODO: RC revert to debug
+			log.Debugf("Metrics provider: %+v", info)
 			metricsProviders = append(metricsProviders, info)
 		}
 	}
@@ -433,13 +433,13 @@ func (m *MetricsSpecification) linkMetricsToEndpoints(endpoint *interfaces.CNSIR
 	metricsProvidersForEndpoint, err := createMetricsMetadataFromTokenMetadata(tokenRecord.Metadata, endpoint.GUID)
 
 	if err != nil {
-		// TODO: RC handle error
+		log.Warnf("Failed to link metric endpoint to other endpoints (creating providers from token): %v", err)
 		return
 	}
 
 	endpoints, err := m.portalProxy.ListEndpointsByUserAndShared(consoleUserID)
 	if err != nil {
-		// TODO: RC handle error
+		log.Warnf("Failed to link metric endpoint to other endpoints (listing connected endpoints): %v", err)
 		return
 	}
 	for _, endpoint := range endpoints {
@@ -457,7 +457,7 @@ func (m *MetricsSpecification) linkMetricsToEndpoints(endpoint *interfaces.CNSIR
 			}
 			_, err := m.portalProxy.SaveRelation(relation)
 			if err != nil {
-				// TODO: RC handle error
+				log.Warnf("Failed to link metric endpoint to other endpoints (could not save relation): %v", err)
 			}
 		}
 		// For K8S
@@ -474,7 +474,7 @@ func (m *MetricsSpecification) linkMetricsToEndpoints(endpoint *interfaces.CNSIR
 			}
 			_, err := m.portalProxy.SaveRelation(relation)
 			if err != nil {
-				// TODO: RC handle error
+				log.Warnf("Failed to link metric endpoint to other endpoints (could not save relation): %v", err)
 			}
 		}
 	}
@@ -491,7 +491,7 @@ func (m *MetricsSpecification) linkEndpointToMetrics(endpointGuid string, endpoi
 	// Find all metrics endpoints
 	endpoints, err := m.portalProxy.ListEndpointsByUserAndShared(consoleUserID)
 	if err != nil {
-		// TODO: RC handle error
+		log.Warnf("Failed to link endpoint to metric endpoints (listing connected endpoints): %v", err)
 		return
 	}
 	metricsEndpoints := filterEndpoints(endpoints, func(v *interfaces.ConnectedEndpoint) bool {
@@ -507,7 +507,7 @@ func (m *MetricsSpecification) linkEndpointToMetrics(endpointGuid string, endpoi
 		}
 		metricsProvidersForEndpoint, err := createMetricsMetadataFromTokenMetadata(tokenRecord.Metadata, endpointGuid)
 		if err != nil {
-			// TODO: RC handle error
+			log.Warnf("Failed to link endpoint to metric endpoints (creating providers from token): %v", err)
 			continue
 		}
 		if provider, ok := hasMetricsProvider(metricsProvidersForEndpoint, endpointUrl); ok {
@@ -519,18 +519,16 @@ func (m *MetricsSpecification) linkEndpointToMetrics(endpointGuid string, endpoi
 				Metadata: metadataToMap(MetricsRelationMetadata{
 					Job:         provider.Job,
 					Environment: provider.Environment,
-				}), //TODO: This will wipe out metadata on save
+				}),
 			}
 			_, err := m.portalProxy.SaveRelation(relation)
 			if err != nil {
-				log.Warnf("!!!!!linkEndpointToMetrics: err2: %v", err)
-				// TODO: RC handle error
+				log.Warnf("Failed to link endpoint to metric endpoints (could not save relation): %v", err)
 			}
 		}
 	}
 }
 
-// TODO: RC Gotta be a generic way to do this??
 func filterEndpoints(vs []*interfaces.ConnectedEndpoint, f func(*interfaces.ConnectedEndpoint) bool) []*interfaces.ConnectedEndpoint {
 	vsf := make([]*interfaces.ConnectedEndpoint, 0)
 	for _, v := range vs {

--- a/src/jetstream/plugins/userfavorites/userfavoritesstore/favorites-store-db.go
+++ b/src/jetstream/plugins/userfavorites/userfavoritesstore/favorites-store-db.go
@@ -24,7 +24,8 @@ func InitRepositoryProvider(databaseProvider string) {
 	getFavorites = datastore.ModifySQLStatement(getFavorites, databaseProvider)
 	deleteFavorite = datastore.ModifySQLStatement(deleteFavorite, databaseProvider)
 	saveFavorite = datastore.ModifySQLStatement(saveFavorite, databaseProvider)
-	// TODO: RC is setMetadata and deleteEndpointFavorite needed here?
+	setMetadata = datastore.ModifySQLStatement(setMetadata, databaseProvider)
+	deleteEndpointFavorite = datastore.ModifySQLStatement(deleteEndpointFavorite, databaseProvider)
 }
 
 // FavoritesDBStore is a DB-backed User Favorites repository

--- a/src/jetstream/plugins/userfavorites/userfavoritesstore/favorites-store-db.go
+++ b/src/jetstream/plugins/userfavorites/userfavoritesstore/favorites-store-db.go
@@ -24,6 +24,7 @@ func InitRepositoryProvider(databaseProvider string) {
 	getFavorites = datastore.ModifySQLStatement(getFavorites, databaseProvider)
 	deleteFavorite = datastore.ModifySQLStatement(deleteFavorite, databaseProvider)
 	saveFavorite = datastore.ModifySQLStatement(saveFavorite, databaseProvider)
+	// TODO: RC is setMetadata and deleteEndpointFavorite needed here?
 }
 
 // FavoritesDBStore is a DB-backed User Favorites repository

--- a/src/jetstream/plugins/userinvite/auth.go
+++ b/src/jetstream/plugins/userinvite/auth.go
@@ -33,7 +33,7 @@ func (invite *UserInvite) RefreshToken(cfGUID, clientID, clientSecret string) (*
 		return nil, nil, interfaces.NewHTTPShadowError(
 			http.StatusInternalServerError,
 			"Unable to save user invite token",
-			"Unable to save user invite token: %v+", err,
+			"Unable to save user invite token: %+v", err,
 		)
 	}
 
@@ -93,7 +93,7 @@ func (invite *UserInvite) refreshToken(clientID, clientSecret string, endpoint i
 		return nil, nil, interfaces.NewHTTPShadowError(
 			res.StatusCode,
 			errMessage,
-			errMessage+" %v+", err,
+			errMessage+" %+v", err,
 		)
 	}
 
@@ -103,7 +103,7 @@ func (invite *UserInvite) refreshToken(clientID, clientSecret string, endpoint i
 		return nil, nil, interfaces.NewHTTPShadowError(
 			http.StatusBadRequest,
 			"Error parsing response from UAA",
-			"Error parsing response from UAA: %v+", err,
+			"Error parsing response from UAA: %+v", err,
 		)
 	}
 

--- a/src/jetstream/plugins/userinvite/endpoint.go
+++ b/src/jetstream/plugins/userinvite/endpoint.go
@@ -9,7 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// GetType - return empty string as we don't introduce a new enpoint type
+// GetType - return empty string as we don't introduce a new endpoint type
 func (invite *UserInvite) GetType() string {
 	return ""
 }

--- a/src/jetstream/plugins/userinvite/endpoint.go
+++ b/src/jetstream/plugins/userinvite/endpoint.go
@@ -36,7 +36,7 @@ func (invite *UserInvite) Validate(userGUID string, cnsiRecord interfaces.CNSIRe
 // UpdateMetadata will add metadata for each Cloud Foundry endpoint to indicate if user invitation is allowed
 func (invite *UserInvite) UpdateMetadata(info *interfaces.Info, userGUID string, echoContext echo.Context) {
 	log.Debug("User Invite:: UpdateMetadata")
-	endpoints, err := invite.portalProxy.ListEndpointsByUser(UserInviteUserID, false)
+	endpoints, err := invite.portalProxy.ListEndpointsByUser(UserInviteUserID)
 	if err == nil {
 		// Update all of the Cloud Foundry endpoints that have an invite token set to indicate that user invitation is enabled
 		if info.Endpoints["cf"] != nil {

--- a/src/jetstream/plugins/userinvite/endpoint.go
+++ b/src/jetstream/plugins/userinvite/endpoint.go
@@ -36,7 +36,7 @@ func (invite *UserInvite) Validate(userGUID string, cnsiRecord interfaces.CNSIRe
 // UpdateMetadata will add metadata for each Cloud Foundry endpoint to indicate if user invitation is allowed
 func (invite *UserInvite) UpdateMetadata(info *interfaces.Info, userGUID string, echoContext echo.Context) {
 	log.Debug("User Invite:: UpdateMetadata")
-	endpoints, err := invite.portalProxy.ListEndpointsByUser(UserInviteUserID)
+	endpoints, err := invite.portalProxy.ListEndpointsByUser(UserInviteUserID, false)
 	if err == nil {
 		// Update all of the Cloud Foundry endpoints that have an invite token set to indicate that user invitation is enabled
 		if info.Endpoints["cf"] != nil {

--- a/src/jetstream/plugins/userinvite/invite.go
+++ b/src/jetstream/plugins/userinvite/invite.go
@@ -262,7 +262,7 @@ func (invite *UserInvite) UAAUserInvite(c echo.Context, endpoint interfaces.CNSI
 		return nil, interfaces.NewHTTPShadowError(
 			http.StatusInternalServerError,
 			"Failed to request user invite links",
-			"Failed to request user invite links: %v+",
+			"Failed to request user invite links: %+v",
 			err,
 		)
 	}

--- a/src/jetstream/portal_proxy.go
+++ b/src/jetstream/portal_proxy.go
@@ -31,3 +31,19 @@ type HttpSessionStore interface {
 	StopCleanup(quit chan<- struct{}, done <-chan struct{})
 	Cleanup(interval time.Duration) (chan<- struct{}, <-chan struct{})
 }
+
+// canPerformMigrations indicates if we can safely perform migrations
+// This depends on the deployment mechanism and the database config
+// e.g. if running in Cloud Foundry with a shared DB, then only the 0-index application instance
+// can perform migrations
+var canPerformMigrations = true
+
+// SetCanPerformMigrations updates the state that records if we can perform Database migrations
+func (p *portalProxy) SetCanPerformMigrations(value bool) {
+	canPerformMigrations = canPerformMigrations && value
+}
+
+// CanPerformMigrations returns if we can perform Database migrations
+func (p *portalProxy) CanPerformMigrations() bool {
+	return canPerformMigrations
+}

--- a/src/jetstream/realtions.go
+++ b/src/jetstream/realtions.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/relations"
+	"github.com/labstack/echo"
+
+	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/interfaces"
+)
+
+// TODO: RC how to add jsdoc style comments?
+func (p *portalProxy) SaveRelation(relation interfaces.RelationsRecord) (*interfaces.RelationsRecord, error) {
+	store, err := relations.NewRelationsDBStore(p.DatabaseConnectionPool)
+	if err != nil {
+		// TODO: RC handle error
+	}
+	return store.Save(relation)
+}
+
+
+func (p *portalProxy) ListRelations() ([]*interfaces.RelationsRecord, error) {
+	store, err := relations.NewRelationsDBStore(p.DatabaseConnectionPool)
+	if err != nil {
+		return nil, err
+	}
+
+	return store.List()
+}
+
+func (p *portalProxy) RemoveRelations(providerOrTarget string) error {
+	store, err := relations.NewRelationsDBStore(p.DatabaseConnectionPool)
+	if err != nil {
+		return err
+	}
+
+	return store.DeleteRelations(providerOrTarget)
+}
+
+func (p *portalProxy) listRelations(c echo.Context) error {
+
+	list, err := p.ListRelations()
+	if err != nil {
+		return interfaces.NewHTTPShadowError(
+			http.StatusBadRequest,
+			"Unable to get relations from relations store",
+			"Unable to get relations from relations store: %v", err)
+	}
+
+	jsonString, err := json.Marshal(list)
+	if err != nil {
+		return interfaces.NewHTTPShadowError(
+			http.StatusBadRequest,
+			"Unable Marshal relations from relations json",
+			"Unable Marshal relations from relations json: %v", err)
+	}
+
+	c.Response().Header().Set("Content-Type", "application/json")
+	c.Response().Write(jsonString)
+	return nil
+}
+
+
+
+func (p *portalProxy) createRelation(c echo.Context) error {
+	req := c.Request()
+	body, _ := ioutil.ReadAll(req.Body)
+
+	relation := interfaces.RelationsRecord{}
+	err := json.Unmarshal(body, &relation)
+	if err != nil {
+		return interfaces.NewHTTPShadowError(
+			http.StatusBadRequest,
+			"Unable to parse Relations from request body",
+			"Unable to parse Relations from request body: %v", err)
+	}
+
+	if len(relation.Provider) == 0 || len(relation.RelationType) == 0 || len(relation.Target) == 0 {
+		return interfaces.NewHTTPShadowError(
+			http.StatusBadRequest,
+			"Invalid request - must provide provider, type and target",
+			"Invalid request - must provide provider, type and target")
+	}
+
+
+
+	// updatedRelation, err := store.Save(relation)
+	updatedRelation, err := p.SaveRelation(relation)
+
+	if err != nil {
+		return interfaces.NewHTTPShadowError(
+			http.StatusBadRequest,
+			"Failed to save relation to db",
+			"Failed to save relation to db: %v", err)
+	}
+
+	jsonString, err := json.Marshal(updatedRelation)
+	if err != nil {
+		return interfaces.NewHTTPShadowError(
+			http.StatusBadRequest,
+			"Failed to Marshal relation from db",
+			"Failed to Marshal relation from db: %v", err)
+	}
+
+	c.Response().Header().Set("Content-Type", "application/json")
+	c.Response().Write(jsonString)
+	return nil
+}

--- a/src/jetstream/relations.go
+++ b/src/jetstream/relations.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/interfaces"
 )
 
-// TODO: RC how to add jsdoc style comments?
 func (p *portalProxy) SaveRelation(relation interfaces.RelationsRecord) (*interfaces.RelationsRecord, error) {
 	store, err := relations.NewRelationsDBStore(p.DatabaseConnectionPool)
 	if err != nil {

--- a/src/jetstream/relations.go
+++ b/src/jetstream/relations.go
@@ -15,11 +15,10 @@ import (
 func (p *portalProxy) SaveRelation(relation interfaces.RelationsRecord) (*interfaces.RelationsRecord, error) {
 	store, err := relations.NewRelationsDBStore(p.DatabaseConnectionPool)
 	if err != nil {
-		// TODO: RC handle error
+		return nil, err
 	}
 	return store.Save(relation)
 }
-
 
 func (p *portalProxy) ListRelations() ([]*interfaces.RelationsRecord, error) {
 	store, err := relations.NewRelationsDBStore(p.DatabaseConnectionPool)
@@ -62,8 +61,6 @@ func (p *portalProxy) listRelations(c echo.Context) error {
 	return nil
 }
 
-
-
 func (p *portalProxy) createRelation(c echo.Context) error {
 	req := c.Request()
 	body, _ := ioutil.ReadAll(req.Body)
@@ -84,9 +81,6 @@ func (p *portalProxy) createRelation(c echo.Context) error {
 			"Invalid request - must provide provider, type and target")
 	}
 
-
-
-	// updatedRelation, err := store.Save(relation)
 	updatedRelation, err := p.SaveRelation(relation)
 
 	if err != nil {

--- a/src/jetstream/repository/console_config/console_config.go
+++ b/src/jetstream/repository/console_config/console_config.go
@@ -6,7 +6,10 @@ import (
 
 type Repository interface {
 	GetConsoleConfig() (*interfaces.ConsoleConfig, error)
-	SaveConsoleConfig(config *interfaces.ConsoleConfig) error
-	UpdateConsoleConfig(config *interfaces.ConsoleConfig) error
-	IsInitialised() (bool, error)
+
+	// Access to the config data
+	GetValue(group, name string) (string, bool, error)
+	SetValue(group, name, value string) error
+	DeleteValue(group, name string) error
+	GetValues(group string) (map[string]string, error)
 }

--- a/src/jetstream/repository/console_config/env_lookup.go
+++ b/src/jetstream/repository/console_config/env_lookup.go
@@ -1,0 +1,126 @@
+package console_config
+
+import (
+	"strconv"
+
+	"github.com/govau/cf-common/env"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/interfaces"
+)
+
+const (
+	configSetupNeededMarker = "__CONFIG_MIGRATION_NEEDED"
+	envGroupName            = "env"
+	systemGroupName         = "system"
+)
+
+// Env Vars from config store
+var envVars map[string]string
+
+// ConfigLookup looks up env var from the config database
+func ConfigLookup(name string) (string, bool) {
+	// Not initialized yet
+	if envVars == nil {
+		return "", false
+	}
+
+	// Get value from map if available
+	v, ok := envVars[name]
+	return v, ok
+}
+
+// InitializeConfEnvProvider reads the config from the database
+func InitializeConfEnvProvider(configStore Repository) error {
+
+	vars, err := configStore.GetValues(envGroupName)
+	if err != nil {
+		return err
+	}
+
+	envVars = vars
+	return nil
+}
+
+// MigrateSetupData will migrate the old data if needed
+func MigrateSetupData(portal interfaces.PortalProxy, configStore Repository) error {
+
+	// Determine if we need to migrate data first
+	_, ok, err := configStore.GetValue(systemGroupName, configSetupNeededMarker)
+	if err != nil || !ok {
+		return err
+	}
+
+	// If we got a value, then we should migrate
+
+	if !portal.CanPerformMigrations() {
+		log.Info("Will not migrate setup data on this instance")
+		return nil
+	}
+
+	log.Info("Migrating setup data to config store")
+
+	// Load the set  up config from the old table, first
+
+	config, err := configStore.GetConsoleConfig()
+	if err != nil {
+		log.Warn("Unable to load Setup configuration from the database")
+		return err
+	}
+
+	if config == nil {
+		log.Info("Can not migrate setup data - setup table is empty")
+		return nil
+	}
+
+	// Persist the config - only save the settings if they differ from the environment
+	if err := migrateConfigSetting(portal.Env(), configStore, "UAA_ENDPOINT", config.UAAEndpoint.String()); err != nil {
+		return err
+	}
+
+	if err := migrateConfigSetting(portal.Env(), configStore, "CONSOLE_ADMIN_SCOPE", config.ConsoleAdminScope); err != nil {
+		return err
+	}
+
+	if err := migrateConfigSetting(portal.Env(), configStore, "CONSOLE_CLIENT", config.ConsoleClient); err != nil {
+		return err
+	}
+
+	if err := migrateConfigSetting(portal.Env(), configStore, "CONSOLE_CLIENT_SECRET", config.ConsoleClientSecret); err != nil {
+		return err
+	}
+
+	if err := migrateConfigSetting(portal.Env(), configStore, "SKIP_SSL_VALIDATION", strconv.FormatBool(config.SkipSSLValidation)); err != nil {
+		return err
+	}
+
+	if err := migrateConfigSetting(portal.Env(), configStore, "SSO_LOGIN", strconv.FormatBool(config.UseSSO)); err != nil {
+		return err
+	}
+
+	// Delete the migration marker
+	err = configStore.DeleteValue(systemGroupName, configSetupNeededMarker)
+	if err != nil {
+		log.Warnf("Unable to delete setup config migration marker: %+v", err)
+		return err
+	}
+
+	return nil
+}
+
+func migrateConfigSetting(envLookup *env.VarSet, configStore Repository, envVarName, value string) error {
+
+	var shouldStore = true
+
+	// Get the current value from the environment
+	if currentValue, ok := envLookup.Lookup(envVarName); ok {
+		shouldStore = currentValue != value
+	}
+
+	if shouldStore {
+		err := configStore.SetValue(envGroupName, envVarName, value)
+		return err
+	}
+
+	return nil
+}

--- a/src/jetstream/repository/console_config/psql_console_config.go
+++ b/src/jetstream/repository/console_config/psql_console_config.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strings"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -14,19 +12,22 @@ import (
 	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/interfaces"
 )
 
-var getConsoleConfig = `SELECT uaa_endpoint, console_admin_scope, console_client, console_client_secret, skip_ssl_validation, use_sso
-							FROM console_config`
+// Legacy
+var getConsoleConfig = `SELECT uaa_endpoint, console_admin_scope, console_client, console_client_secret, skip_ssl_validation, use_sso FROM console_config`
 
-var saveConsoleConfig = `INSERT INTO console_config (uaa_endpoint, console_admin_scope, console_client, console_client_secret, skip_ssl_validation, is_setup_complete, use_sso)
-						VALUES ($1, $2, $3, $4, $5, $6, $7)`
+var deleteConsoleConfig = `DELETE FROM console_config`
 
-var updateConsoleConfig = `UPDATE console_config SET console_admin_scope = $1, is_setup_complete = '1'`
+// New Config Tale schema
 
-var getTableCount = `SELECT count(uaa_endpoint) FROM console_config`
+var getConfigValue = `SELECT name, value, last_updated FROM config WHERE groupName = $1 AND name = $2`
 
-var hasSetupCompleted = `SELECT is_setup_complete FROM console_config`
+var insertConfigValue = `INSERT INTO config (groupName, name, value) VALUES ($1, $2, $3)`
 
-var deleteConsoleConfig = ` DELETE FROM console_config`
+var updateConfigValue = `UPDATE config SET value=$1 WHERE groupName=$2 AND name=$3`
+
+var deleteConfigValue = `DELETE FROM config WHERE groupName=$1 AND name=$2`
+
+var getAllConfigValues = `SELECT name, value, last_updated FROM config WHERE groupName = $1`
 
 // PostgresCNSIRepository is a PostgreSQL-backed ConsoleConfig repository
 type ConsoleConfigRepository struct {
@@ -42,14 +43,109 @@ func NewPostgresConsoleConfigRepository(dcp *sql.DB) (Repository, error) {
 func InitRepositoryProvider(databaseProvider string) {
 	// Modify the database statements if needed, for the given database type
 	getConsoleConfig = datastore.ModifySQLStatement(getConsoleConfig, databaseProvider)
-	saveConsoleConfig = datastore.ModifySQLStatement(saveConsoleConfig, databaseProvider)
-	getTableCount = datastore.ModifySQLStatement(getTableCount, databaseProvider)
-	hasSetupCompleted = datastore.ModifySQLStatement(hasSetupCompleted, databaseProvider)
-	updateConsoleConfig = datastore.ModifySQLStatement(updateConsoleConfig, databaseProvider)
 	deleteConsoleConfig = datastore.ModifySQLStatement(deleteConsoleConfig, databaseProvider)
+
+	getConfigValue = datastore.ModifySQLStatement(getConfigValue, databaseProvider)
+	insertConfigValue = datastore.ModifySQLStatement(insertConfigValue, databaseProvider)
+	updateConfigValue = datastore.ModifySQLStatement(updateConfigValue, databaseProvider)
+	deleteConfigValue = datastore.ModifySQLStatement(deleteConfigValue, databaseProvider)
+	getAllConfigValues = datastore.ModifySQLStatement(getAllConfigValues, databaseProvider)
 }
 
-// ListByUser - Returns a list of CNSIs registered by a user
+// GetValue will try and get the config value for the specified key
+func (c *ConsoleConfigRepository) GetValue(group, key string) (string, bool, error) {
+
+	var (
+		name        string
+		value       string
+		lastUpdated string
+	)
+
+	err := c.db.QueryRow(getConfigValue, group, key).Scan(&name, &value, &lastUpdated)
+
+	switch {
+	case err == sql.ErrNoRows:
+		// No matching value
+		return "", false, nil
+	case err != nil:
+		return "", false, err
+	default:
+		// do nothing
+	}
+
+	return value, true, nil
+}
+
+func (c *ConsoleConfigRepository) SetValue(group, name, value string) error {
+
+	log.Debug("Config SetValue")
+
+	_, ok, err := c.GetValue(group, name)
+	if err != nil {
+		return err
+	}
+
+	if !ok {
+		if _, err := c.db.Exec(insertConfigValue, group, name, value); err != nil {
+			msg := "Unable to INSERT config value: %v"
+			log.Debugf(msg, err)
+			return fmt.Errorf(msg, err)
+		}
+	} else {
+		if _, err := c.db.Exec(updateConfigValue, value, group, name); err != nil {
+			msg := "Unable to UPDATE config value: %v"
+			log.Debugf(msg, err)
+			return fmt.Errorf(msg, err)
+		}
+	}
+
+	return nil
+}
+
+// DeleteValue deletes a value from the config table
+func (c *ConsoleConfigRepository) DeleteValue(group, key string) error {
+	log.Debug("Config Delete")
+	if _, err := c.db.Exec(deleteConfigValue, group, key); err != nil {
+		return fmt.Errorf("Unable to delete config value: %v", err)
+	}
+
+	return nil
+}
+
+// GetValues returns all values from the config table as a map
+func (c *ConsoleConfigRepository) GetValues(group string) (map[string]string, error) {
+
+	log.Debug("Config GetValues")
+	rows, err := c.db.Query(getAllConfigValues, group)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to retrieve config records: %v", err)
+	}
+	defer rows.Close()
+
+	var values = make(map[string]string)
+
+	for rows.Next() {
+		var (
+			name        string
+			value       string
+			lastUpdated string
+		)
+
+		err := rows.Scan(&name, &value, &lastUpdated)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to scan config records: %v", err)
+		}
+
+		values[name] = value
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("Unable to get config records: %v", err)
+	}
+
+	return values, nil
+}
+
 func (c *ConsoleConfigRepository) GetConsoleConfig() (*interfaces.ConsoleConfig, error) {
 	log.Debug("Get ConsoleConfig")
 	rows, err := c.db.Query(getConsoleConfig)
@@ -83,122 +179,4 @@ func (c *ConsoleConfigRepository) GetConsoleConfig() (*interfaces.ConsoleConfig,
 	}
 
 	return consoleConfig, nil
-}
-
-// Save - Persist a Console setup to a datastore
-func (c *ConsoleConfigRepository) SaveConsoleConfig(config *interfaces.ConsoleConfig) error {
-	log.Debugf("Saving ConsoleConfig: %+v", config)
-
-	// First wipe any values that may exist in the table
-	err := c.deleteConsoleConfig()
-	if err != nil {
-		return fmt.Errorf("Unable to truncate Console Config table: %v", err)
-	}
-	isComplete := config.ConsoleAdminScope != ""
-
-	if _, err := c.db.Exec(saveConsoleConfig, fmt.Sprintf("%s", config.UAAEndpoint),
-		config.ConsoleAdminScope, config.ConsoleClient, config.ConsoleClientSecret, config.SkipSSLValidation, isComplete, config.UseSSO); err != nil {
-		return fmt.Errorf("Unable to Save Console Config record: %v", err)
-	}
-
-	return nil
-}
-
-func (c *ConsoleConfigRepository) UpdateConsoleConfig(config *interfaces.ConsoleConfig) error {
-	log.Debugf("Saving ConsoleConfig: %+v", config)
-	if _, err := c.db.Exec(updateConsoleConfig, config.ConsoleAdminScope); err != nil {
-		return fmt.Errorf("Unable to Save Console Config record: %v", err)
-	}
-
-	return nil
-}
-
-func (c *ConsoleConfigRepository) deleteConsoleConfig() error {
-	if _, err := c.db.Exec(deleteConsoleConfig); err != nil {
-		return fmt.Errorf("Unable to delete Console Config record: %v", err)
-	}
-
-	return nil
-}
-
-func (c *ConsoleConfigRepository) IsInitialised() (bool, error) {
-
-	rowCount, err := c.getTableCount()
-	if err != nil {
-		for strings.Contains(err.Error(), "does not exist") || strings.Contains(err.Error(), "doesn't exist") {
-			// Schema isn't initialised yet. Wait a few secs and retry
-			log.Warnf("It appears schema isn't initialised yet, sleeping and trying again %s", err)
-			time.Sleep(1 * time.Second)
-			rowCount, err = c.getTableCount()
-			if err == nil {
-				break
-			}
-		}
-		if err != nil {
-			return false, err
-		}
-
-	}
-
-	if rowCount == 0 {
-		return false, nil
-	}
-
-	// A row exists, check if is_setup_complete is set
-	isSetupComplete, err := c.isSetupComplete()
-	if err != nil {
-		return false, err
-	}
-
-	return isSetupComplete, nil
-}
-
-func (c *ConsoleConfigRepository) isSetupComplete() (bool, error) {
-	rows, err := c.db.Query(hasSetupCompleted)
-
-	if err != nil {
-		return false, fmt.Errorf("Exception occurred when fetching row: %v", err)
-	}
-	defer rows.Close()
-
-	isSetupComplete := false
-	for rows.Next() {
-
-		err := rows.Scan(&isSetupComplete)
-		if err != nil {
-			return false, fmt.Errorf("Unable to scan config record: %v", err)
-		}
-	}
-
-	return isSetupComplete, nil
-}
-
-func (c *ConsoleConfigRepository) getCount(sqlStatement string) (int, error) {
-	rows, err := c.db.Query(sqlStatement)
-
-	if err != nil {
-		if strings.Contains(err.Error(), "does not exist") {
-			// Schema isn't initialised yet. Wait a few secs and retry
-			log.Warnf("It appears schema isn't initialised yet, sleeping and trying again %s", err)
-			time.Sleep(1 * time.Second)
-			c.getTableCount()
-		}
-		return 0, fmt.Errorf("Exception occurred when fetching row count: %v", err)
-	}
-	defer rows.Close()
-
-	count := 0
-	for rows.Next() {
-
-		err := rows.Scan(&count)
-		if err != nil {
-			return 0, fmt.Errorf("Unable to scan config record: %v", err)
-		}
-	}
-
-	return count, nil
-}
-
-func (c *ConsoleConfigRepository) getTableCount() (int, error) {
-	return c.getCount(getTableCount)
 }

--- a/src/jetstream/repository/interfaces/config/config.go
+++ b/src/jetstream/repository/interfaces/config/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -18,6 +19,8 @@ import (
 )
 
 const secretsDir = "/etc/secrets"
+
+var urlType *url.URL
 
 // Load the given pointer to struct with values from the environment and the
 // /etc/secrets/ directory.
@@ -118,7 +121,11 @@ func SetStructFieldValue(value reflect.Value, field reflect.Value, val string) e
 	case reflect.String:
 		newVal = val
 	default:
-		return fmt.Errorf("failed to decode value: unsupported type %q", kind.String())
+		if typ == reflect.TypeOf(urlType) {
+			newVal, err = url.Parse(val)
+		} else {
+			return fmt.Errorf("failed to decode value: unsupported type %q", kind.String())
+		}
 	}
 
 	if err != nil {

--- a/src/jetstream/repository/interfaces/plugin.go
+++ b/src/jetstream/repository/interfaces/plugin.go
@@ -29,5 +29,6 @@ type EndpointNotificationPlugin interface {
 }
 
 type TokenNotificationPlugin interface {
-	OnTokenNotification(*CNSIRecord, *TokenRecord, string, *ConnectedUser)
+	OnConnect(*CNSIRecord, *TokenRecord, string, *ConnectedUser)
+	OnDisconnect()
 }

--- a/src/jetstream/repository/interfaces/plugin.go
+++ b/src/jetstream/repository/interfaces/plugin.go
@@ -27,3 +27,7 @@ func RegisterJetstreamConfigPlugin(plugin JetstreamConfigInit) {
 type EndpointNotificationPlugin interface {
 	OnEndpointNotification(EndpointAction, *CNSIRecord)
 }
+
+type TokenNotificationPlugin interface {
+	OnTokenNotification(*CNSIRecord, *TokenRecord, string, *ConnectedUser)
+}

--- a/src/jetstream/repository/interfaces/plugin.go
+++ b/src/jetstream/repository/interfaces/plugin.go
@@ -29,6 +29,6 @@ type EndpointNotificationPlugin interface {
 }
 
 type TokenNotificationPlugin interface {
-	OnConnect(*CNSIRecord, *TokenRecord, string, *ConnectedUser)
+	OnConnect(*CNSIRecord, *TokenRecord, string)
 	OnDisconnect()
 }

--- a/src/jetstream/repository/interfaces/portal_proxy.go
+++ b/src/jetstream/repository/interfaces/portal_proxy.go
@@ -30,8 +30,6 @@ type PortalProxy interface {
 	GetSessionStringValue(c echo.Context, key string) (string, error)
 	SaveSession(c echo.Context, session *sessions.Session) error
 
-	SaveConsoleConfig(consoleConfig *ConsoleConfig, consoleRepoInterface interface{}) error
-
 	RefreshOAuthToken(skipSSLValidation bool, cnsiGUID, userGUID, client, clientSecret, tokenEndpoint string) (t TokenRecord, err error)
 	DoLoginToCNSI(c echo.Context, cnsiGUID string, systemSharedToken bool) (*LoginRes, error)
 	DoLoginToCNSIwithConsoleUAAtoken(c echo.Context, theCNSIrecord CNSIRecord) error
@@ -85,4 +83,10 @@ type PortalProxy interface {
 	SaveRelation(relation RelationsRecord) (*RelationsRecord, error)
 	ListRelations() ([]*RelationsRecord, error)
 	RemoveRelations(providerOrTarget string) error
+
+	// SetCanPerformMigrations updates the state that records if we can perform Database migrations
+	SetCanPerformMigrations(bool)
+
+	// CanPerformMigrations returns if we can perform Database migrations
+	CanPerformMigrations() bool
 }

--- a/src/jetstream/repository/interfaces/portal_proxy.go
+++ b/src/jetstream/repository/interfaces/portal_proxy.go
@@ -40,6 +40,7 @@ type PortalProxy interface {
 	GetCNSITokenRecord(cnsiGUID string, userGUID string) (TokenRecord, bool)
 	GetCNSITokenRecordWithDisconnected(cnsiGUID string, userGUID string) (TokenRecord, bool)
 	GetCNSIUser(cnsiGUID string, userGUID string) (*ConnectedUser, bool)
+	GetCNSIUsers() ([]string, error)
 	GetConfig() *PortalConfig
 	Env() *env.VarSet
 	ListEndpointsByUser(userGUID string) ([]*ConnectedEndpoint, error)
@@ -89,4 +90,8 @@ type PortalProxy interface {
 
 	// CanPerformMigrations returns if we can perform Database migrations
 	CanPerformMigrations() bool
+
+	// Config Table
+	GetConfigValue(group, name string) (string, error)
+	DeleteConfigValue(group, name string) error
 }

--- a/src/jetstream/repository/interfaces/portal_proxy.go
+++ b/src/jetstream/repository/interfaces/portal_proxy.go
@@ -44,9 +44,10 @@ type PortalProxy interface {
 	GetCNSIUser(cnsiGUID string, userGUID string) (*ConnectedUser, bool)
 	GetConfig() *PortalConfig
 	Env() *env.VarSet
-	ListEndpointsByUser(userGUID string, includeShared bool) ([]*ConnectedEndpoint, error)
+	ListEndpointsByUser(userGUID string) ([]*ConnectedEndpoint, error)
+	ListEndpointsByUserAndShared(userGUID string) ([]*ConnectedEndpoint, error)
 	ListEndpoints() ([]*CNSIRecord, error)
-	UpdateEndpointMetadata(guid string, metadata string) error
+	UpdateEndointMetadata(guid string, metadata string) error
 
 	// UAA Token
 	GetUAATokenRecord(userGUID string) (TokenRecord, error)

--- a/src/jetstream/repository/interfaces/portal_proxy.go
+++ b/src/jetstream/repository/interfaces/portal_proxy.go
@@ -46,7 +46,7 @@ type PortalProxy interface {
 	Env() *env.VarSet
 	ListEndpointsByUser(userGUID string) ([]*ConnectedEndpoint, error)
 	ListEndpoints() ([]*CNSIRecord, error)
-	UpdateEndointMetadata(guid string, metadata string) error
+	UpdateEndpointMetadata(guid string, metadata string) error
 
 	// UAA Token
 	GetUAATokenRecord(userGUID string) (TokenRecord, error)
@@ -76,8 +76,12 @@ type PortalProxy interface {
 
 	AddLoginHook(priority int, function LoginHookFunc) error
 	ExecuteLoginHooks(c echo.Context) error
-	
+
 	// Plugins
 	GetPlugin(name string) interface{}
-	
+
+	// Relations
+	SaveRelation(relation RelationsRecord) (*RelationsRecord, error)
+	ListRelations() ([]*RelationsRecord, error)
+	RemoveRelations(providerOrTarget string) error
 }

--- a/src/jetstream/repository/interfaces/portal_proxy.go
+++ b/src/jetstream/repository/interfaces/portal_proxy.go
@@ -44,7 +44,7 @@ type PortalProxy interface {
 	GetCNSIUser(cnsiGUID string, userGUID string) (*ConnectedUser, bool)
 	GetConfig() *PortalConfig
 	Env() *env.VarSet
-	ListEndpointsByUser(userGUID string) ([]*ConnectedEndpoint, error)
+	ListEndpointsByUser(userGUID string, includeShared bool) ([]*ConnectedEndpoint, error)
 	ListEndpoints() ([]*CNSIRecord, error)
 	UpdateEndpointMetadata(guid string, metadata string) error
 

--- a/src/jetstream/repository/interfaces/structs.go
+++ b/src/jetstream/repository/interfaces/structs.go
@@ -91,7 +91,7 @@ type EndpointTokenRecord struct {
 	LoggingEndpoint string
 }
 
-// TokenRecord repsrents and endpoint or uaa token
+// TokenRecord represents an endpoint or uaa token
 type TokenRecord struct {
 	TokenGUID      string
 	AuthToken      string

--- a/src/jetstream/repository/interfaces/structs.go
+++ b/src/jetstream/repository/interfaces/structs.go
@@ -200,14 +200,26 @@ type Info struct {
 	Diagnostics  *Diagnostics                          `json:"diagnostics,omitempty"`
 }
 
+type EndpointRelation struct {
+	Guid         string                 `json:"guid"`
+	RelationType string                 `json:"type"`
+	Metadata     map[string]interface{} `json:"metadata,omitempty"`
+}
+
+type EndpointRelations struct {
+	Provides []EndpointRelation `json:"provides"`
+	Receives []EndpointRelation `json:"receives"`
+}
+
 // Extends CNSI Record and adds the user
 type EndpointDetail struct {
 	*CNSIRecord
-	EndpointMetadata  interface{}       `json:"endpoint_metadata,omitempty"`
-	User              *ConnectedUser    `json:"user"`
-	Metadata          map[string]string `json:"metadata,omitempty"`
-	TokenMetadata     string            `json:"-"`
-	SystemSharedToken bool              `json:"system_shared_token"`
+	EndpointMetadata  interface{}        `json:"endpoint_metadata,omitempty"`
+	Relations         *EndpointRelations `json:"relations,omitempty"`
+	User              *ConnectedUser     `json:"user"`
+	Metadata          map[string]string  `json:"metadata,omitempty"`
+	TokenMetadata     string             `json:"-"`
+	SystemSharedToken bool               `json:"system_shared_token"`
 }
 
 // Versions - response returned to caller from a getVersions action
@@ -242,6 +254,13 @@ type CNSIRequest struct {
 	Response     []byte `json:"-"`
 	Error        error  `json:"-"`
 	ResponseGUID string `json:"-"`
+}
+
+type RelationsRecord struct {
+	Provider     string                 `json:"provider"`
+	RelationType string                 `json:"type"`
+	Target       string                 `json:"target"`
+	Metadata     map[string]interface{} `json:"metadata"`
 }
 
 type PortalConfig struct {

--- a/src/jetstream/repository/interfaces/structs.go
+++ b/src/jetstream/repository/interfaces/structs.go
@@ -191,13 +191,14 @@ type GooseDBVersionRecord struct {
 
 // Info - this represents user specific info
 type Info struct {
-	Versions     *Versions                             `json:"version"`
-	User         *ConnectedUser                        `json:"user"`
-	Endpoints    map[string]map[string]*EndpointDetail `json:"endpoints"`
-	CloudFoundry *CFInfo                               `json:"cloud-foundry,omitempty"`
-	Plugins      map[string]bool                       `json:"plugins"`
-	PluginConfig map[string]string                     `json:"plugin-config,omitempty"`
-	Diagnostics  *Diagnostics                          `json:"diagnostics,omitempty"`
+	Versions      *Versions                             `json:"version"`
+	User          *ConnectedUser                        `json:"user"`
+	Endpoints     map[string]map[string]*EndpointDetail `json:"endpoints"`
+	CloudFoundry  *CFInfo                               `json:"cloud-foundry,omitempty"`
+	Plugins       map[string]bool                       `json:"plugins"`
+	PluginConfig  map[string]string                     `json:"plugin-config,omitempty"`
+	Diagnostics   *Diagnostics                          `json:"diagnostics,omitempty"`
+	Configuration map[string]string                     `json:"configuration,omitempty"`
 }
 
 type EndpointRelation struct {

--- a/src/jetstream/repository/interfaces/structs.go
+++ b/src/jetstream/repository/interfaces/structs.go
@@ -230,13 +230,21 @@ type Versions struct {
 }
 
 type ConsoleConfig struct {
-	UAAEndpoint         *url.URL `json:"uaa_endpoint"`
-	ConsoleAdminScope   string   `json:"console_admin_scope"`
-	ConsoleClient       string   `json:"console_client"`
-	ConsoleClientSecret string   `json:"console_client_secret"`
-	SkipSSLValidation   bool     `json:"skip_ssl_validation"`
-	IsSetupComplete     bool     `json:"is_setup_complete"`
-	UseSSO              bool     `json:"use_sso"`
+	UAAEndpoint         *url.URL `json:"uaa_endpoint" configName:"UAA_ENDPOINT"`
+	ConsoleAdminScope   string   `json:"console_admin_scope" configName:"CONSOLE_ADMIN_SCOPE"`
+	ConsoleClient       string   `json:"console_client" configName:"CONSOLE_CLIENT"`
+	ConsoleClientSecret string   `json:"console_client_secret" configName:"CONSOLE_CLIENT_SECRET"`
+	SkipSSLValidation   bool     `json:"skip_ssl_validation" configName:"SKIP_SSL_VALIDATION"`
+	UseSSO              bool     `json:"use_sso" configName:"SSO_LOGIN"`
+}
+
+// IsSetupComplete indicates if we have enough config
+func (consoleConfig *ConsoleConfig) IsSetupComplete() bool {
+	if consoleConfig.UAAEndpoint == nil {
+		return false
+	}
+
+	return len(consoleConfig.UAAEndpoint.String()) > 0 && len(consoleConfig.ConsoleAdminScope) > 0
 }
 
 // CNSIRequest

--- a/src/jetstream/repository/relations/pgsql_relations.go
+++ b/src/jetstream/repository/relations/pgsql_relations.go
@@ -1,0 +1,154 @@
+package relations
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/interfaces"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	getRelations       = `SELECT provider, type, target, metadata FROM relations`
+	getRelationsByType = `SELECT provider, type, target, metadata FROM relations WHERE type = $1`
+	getRelation        = `SELECT provider, type, target, metadata FROM relations WHERE provider = $1 AND target = $2`
+	deleteRelation     = `DELETE FROM relations WHERE provider = $1 AND target = $2`
+	deleteRelations    = `DELETE FROM relations WHERE provider = $1 OR target = $1`
+	insertRelation     = `INSERT INTO relations (provider, type, target, metadata) VALUES ($1, $2, $3, $4)`
+	updateRelation     = `UPDATE relations SET provider = $1, type = $2, target = $3, metadata = $4 WHERE provider = $1 AND target = $3`
+)
+
+// InitRepositoryProvider - One time init for the given DB Provider
+func InitRepositoryProvider(databaseProvider string) {
+	// Modify the database statements if needed, for the given database type
+	// TODO: RC which statements need this, anyone with $?
+	// getRelations = datastore.ModifySQLStatement(getRelations, databaseProvider)
+	// deleteFavorite = datastore.ModifySQLStatement(deleteFavorite, databaseProvider)
+	// saveRelation = datastore.ModifySQLStatement(saveRelation, databaseProvider)
+}
+
+// RelationsDBStore is a DB-backed Relations repository
+type RelationsDBStore struct {
+	db *sql.DB
+}
+
+// NewRelationsDBStore will create a new instance of the RelationsDBStore
+func NewRelationsDBStore(dcp *sql.DB) (RelationsStore, error) {
+	return &RelationsDBStore{db: dcp}, nil
+}
+
+// List - Returns a list of all relations
+func (p *RelationsDBStore) List() ([]*interfaces.RelationsRecord, error) {
+	log.Debug("List")
+	rows, err := p.db.Query(getRelations)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to retrieve Relations records: %v", err)
+	}
+	defer rows.Close()
+
+	var relationsList []*interfaces.RelationsRecord
+	relationsList = make([]*interfaces.RelationsRecord, 0)
+
+	for rows.Next() {
+		relation := new(interfaces.RelationsRecord)
+		var metaString sql.NullString
+		err := rows.Scan(&relation.Provider, &relation.RelationType, &relation.Target, &metaString)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to scan Relations records: %v", err)
+		}
+
+		var metadata map[string]interface{}
+		err = json.Unmarshal([]byte(metaString.String), &metadata)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to Marshal Relations metadata: %v", err)
+		}
+		relation.Metadata = metadata
+
+		relationsList = append(relationsList, relation)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("Unable to List Relations records: %v", err)
+	}
+
+	return relationsList, nil
+}
+
+func (p *RelationsDBStore) ListByType(relationType string) ([]*interfaces.RelationsRecord, error) {
+	log.Debug("ListByType")
+	rows, err := p.db.Query(getRelationsByType, relationType)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to retrieve Relation records by type: %v", err)
+	}
+	defer rows.Close()
+
+	var relationsList []*interfaces.RelationsRecord
+	relationsList = make([]*interfaces.RelationsRecord, 0)
+
+	for rows.Next() {
+		relation := new(interfaces.RelationsRecord)
+		var metaString sql.NullString
+		err := rows.Scan(&relation.Provider, &relation.RelationType, &relation.Target, &metaString)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to scan Relations records: %v", err)
+		}
+
+		var metadata map[string]interface{}
+		err = json.Unmarshal([]byte(metaString.String), &metadata)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to Marshal Relations metadata: %v", err)
+		}
+		relation.Metadata = metadata
+
+		relationsList = append(relationsList, relation)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("Unable to List Relations records by type: %v", err)
+	}
+
+	return relationsList, nil
+}
+
+// Delete will delete a Relation from the datastore
+func (p *RelationsDBStore) DeleteRelation(provider string, target string) error {
+	if _, err := p.db.Exec(deleteRelation, provider, target); err != nil {
+		return fmt.Errorf("Unable to delete Relations record: %v", err)
+	}
+
+	return nil
+}
+
+func (p *RelationsDBStore) DeleteRelations(providerOrTarget string) error {
+	if _, err := p.db.Exec(deleteRelations, providerOrTarget); err != nil {
+		return fmt.Errorf("Unable to delete Relations: %v", err)
+	}
+
+	return nil
+}
+
+// Save will persist a Relation to a datastore, whether it's new or existing
+func (p *RelationsDBStore) Save(relationsRecord interfaces.RelationsRecord) (*interfaces.RelationsRecord, error) {
+
+	metaString, err := json.Marshal(relationsRecord.Metadata)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to marshal Relations metadata: %v", err)
+	}
+
+	existingRelation, err := p.db.Exec(getRelation, relationsRecord.Provider, relationsRecord.Target)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to determine existing relation: %v", err)
+	}
+	if existingRelation != nil {
+		if _, err := p.db.Exec(insertRelation, relationsRecord.Provider, relationsRecord.RelationType, relationsRecord.Target, metaString); err != nil {
+			return nil, fmt.Errorf("Unable to insert Relations record: %v", err)
+		}
+	} else {
+		if _, err := p.db.Exec(updateRelation, relationsRecord.Provider, relationsRecord.RelationType, relationsRecord.Target, metaString); err != nil {
+			return nil, fmt.Errorf("Unable to update Relations record: %v", err)
+		}
+	}
+
+	return &relationsRecord, nil
+}

--- a/src/jetstream/repository/relations/pgsql_relations.go
+++ b/src/jetstream/repository/relations/pgsql_relations.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/cloudfoundry-incubator/stratos/src/jetstream/datastore"
 	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/interfaces"
 	log "github.com/sirupsen/logrus"
 )
@@ -22,10 +23,12 @@ var (
 // InitRepositoryProvider - One time init for the given DB Provider
 func InitRepositoryProvider(databaseProvider string) {
 	// Modify the database statements if needed, for the given database type
-	// TODO: RC which statements need this, anyone with $?
-	// getRelations = datastore.ModifySQLStatement(getRelations, databaseProvider)
-	// deleteFavorite = datastore.ModifySQLStatement(deleteFavorite, databaseProvider)
-	// saveRelation = datastore.ModifySQLStatement(saveRelation, databaseProvider)
+	getRelationsByType = datastore.ModifySQLStatement(getRelationsByType, databaseProvider)
+	getRelation = datastore.ModifySQLStatement(getRelation, databaseProvider)
+	deleteRelation = datastore.ModifySQLStatement(deleteRelation, databaseProvider)
+	deleteRelations = datastore.ModifySQLStatement(deleteRelations, databaseProvider)
+	insertRelation = datastore.ModifySQLStatement(insertRelation, databaseProvider)
+	updateRelation = datastore.ModifySQLStatement(updateRelation, databaseProvider)
 }
 
 // RelationsDBStore is a DB-backed Relations repository

--- a/src/jetstream/repository/relations/relations.go
+++ b/src/jetstream/repository/relations/relations.go
@@ -1,0 +1,13 @@
+package relations
+
+import (
+	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/interfaces"
+)
+
+type RelationsStore interface {
+	List() ([]*interfaces.RelationsRecord, error)
+	ListByType(relationType string) ([]*interfaces.RelationsRecord, error)
+	DeleteRelation(provider string, target string) error
+	DeleteRelations(providerOrTarget string) error
+	Save(relation interfaces.RelationsRecord) (*interfaces.RelationsRecord, error)
+}

--- a/src/jetstream/repository/tokens/pgsql_tokens.go
+++ b/src/jetstream/repository/tokens/pgsql_tokens.go
@@ -62,6 +62,8 @@ var updateToken = `UPDATE tokens
 										SET auth_token = $1, refresh_token = $2, token_expiry = $3
 										WHERE token_guid = $4 AND user_guid = $5`
 
+var listUsers = `SELECT DISTINCT user_guid from tokens;`
+
 // PgsqlTokenRepository is a PostgreSQL-backed token repository
 type PgsqlTokenRepository struct {
 	db *sql.DB
@@ -544,4 +546,33 @@ func (p *PgsqlTokenRepository) UpdateTokenAuth(userGUID string, tr interfaces.To
 	log.Debug("Token UPDATE complete")
 
 	return nil
+}
+
+func (p *PgsqlTokenRepository) ListUsers() ([]string, error) {
+	log.Debug("ListUsers")
+	rows, err := p.db.Query(listUsers)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to retrieve user records: %v", err)
+	}
+	defer rows.Close()
+
+	var userList []string
+	userList = make([]string, 0)
+
+	for rows.Next() {
+		var (
+			userGuid string
+		)
+		err := rows.Scan(&userGuid)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to scan token records: %v", err)
+		}
+		userList = append(userList, userGuid)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("Unable to List User records: %v", err)
+	}
+
+	return userList, nil
 }

--- a/src/jetstream/repository/tokens/tokens.go
+++ b/src/jetstream/repository/tokens/tokens.go
@@ -24,4 +24,6 @@ type Repository interface {
 
 	// Update a token's auth data
 	UpdateTokenAuth(userGUID string, tokenRecord interfaces.TokenRecord, encryptionKey []byte) error
+
+	ListUsers() ([]string, error)
 }


### PR DESCRIPTION
- store cf to metrics relations in the db
- update relations on endpoint connect/unregister
- return, per endpoint, relations from db

Tweaks
- Remove un-required `metricsAvailable`, use common `getEndpointHasCfMetrics`
- Convenience method to fetch users endpoints including shared endpoints

blocked on #3605