### PR TITLE
Ensure we're not looking at production version of env file

### DIFF
--- a/src/frontend/packages/core/src/main.ts
+++ b/src/frontend/packages/core/src/main.ts
@@ -1,6 +1,6 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { environment } from './environments/environment.prod';
+import { environment } from './environments/environment';
 import { AppModule } from './app.module';
 
 if (environment.production) {


### PR DESCRIPTION
See here https://angular.io/guide/build#configuring-application-environments for the explanation as to why we should reference the default environment file.