### PR TITLE
Fall back on credential's uri when we can't find db config in other credential values

### DIFF
--- a/src/jetstream/datastore/database_cf_config.go
+++ b/src/jetstream/datastore/database_cf_config.go
@@ -110,7 +110,7 @@ func findDatabaseConfig(vcapServices map[string][]VCAPService, db *DatabaseConfi
 			}
 		}
 
-		log.Infof("Applied Cloud Foundry database service config")
+		log.Infof("Applied Cloud Foundry database service config (provider: %s)", db.DatabaseProvider)
 		return true
 	}
 	return false

--- a/src/jetstream/datastore/database_cf_config.go
+++ b/src/jetstream/datastore/database_cf_config.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -69,22 +70,48 @@ func findDatabaseConfig(vcapServices map[string][]VCAPService, db *DatabaseConfi
 	// If we found a service, then use it
 	if len(service.Name) > 0 {
 		dbCredentials := service.Credentials
+
+		log.Infof("Attempting to apply Cloud Foundry database service config from credentials")
+
+		// 1) Check db config in credentials
 		db.Username = fmt.Sprintf("%v", dbCredentials["username"])
 		db.Password = fmt.Sprintf("%v", dbCredentials["password"])
 		db.Host = fmt.Sprintf("%v", dbCredentials["hostname"])
 		db.SSLMode = "disable"
 		db.Port, _ = strconv.Atoi(fmt.Sprintf("%v", dbCredentials["port"]))
+		// Note - Both isPostgresService and isMySQLService look at the credentials uri & tags
 		if isPostgresService(service) {
 			db.DatabaseProvider = "pgsql"
 			db.Database = fmt.Sprintf("%v", dbCredentials["dbname"])
-			log.Infof("Discovered Cloud Foundry postgres service and applied config")
-			return true
 		} else if isMySQLService(service) {
 			db.DatabaseProvider = "mysql"
 			db.Database = fmt.Sprintf("%v", dbCredentials["name"])
-			log.Infof("Discovered Cloud Foundry mysql service and applied config")
-			return true
+		} else {
+			log.Infof("Cloud Foundry database service contains unsupported db type")
+			return false
 		}
+		err := validateRequiredDatabaseParams(db.Username, db.Password, db.Database, db.Host, db.Port)
+
+		if err != nil {
+			// 2) Check for db config in credentials uri
+			log.Infof("Failed to find required Cloud Foundry database service config, falling back on credential's `%v`", DB_URI)
+			uri := fmt.Sprintf("%v", dbCredentials[DB_URI])
+			if len(uri) == 0 {
+				log.Warnf("Failed to find Cloud Foundry service credential's `%v`", DB_URI)
+				return false
+			}
+
+			db.Username, db.Password, db.Host, db.Port, db.Database = findDatabaseConfigurationFromUri(uri)
+			err := validateRequiredDatabaseParams(db.Username, db.Password, db.Database, db.Host, db.Port)
+
+			if err != nil {
+				log.Warnf("Failed to find Cloud Foundry service config's from `%v`", DB_URI)
+				return false
+			}
+		}
+
+		log.Infof("Applied Cloud Foundry database service config")
+		return true
 	}
 	return false
 }
@@ -122,4 +149,23 @@ func stringInSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+func findDatabaseConfigurationFromUri(uri string) (string, string, string, int, string) {
+	re := regexp.MustCompile(`(?P<provider>.+)://(?P<username>[^:]+)(?::(?P<password>.+))?@(?P<host>[^:]+)(?::(?P<port>.+))?\/(?P<dbname>.+)`)
+	n1 := re.SubexpNames()
+	r2 := re.FindAllStringSubmatch(uri, -1)[0]
+	md := map[string]string{}
+	for i, n := range r2 {
+		md[n1[i]] = n
+	}
+
+	username := md["username"]
+	password := md["password"]
+	host := md["host"]
+	port, _ := strconv.Atoi(fmt.Sprintf("%v", md["port"]))
+	dbname := md["dbname"]
+
+	return username, password, host, port, dbname
+
 }

--- a/src/jetstream/datastore/datastore.go
+++ b/src/jetstream/datastore/datastore.go
@@ -94,7 +94,7 @@ func NewDatabaseConnectionParametersFromConfig(dc DatabaseConfig) (DatabaseConfi
 		return dc, nil
 	}
 
-	// Database Config validation - check requried values and the SSL Mode
+	// Database Config validation - check required values and the SSL Mode
 
 	err := validateRequiredDatabaseParams(dc.Username, dc.Password, dc.Database, dc.Host, dc.Port)
 	if err != nil {

--- a/src/jetstream/migrator.go
+++ b/src/jetstream/migrator.go
@@ -40,7 +40,6 @@ func dbConfFromFlags() (dbconf *goose.DBConf, err error) {
 }
 
 func migrateDatabase(env *env.VarSet) bool {
-
 	flag.Usage = usage
 	flag.Parse()
 
@@ -193,7 +192,7 @@ stratos db migration cli
 func parseCloudFoundryEnv(env *env.VarSet) (string, error) {
 	var dbEnv string
 
-	fmt.Println("Attempting to parse VCAP_SERVICES")
+	log.Info("Attempting to parse VCAP_SERVICES")
 
 	var dbConfig datastore.DatabaseConfig
 
@@ -208,10 +207,10 @@ func parseCloudFoundryEnv(env *env.VarSet) (string, error) {
 		switch dbType := env.String(DB_TYPE, "unknown"); dbType {
 		case TYPE_POSTGRES:
 			dbEnv = "cf_postgres"
-			fmt.Printf("Migrating postgresql instance on %s\n", env.String(DB_HOST, ""))
+			log.Infof("Migrating postgresql instance on %s\n", env.String(DB_HOST, ""))
 		case TYPE_MYSQL:
 			dbEnv = "cf_mysql"
-			fmt.Printf("Migrating mysql instance on %s\n", env.String(DB_HOST, ""))
+			log.Infof("Migrating mysql instance on %s\n", env.String(DB_HOST, ""))
 		default:
 			// Database service not found or type not recognized
 			return "", nil


### PR DESCRIPTION
- cf push with bound db
- usually we fetch db config from the VCAP_SERVICES service instance's credential's values
- these can be missing
- fall back on creating db config from credentials uri string
