### PR TITLE
Support separate auth and token endpoints for the console

### DIFF
--- a/src/jetstream/auth.go
+++ b/src/jetstream/auth.go
@@ -96,7 +96,7 @@ func (p *portalProxy) initSSOlogin(c echo.Context) error {
 		return err
 	}
 
-	redirectURL := fmt.Sprintf("%s/oauth/authorize?response_type=code&client_id=%s&redirect_uri=%s", p.Config.ConsoleConfig.UAAEndpoint, p.Config.ConsoleConfig.ConsoleClient, url.QueryEscape(getSSORedirectURI(state, state, "")))
+	redirectURL := fmt.Sprintf("%s/oauth/authorize?response_type=code&client_id=%s&redirect_uri=%s", p.Config.ConsoleConfig.AuthorizationEndpoint, p.Config.ConsoleConfig.ConsoleClient, url.QueryEscape(getSSORedirectURI(state, state, "")))
 	c.Redirect(http.StatusTemporaryRedirect, redirectURL)
 	return nil
 }
@@ -484,9 +484,9 @@ func (p *portalProxy) DoLoginToCNSIwithConsoleUAAtoken(c echo.Context, theCNSIre
 			return err
 		}
 
-		uaaUrl, err := url.Parse(cnsiInfo.AuthorizationEndpoint)
+		uaaUrl, err := url.Parse(cnsiInfo.TokenEndpoint)
 		if err != nil {
-			return fmt.Errorf("invalid authorization endpoint URL %s %s", cnsiInfo.AuthorizationEndpoint, err)
+			return fmt.Errorf("invalid authorization endpoint URL %s %s", cnsiInfo.TokenEndpoint, err)
 		}
 
 		if uaaUrl.String() == p.GetConfig().ConsoleConfig.UAAEndpoint.String() { // CNSI UAA server matches Console UAA server
@@ -540,7 +540,7 @@ func (p *portalProxy) fetchHttpBasicToken(cnsiRecord interfaces.CNSIRecord, c ec
 }
 
 func (p *portalProxy) FetchOAuth2Token(cnsiRecord interfaces.CNSIRecord, c echo.Context) (*interfaces.UAAResponse, *interfaces.JWTUserTokenInfo, *interfaces.CNSIRecord, error) {
-	endpoint := cnsiRecord.AuthorizationEndpoint
+	endpoint := cnsiRecord.TokenEndpoint
 
 	tokenEndpoint := fmt.Sprintf("%s/oauth/token", endpoint)
 

--- a/src/jetstream/datastore/20190515133200_AuthEndpoint.go
+++ b/src/jetstream/datastore/20190515133200_AuthEndpoint.go
@@ -1,0 +1,20 @@
+package datastore
+
+import (
+	"database/sql"
+
+	"bitbucket.org/liamstask/goose/lib/goose"
+)
+
+func init() {
+	RegisterMigration(20190515133200, "AuthEndpoint", func(txn *sql.Tx, conf *goose.DBConf) error {
+
+		addColumn := "ALTER TABLE console_config ADD auth_endpoint VARCHAR(255)"
+		_, err := txn.Exec(addColumn)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -340,12 +340,13 @@ func setSSOFromConfig(portalProxy *portalProxy, configuration *interfaces.Consol
 
 func showStratosConfig(config *interfaces.ConsoleConfig) {
 	log.Infof("Stratos is intialised with the following setup:")
-	log.Infof("... UAA Endpoint        : %s", config.UAAEndpoint)
-	log.Infof("... Console Client      : %s", config.ConsoleClient)
-	log.Infof("... Skip SSL Validation : %t", config.SkipSSLValidation)
-	log.Infof("... Setup Complete      : %t", config.IsSetupComplete)
-	log.Infof("... Admin Scope         : %s", config.ConsoleAdminScope)
-	log.Infof("... Use SSO Login       : %t", config.UseSSO)
+	log.Infof("... UAA Endpoint                  : %s", config.UAAEndpoint)
+	log.Infof("... Authorization Endpoint        : %s", config.AuthorizationEndpoint)
+	log.Infof("... Console Client                : %s", config.ConsoleClient)
+	log.Infof("... Skip SSL Validation           : %t", config.SkipSSLValidation)
+	log.Infof("... Setup Complete                : %t", config.IsSetupComplete)
+	log.Infof("... Admin Scope                   : %s", config.ConsoleAdminScope)
+	log.Infof("... Use SSO Login                 : %t", config.UseSSO)
 }
 
 func showSSOConfig(portalProxy *portalProxy) {

--- a/src/jetstream/plugins/cloudfoundryhosting/main.go
+++ b/src/jetstream/plugins/cloudfoundryhosting/main.go
@@ -194,7 +194,7 @@ func (ch *CFHosting) Init() error {
 		// Override the configuration to set the authorization endpoint
 		url, err = url.Parse(newCNSI.TokenEndpoint)
 		if err != nil {
-			return fmt.Errorf("Invalid authorization endpoint URL %s %s", newCNSI.AuthorizationEndpoint, err)
+			return fmt.Errorf("Invalid token endpoint URL %s %s", newCNSI.TokenEndpoint, err)
 		}
 
 		ch.portalProxy.GetConfig().ConsoleConfig.UAAEndpoint = url

--- a/src/jetstream/plugins/cloudfoundryhosting/main.go
+++ b/src/jetstream/plugins/cloudfoundryhosting/main.go
@@ -189,7 +189,16 @@ func (ch *CFHosting) Init() error {
 			return fmt.Errorf("Invalid authorization endpoint URL %s %s", newCNSI.AuthorizationEndpoint, err)
 		}
 
+		ch.portalProxy.GetConfig().ConsoleConfig.AuthorizationEndpoint = url
+
+		// Override the configuration to set the authorization endpoint
+		url, err = url.Parse(newCNSI.TokenEndpoint)
+		if err != nil {
+			return fmt.Errorf("Invalid authorization endpoint URL %s %s", newCNSI.AuthorizationEndpoint, err)
+		}
+
 		ch.portalProxy.GetConfig().ConsoleConfig.UAAEndpoint = url
+
 		log.Infof("Cloud Foundry UAA is: %s", ch.portalProxy.GetConfig().ConsoleConfig.UAAEndpoint)
 
 		// Not set in the environment and failed to read from the Secrets file

--- a/src/jetstream/repository/interfaces/structs.go
+++ b/src/jetstream/repository/interfaces/structs.go
@@ -217,13 +217,14 @@ type Versions struct {
 }
 
 type ConsoleConfig struct {
-	UAAEndpoint         *url.URL `json:"uaa_endpoint"`
-	ConsoleAdminScope   string   `json:"console_admin_scope"`
-	ConsoleClient       string   `json:"console_client"`
-	ConsoleClientSecret string   `json:"console_client_secret"`
-	SkipSSLValidation   bool     `json:"skip_ssl_validation"`
-	IsSetupComplete     bool     `json:"is_setup_complete"`
-	UseSSO              bool     `json:"use_sso"`
+	UAAEndpoint           *url.URL `json:"uaa_endpoint"`
+	AuthorizationEndpoint *url.URL `json:"authorization_endpoint"`
+	ConsoleAdminScope     string   `json:"console_admin_scope"`
+	ConsoleClient         string   `json:"console_client"`
+	ConsoleClientSecret   string   `json:"console_client_secret"`
+	SkipSSLValidation     bool     `json:"skip_ssl_validation"`
+	IsSetupComplete       bool     `json:"is_setup_complete"`
+	UseSSO                bool     `json:"use_sso"`
 }
 
 // CNSIRequest

--- a/src/jetstream/setup_console.go
+++ b/src/jetstream/setup_console.go
@@ -157,6 +157,10 @@ func (p *portalProxy) initialiseConsoleConfig(consoleRepo console_config.Reposit
 	if !found {
 		return consoleConfig, errors.New("UAA_Endpoint not found")
 	}
+	authEndpoint, found := p.Env().Lookup("AUTH_ENDPOINT")
+	if !found {
+		return consoleConfig, errors.New("AUTH_ENDPOINT not found")
+	}
 
 	consoleClient, found := p.Env().Lookup("CONSOLE_CLIENT")
 	if !found {
@@ -181,6 +185,9 @@ func (p *portalProxy) initialiseConsoleConfig(consoleRepo console_config.Reposit
 
 	if consoleConfig.UAAEndpoint, err = url.Parse(uaaEndpoint); err != nil {
 		return consoleConfig, fmt.Errorf("Unable to parse UAA Endpoint: %v", err)
+	}
+	if consoleConfig.AuthorizationEndpoint, err = url.Parse(authEndpoint); err != nil {
+		return consoleConfig, fmt.Errorf("Unable to parse Authorization Endpoint: %v", err)
 	}
 
 	consoleConfig.ConsoleAdminScope = consoleAdminScope

--- a/src/jetstream/setup_console.go
+++ b/src/jetstream/setup_console.go
@@ -159,7 +159,7 @@ func (p *portalProxy) initialiseConsoleConfig(consoleRepo console_config.Reposit
 	}
 	authEndpoint, found := p.Env().Lookup("AUTH_ENDPOINT")
 	if !found {
-		return consoleConfig, errors.New("AUTH_ENDPOINT not found")
+		authEndpoint = uaaEndpoint
 	}
 
 	consoleClient, found := p.Env().Lookup("CONSOLE_CLIENT")


### PR DESCRIPTION
This is PR creates a new console config for Auth Endpoint. Before this PR, there was only "UAA Endpoint", which was the auth_endpoint from /v2/info. Since /v2/info contains both auth_endpint and token_endpoint and they are used for different types of requests, they should also be separate in Stratos.

## Description
-Added new AuthorizationEndpoint in ConsoleConfig
-Use the AuthorizationEndpoint only for /oauth/authorize redirect
-Use the UAAEndpoint for all /oauth/token calls
-Make necessary DB changes and DB migration

## Motivation and Context
-While today the authorization endpoint is used for both /oauth/authorize and /oauth/token, and this works for most of the time, we have a use case in which the authorization endpoint cannot be used to do /oauth/token. By the /v2/info standard, token_endpoint should be used to retrieve tokens, and auth_endpoint should be used for oauth redirect.

## How Has This Been Tested?
I tested this using a CF and Docker AIO install on our environments.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message