### PR TITLE
Entity catalogue: List Fixes

### DIFF
--- a/src/frontend/packages/core/src/core/entity-catalogue/entity-catalogue-entity.ts
+++ b/src/frontend/packages/core/src/core/entity-catalogue/entity-catalogue-entity.ts
@@ -1,21 +1,22 @@
-import {
-  IEntityMetadata,
-  IStratosEntityDefinition,
-  EntityCatalogueSchemas,
-  IStratosEndpointDefinition,
-  IStratosEntityBuilder,
-  IStratosEndpointWithoutSchemaDefinition,
-  IStratosBaseEntityDefinition
-} from './entity-catalogue.types';
 import { Store } from '@ngrx/store';
-import { GeneralEntityAppState, AppState } from '../../../../store/src/app-state';
-import { EntityCatalogueHelpers } from './entity-catalogue.helper';
-import { IEndpointFavMetadata } from '../../../../store/src/types/user-favorites.types';
-import { EndpointModel } from '../../../../store/src/types/endpoint.types';
-import { getFullEndpointApiUrl } from '../../features/endpoints/endpoint-helpers';
-import { endpointEntitySchema } from '../../base-entity-schemas';
+
+import { AppState } from '../../../../store/src/app-state';
 import { EntitySchema } from '../../../../store/src/helpers/entity-schema';
+import { EndpointModel } from '../../../../store/src/types/endpoint.types';
+import { IEndpointFavMetadata } from '../../../../store/src/types/user-favorites.types';
+import { endpointEntitySchema } from '../../base-entity-schemas';
+import { getFullEndpointApiUrl } from '../../features/endpoints/endpoint-helpers';
 import { EntityMonitor } from '../../shared/monitors/entity-monitor';
+import { EntityCatalogueHelpers } from './entity-catalogue.helper';
+import {
+  EntityCatalogueSchemas,
+  IEntityMetadata,
+  IStratosBaseEntityDefinition,
+  IStratosEndpointDefinition,
+  IStratosEndpointWithoutSchemaDefinition,
+  IStratosEntityBuilder,
+  IStratosEntityDefinition,
+} from './entity-catalogue.types';
 
 export class StratosBaseCatalogueEntity<T extends IEntityMetadata = IEntityMetadata, Y = any> {
   public readonly entityKey: string;
@@ -63,7 +64,7 @@ export class StratosBaseCatalogueEntity<T extends IEntityMetadata = IEntityMetad
       return catalogueSchema.default;
     }
     const entityCatalogue = this.definition as IStratosEntityDefinition;
-    const tempId = EntityCatalogueHelpers.buildEntityKey(entityCatalogue.endpoint.type, schemaKey);
+    const tempId = EntityCatalogueHelpers.buildEntityKey(schemaKey, entityCatalogue.endpoint.type);
     if (!catalogueSchema[schemaKey] && tempId === this.entityKey) {
       // We've requested the default by passing the schema key that matches the entity type
       return catalogueSchema.default;

--- a/src/frontend/packages/core/src/core/entity-catalogue/entity-catalogue.service.ts
+++ b/src/frontend/packages/core/src/core/entity-catalogue/entity-catalogue.service.ts
@@ -1,11 +1,12 @@
-import {
-  IEntityMetadata,
-  EntityCatalogueEntityConfig,
-  IStratosBaseEntityDefinition,
-} from './entity-catalogue.types';
-import { EntityCatalogueHelpers } from './entity-catalogue.helper';
 import { STRATOS_ENDPOINT_TYPE } from '../../base-entity-schemas';
-import { StratosCatalogueEntity, StratosCatalogueEndpointEntity, StratosBaseCatalogueEntity } from './entity-catalogue-entity';
+import {
+  StratosBaseCatalogueEntity,
+  StratosCatalogueEndpointEntity,
+  StratosCatalogueEntity,
+} from './entity-catalogue-entity';
+import { EntityCatalogueHelpers } from './entity-catalogue.helper';
+import { EntityCatalogueEntityConfig, IEntityMetadata, IStratosBaseEntityDefinition } from './entity-catalogue.types';
+
 class EntityCatalogue {
   private entities: Map<string, StratosCatalogueEntity> = new Map();
   private endpoints: Map<string, StratosCatalogueEndpointEntity> = new Map();

--- a/src/frontend/packages/core/src/core/entity-service.spec.ts
+++ b/src/frontend/packages/core/src/core/entity-service.spec.ts
@@ -7,6 +7,7 @@ import { filter, first, map, pairwise, tap } from 'rxjs/operators';
 import { GetApplication } from '../../../store/src/actions/application.actions';
 import { APIResponse } from '../../../store/src/actions/request.actions';
 import { GeneralAppState } from '../../../store/src/app-state';
+import { EntitySchema } from '../../../store/src/helpers/entity-schema';
 import {
   completeApiRequest,
   failApiRequest,
@@ -15,18 +16,16 @@ import {
 import { RequestSectionKeys } from '../../../store/src/reducers/api-request-reducer/types';
 import { NormalizedResponse } from '../../../store/src/types/api.types';
 import { ICFAction, IRequestAction } from '../../../store/src/types/request.types';
+import { EntityCatalogueTestHelper } from '../../test-framework/entity-catalogue-test-helpers';
 import { generateTestEntityServiceProvider } from '../../test-framework/entity-service.helper';
 import { createEntityStore, TestStoreEntity } from '../../test-framework/store-test-helper';
 import { ENTITY_SERVICE } from '../shared/entity.tokens';
 import { EntityMonitor } from '../shared/monitors/entity-monitor';
 import { EntityMonitorFactory } from '../shared/monitors/entity-monitor.factory.service';
-import { EntityService } from './entity-service';
-import { EntityServiceFactory } from './entity-service-factory.service';
-import { EntitySchema } from '../../../store/src/helpers/entity-schema';
-import { entityCatalogue } from './entity-catalogue/entity-catalogue.service';
 import { StratosBaseCatalogueEntity } from './entity-catalogue/entity-catalogue-entity';
 import { EntityCatalogueEntityConfig } from './entity-catalogue/entity-catalogue.types';
-import { EntityCatalogueTestHelper } from '../../test-framework/entity-catalogue-test-helpers';
+import { EntityService } from './entity-service';
+import { EntityServiceFactory } from './entity-service-factory.service';
 
 const endpointType = 'endpoint1';
 const entitySchema = new EntitySchema('child2', endpointType);

--- a/src/frontend/packages/core/src/shared/components/list/data-sources-controllers/list-data-source.ts
+++ b/src/frontend/packages/core/src/shared/components/list/data-sources-controllers/list-data-source.ts
@@ -28,6 +28,7 @@ import { ListFilter, ListSort } from '../../../../../../store/src/actions/list.a
 import { MetricsAction } from '../../../../../../store/src/actions/metrics.actions';
 import { SetResultCount } from '../../../../../../store/src/actions/pagination.actions';
 import { CFAppState } from '../../../../../../store/src/app-state';
+import { EntitySchema } from '../../../../../../store/src/helpers/entity-schema';
 import { getPaginationObservables } from '../../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import {
   PaginatedAction,
@@ -35,6 +36,7 @@ import {
   PaginationParam,
   QParam,
 } from '../../../../../../store/src/types/pagination.types';
+import { entityCatalogue } from '../../../../core/entity-catalogue/entity-catalogue.service';
 import { PaginationMonitor } from '../../../monitors/pagination-monitor';
 import { IListDataSourceConfig, MultiActionConfig } from './list-data-source-config';
 import {
@@ -49,8 +51,6 @@ import {
 import { getDataFunctionList } from './local-filtering-sorting';
 import { LocalListController } from './local-list-controller';
 import { LocalPaginationHelpers } from './local-list.helpers';
-import { entityCatalogue } from '../../../../core/entity-catalogue/entity-catalogue.service';
-import { EntitySchema } from '../../../../../../store/src/helpers/entity-schema';
 
 export class DataFunctionDefinition {
   type: 'sort' | 'filter';

--- a/src/frontend/packages/core/src/shared/components/list/data-sources-controllers/local-list-controller.ts
+++ b/src/frontend/packages/core/src/shared/components/list/data-sources-controllers/local-list-controller.ts
@@ -57,9 +57,7 @@ export class LocalListController<T = any> {
           return { paginationEntity, entities: [] };
         }
         if (dataFunctions && dataFunctions.length) {
-          entities = dataFunctions.reduce((value, fn) => {
-            return fn(value, paginationEntity);
-          }, entities);
+          entities = dataFunctions.reduce((value, fn) => fn(value, paginationEntity), entities);
         }
         return { paginationEntity, entities };
       }),

--- a/src/frontend/packages/core/src/shared/components/list/data-sources-controllers/local-list.helpers.ts
+++ b/src/frontend/packages/core/src/shared/components/list/data-sources-controllers/local-list.helpers.ts
@@ -1,5 +1,4 @@
 import { PaginationEntityState } from '../../../../../../store/src/types/pagination.types';
-import { entityCatalogue } from '../../../../core/entity-catalogue/entity-catalogue.service';
 import { EntityCatalogueHelpers } from '../../../../core/entity-catalogue/entity-catalogue.helper';
 
 export class LocalPaginationHelpers {

--- a/src/frontend/packages/core/src/shared/components/list/data-sources-controllers/local-list.helpers.ts
+++ b/src/frontend/packages/core/src/shared/components/list/data-sources-controllers/local-list.helpers.ts
@@ -21,7 +21,7 @@ export class LocalPaginationHelpers {
     const pageNumber = Object.keys(pagination.pageRequests).find(key => {
       const entityType = pageRequests[key].baseEntityConfig.entityType;
       const endpointType = pageRequests[key].baseEntityConfig.endpointType;
-      const baseEntityKey = EntityCatalogueHelpers.buildEntityKey(endpointType, entityType);
+      const baseEntityKey = EntityCatalogueHelpers.buildEntityKey(entityType, endpointType);
       return baseEntityKey === entityKey;
     }) || null;
     if (pageNumber) {

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/base-endpoints-data-source.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/base-endpoints-data-source.ts
@@ -31,13 +31,19 @@ export function syncPaginationSection(
 
 export class BaseEndpointsDataSource extends ListDataSource<EndpointModel> {
   store: Store<CFAppState>;
-  cnsiType: string;
+  /**
+   * Used to distinguish between data sources providing all endpoints or those that only provide endpoints matching this value.
+   * Value should match those of an endpoint's `cnsi_type`.
+   *
+   * Note - Should not be renamed to endpointType to avoid clash with ListDataSource endpointType
+   */
+  dsEndpointType: string;
 
   constructor(
     store: Store<CFAppState>,
     listConfig: IListConfig<EndpointModel>,
     action: GetAllEndpoints,
-    cnsiType: string = null,
+    dsEndpointType: string = null,
     paginationMonitorFactory: PaginationMonitorFactory,
     entityMonitorFactory: EntityMonitorFactory,
     internalEventMonitorFactory: InternalEventMonitorFactory,
@@ -69,9 +75,9 @@ export class BaseEndpointsDataSource extends ListDataSource<EndpointModel> {
       paginationKey: action.paginationKey,
       transformEntities: [
         (entities: EndpointModel[]) => {
-          return cnsiType || onlyConnected ? entities.filter(endpoint => {
+          return dsEndpointType || onlyConnected ? entities.filter(endpoint => {
             return (!onlyConnected || endpoint.connectionStatus === 'connected') &&
-              (!cnsiType || endpoint.cnsi_type === cnsiType);
+              (!dsEndpointType || endpoint.cnsi_type === dsEndpointType);
           }) : entities;
         },
         {
@@ -80,7 +86,7 @@ export class BaseEndpointsDataSource extends ListDataSource<EndpointModel> {
         },
       ],
     });
-    this.cnsiType = cnsiType;
+    this.dsEndpointType = dsEndpointType;
   }
   // TODO Fix the typing
   static getEndpointConfig(

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/base-endpoints-data-source.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/base-endpoints-data-source.ts
@@ -31,13 +31,13 @@ export function syncPaginationSection(
 
 export class BaseEndpointsDataSource extends ListDataSource<EndpointModel> {
   store: Store<CFAppState>;
-  endpointType: string;
+  cnsiType: string;
 
   constructor(
     store: Store<CFAppState>,
     listConfig: IListConfig<EndpointModel>,
     action: GetAllEndpoints,
-    endpointType: string = null,
+    cnsiType: string = null,
     paginationMonitorFactory: PaginationMonitorFactory,
     entityMonitorFactory: EntityMonitorFactory,
     internalEventMonitorFactory: InternalEventMonitorFactory,
@@ -69,9 +69,9 @@ export class BaseEndpointsDataSource extends ListDataSource<EndpointModel> {
       paginationKey: action.paginationKey,
       transformEntities: [
         (entities: EndpointModel[]) => {
-          return endpointType || onlyConnected ? entities.filter(endpoint => {
+          return cnsiType || onlyConnected ? entities.filter(endpoint => {
             return (!onlyConnected || endpoint.connectionStatus === 'connected') &&
-              (!endpointType || endpoint.cnsi_type === endpointType);
+              (!cnsiType || endpoint.cnsi_type === cnsiType);
           }) : entities;
         },
         {
@@ -80,7 +80,7 @@ export class BaseEndpointsDataSource extends ListDataSource<EndpointModel> {
         },
       ],
     });
-    this.endpointType = endpointType;
+    this.cnsiType = cnsiType;
   }
   // TODO Fix the typing
   static getEndpointConfig(

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/endpoint-card/endpoint-card.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/endpoint-card/endpoint-card.component.ts
@@ -88,7 +88,7 @@ export class EndpointCardComponent extends CardCell<EndpointModel> implements On
   set dataSource(ds: BaseEndpointsDataSource) {
     this.pDs = ds;
     // Don't show card menu if the ds only provides a single endpoint type (for instance the cf endpoint page)
-    if (ds && !ds.cnsiType && !this.cardMenu) {
+    if (ds && !ds.dsEndpointType && !this.cardMenu) {
       this.cardMenu = this.endpointListHelper.endpointActions().map(endpointAction => ({
         label: endpointAction.label,
         action: () => endpointAction.action(this.pRow),

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/endpoint-card/endpoint-card.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/endpoint-card/endpoint-card.component.ts
@@ -16,19 +16,19 @@ import { SetHeaderEvent } from '../../../../../../../../store/src/actions/dashbo
 import { CFAppState } from '../../../../../../../../store/src/app-state';
 import { EndpointModel } from '../../../../../../../../store/src/types/endpoint.types';
 import { UserFavoriteEndpoint } from '../../../../../../../../store/src/types/user-favorites.types';
+import { StratosCatalogueEndpointEntity } from '../../../../../../core/entity-catalogue/entity-catalogue-entity';
+import { entityCatalogue } from '../../../../../../core/entity-catalogue/entity-catalogue.service';
 import { safeUnsubscribe } from '../../../../../../core/utils.service';
 import {
   coreEndpointListDetailsComponents,
   getFullEndpointApiUrl,
 } from '../../../../../../features/endpoints/endpoint-helpers';
 import { StratosStatus } from '../../../../../shared.types';
+import { FavoritesConfigMapper } from '../../../../favorites-meta-card/favorite-config-mapper';
 import { MetaCardMenuItem } from '../../../list-cards/meta-card/meta-card-base/meta-card.component';
 import { CardCell } from '../../../list.types';
 import { BaseEndpointsDataSource } from '../base-endpoints-data-source';
 import { EndpointListDetailsComponent, EndpointListHelper } from '../endpoint-list.helpers';
-import { FavoritesConfigMapper } from '../../../../favorites-meta-card/favorite-config-mapper';
-import { entityCatalogue } from '../../../../../../core/entity-catalogue/entity-catalogue.service';
-import { StratosCatalogueEndpointEntity } from '../../../../../../core/entity-catalogue/entity-catalogue-entity';
 
 @Component({
   selector: 'app-endpoint-card',
@@ -88,7 +88,7 @@ export class EndpointCardComponent extends CardCell<EndpointModel> implements On
   set dataSource(ds: BaseEndpointsDataSource) {
     this.pDs = ds;
     // Don't show card menu if the ds only provides a single endpoint type (for instance the cf endpoint page)
-    if (ds && !ds.endpointType && !this.cardMenu) {
+    if (ds && !ds.cnsiType && !this.cardMenu) {
       this.cardMenu = this.endpointListHelper.endpointActions().map(endpointAction => ({
         label: endpointAction.label,
         action: () => endpointAction.action(this.pRow),

--- a/src/frontend/packages/core/src/shared/components/list/list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list.component.ts
@@ -16,7 +16,6 @@ import {
 import { NgForm, NgModel } from '@angular/forms';
 import { MatPaginator, PageEvent, SortDirection } from '@angular/material';
 import { Store } from '@ngrx/store';
-import { schema as normalizrSchema } from 'normalizr';
 import {
   asapScheduler,
   BehaviorSubject,
@@ -53,8 +52,9 @@ import { SetPage } from '../../../../../store/src/actions/pagination.actions';
 import { CFAppState } from '../../../../../store/src/app-state';
 import { ActionState } from '../../../../../store/src/reducers/api-request-reducer/types';
 import { getListStateObservables } from '../../../../../store/src/reducers/list.reducer';
+import { entityCatalogue } from '../../../core/entity-catalogue/entity-catalogue.service';
+import { EntityCatalogueEntityConfig } from '../../../core/entity-catalogue/entity-catalogue.types';
 import { safeUnsubscribe } from '../../../core/utils.service';
-import { EntityMonitor } from '../../monitors/entity-monitor';
 import {
   EntitySelectConfig,
   getDefaultRowState,
@@ -74,9 +74,6 @@ import {
   ListViewTypes,
   MultiFilterManager,
 } from './list.component.types';
-import { entityCatalogue } from '../../../core/entity-catalogue/entity-catalogue.service';
-import { EntitySchema } from '../../../../../store/src/helpers/entity-schema';
-import { EntityCatalogueEntityConfig } from '../../../core/entity-catalogue/entity-catalogue.types';
 
 @Component({
   selector: 'app-list',

--- a/src/frontend/packages/core/src/shared/monitors/entity-monitor.factory.service.ts
+++ b/src/frontend/packages/core/src/shared/monitors/entity-monitor.factory.service.ts
@@ -1,10 +1,10 @@
-import { CFAppState } from './../../../../store/src/app-state';
 import { Injectable } from '@angular/core';
-import { EntityMonitor } from './entity-monitor';
 import { Store } from '@ngrx/store';
-import { schema as normalizrSchema } from 'normalizr';
-import { EntityCatalogueEntityConfig } from '../../core/entity-catalogue/entity-catalogue.types';
+
 import { entityCatalogue } from '../../core/entity-catalogue/entity-catalogue.service';
+import { EntityCatalogueEntityConfig } from '../../core/entity-catalogue/entity-catalogue.types';
+import { CFAppState } from './../../../../store/src/app-state';
+import { EntityMonitor } from './entity-monitor';
 
 @Injectable()
 export class EntityMonitorFactory {

--- a/src/frontend/packages/core/src/shared/monitors/pagination-monitor.factory.ts
+++ b/src/frontend/packages/core/src/shared/monitors/pagination-monitor.factory.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
-import { PaginationMonitor } from './pagination-monitor';
 import { Store } from '@ngrx/store';
+
 import { CFAppState } from '../../../../store/src/app-state';
-import { EntityCatalogueEntityConfig } from '../../core/entity-catalogue/entity-catalogue.types';
 import { entityCatalogue } from '../../core/entity-catalogue/entity-catalogue.service';
+import { EntityCatalogueEntityConfig } from '../../core/entity-catalogue/entity-catalogue.types';
+import { PaginationMonitor } from './pagination-monitor';
 
 @Injectable()
 export class PaginationMonitorFactory {

--- a/src/frontend/packages/core/src/shared/monitors/pagination-monitor.ts
+++ b/src/frontend/packages/core/src/shared/monitors/pagination-monitor.ts
@@ -14,18 +14,17 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 
-import { GeneralEntityAppState, AppState, GeneralRequestDataState } from '../../../../store/src/app-state';
+import { AppState, GeneralEntityAppState, GeneralRequestDataState } from '../../../../store/src/app-state';
+import { EntitySchema } from '../../../../store/src/helpers/entity-schema';
 import { ActionState, ListActionState } from '../../../../store/src/reducers/api-request-reducer/types';
 import { getAPIRequestDataState, selectEntities } from '../../../../store/src/selectors/api.selectors';
 import { selectPaginationState } from '../../../../store/src/selectors/pagination.selectors';
-import { BaseRequestDataState } from '../../../../store/src/types/entity.types';
 import { PaginationEntityState } from '../../../../store/src/types/pagination.types';
-import { LocalPaginationHelpers } from '../components/list/data-sources-controllers/local-list.helpers';
-import { EntitySchema } from '../../../../store/src/helpers/entity-schema';
-import { EntityCatalogueHelpers } from '../../core/entity-catalogue/entity-catalogue.helper';
 import { StratosBaseCatalogueEntity } from '../../core/entity-catalogue/entity-catalogue-entity';
+import { EntityCatalogueHelpers } from '../../core/entity-catalogue/entity-catalogue.helper';
 import { entityCatalogue } from '../../core/entity-catalogue/entity-catalogue.service';
 import { EntityCatalogueEntityConfig } from '../../core/entity-catalogue/entity-catalogue.types';
+import { LocalPaginationHelpers } from '../components/list/data-sources-controllers/local-list.helpers';
 
 export class MultiActionListEntity {
   static getEntity(entity: MultiActionListEntity | any) {
@@ -79,7 +78,7 @@ export class PaginationMonitor<T = any, Y extends AppState = GeneralEntityAppSta
       schemaKey = ''
     }: any
   ) {
-    // This is a static on the pagintion monitor rather than a member of StratosBaseCatalogueEntity due to 
+    // This is a static on the pagintion monitor rather than a member of StratosBaseCatalogueEntity due to
     // a circular dependency on entityFactory from the getPageInfo function below.
     const schema = catalogueEntity.getSchema(schemaKey);
     return new PaginationMonitor(store, paginationKey, schema, isLocal);

--- a/src/frontend/packages/core/src/shared/monitors/pagination-monitor.ts
+++ b/src/frontend/packages/core/src/shared/monitors/pagination-monitor.ts
@@ -250,7 +250,7 @@ export class PaginationMonitor<T = any, Y extends AppState = GeneralEntityAppSta
       map(([pagination]) => {
         return Object.values(pagination.pageRequests).reduce((entityKeys, pageRequest) => {
           const { entityConfig } = pageRequest;
-          const key = EntityCatalogueHelpers.buildEntityKey(entityConfig.endpointType, entityConfig.entityType);
+          const key = EntityCatalogueHelpers.buildEntityKey(entityConfig.entityType, entityConfig.endpointType);
           if (key && !entityKeys.includes(key)) {
             entityKeys.push(key);
           }

--- a/src/frontend/packages/store/src/actions/endpoint.actions.ts
+++ b/src/frontend/packages/store/src/actions/endpoint.actions.ts
@@ -1,12 +1,12 @@
 import { Action } from '@ngrx/store';
 
+import { CF_ENDPOINT_TYPE } from '../../../cloud-foundry/cf-types';
+import { STRATOS_ENDPOINT_TYPE } from '../../../core/src/base-entity-schemas';
 import { EndpointType } from '../../../core/src/core/extension/extension-types';
 import { endpointSchemaKey } from '../helpers/entity-factory';
 import { NormalizedResponse } from '../types/api.types';
 import { endpointListKey, EndpointModel, INewlyConnectedEndpointInfo } from '../types/endpoint.types';
 import { PaginatedAction } from '../types/pagination.types';
-import { CF_ENDPOINT_TYPE } from '../../../cloud-foundry/cf-types';
-import { STRATOS_ENDPOINT_TYPE } from '../../../core/src/base-entity-schemas';
 
 export const GET_ENDPOINTS = '[Endpoints] Get all';
 export const GET_ENDPOINTS_START = '[Endpoints] Get all start';

--- a/src/frontend/packages/store/src/effects/endpoint.effects.ts
+++ b/src/frontend/packages/store/src/effects/endpoint.effects.ts
@@ -4,6 +4,9 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { catchError, mergeMap } from 'rxjs/operators';
 
+import { STRATOS_ENDPOINT_TYPE } from '../../../core/src/base-entity-schemas';
+import { EntityCatalogueHelpers } from '../../../core/src/core/entity-catalogue/entity-catalogue.helper';
+import { entityCatalogue } from '../../../core/src/core/entity-catalogue/entity-catalogue.service';
 import { EndpointType } from '../../../core/src/core/extension/extension-types';
 import { BrowserStandardEncoder } from '../../../core/src/helper';
 import {
@@ -36,7 +39,7 @@ import { CFAppState } from '../app-state';
 import { endpointSchemaKey } from '../helpers/entity-factory';
 import { ApiRequestTypes } from '../reducers/api-request-reducer/request-helpers';
 import { NormalizedResponse } from '../types/api.types';
-import { EndpointModel, endpointStoreNames } from '../types/endpoint.types';
+import { EndpointModel } from '../types/endpoint.types';
 import {
   IRequestAction,
   StartRequestAction,
@@ -44,9 +47,6 @@ import {
   WrapperRequestActionSuccess,
 } from '../types/request.types';
 import { PaginatedAction } from './../types/pagination.types';
-import { EntityCatalogueHelpers } from '../../../core/src/core/entity-catalogue/entity-catalogue.helper';
-import { entityCatalogue } from '../../../core/src/core/entity-catalogue/entity-catalogue.service';
-import { STRATOS_ENDPOINT_TYPE } from '../../../core/src/base-entity-schemas';
 
 
 @Injectable()

--- a/src/frontend/packages/store/src/effects/user-favorites-effect.ts
+++ b/src/frontend/packages/store/src/effects/user-favorites-effect.ts
@@ -4,6 +4,8 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { catchError, first, map, mergeMap, switchMap } from 'rxjs/operators';
 
+import { userFavoritesEntitySchema } from '../../../core/src/base-entity-schemas';
+import { entityCatalogue } from '../../../core/src/core/entity-catalogue/entity-catalogue.service';
 import { UserFavoriteManager } from '../../../core/src/core/user-favorite-manager';
 import { environment } from '../../../core/src/environments/environment.prod';
 import { ClearPaginationOfEntity } from '../actions/pagination.actions';
@@ -30,8 +32,6 @@ import { NormalizedResponse } from '../types/api.types';
 import { PaginatedAction } from '../types/pagination.types';
 import { WrapperRequestActionSuccess } from '../types/request.types';
 import { IFavoriteMetadata, UserFavorite, userFavoritesPaginationKey } from '../types/user-favorites.types';
-import { userFavoritesEntitySchema } from '../../../core/src/base-entity-schemas';
-import { entityCatalogue } from '../../../core/src/core/entity-catalogue/entity-catalogue.service';
 
 const { proxyAPIVersion } = environment;
 const favoriteUrlPath = `/pp/${proxyAPIVersion}/favorites`;

--- a/src/frontend/packages/store/src/helpers/entity-relations/entity-relations.ts
+++ b/src/frontend/packages/store/src/helpers/entity-relations/entity-relations.ts
@@ -524,7 +524,7 @@ export function populatePaginationFromParent(store: Store<GeneralEntityAppState>
           const catalogueEntity = entityCatalogue.getEntity(eicAction);
           const entityKey = catalogueEntity.entityKey;
           const normedEntities = entity.entity[paramName].reduce((normedEntities, entity) => {
-            const guid = typeof(entity) === 'string' ? entity : catalogueEntity.getGuidFromEntity(entity);
+            const guid = typeof (entity) === 'string' ? entity : catalogueEntity.getGuidFromEntity(entity);
             normedEntities[entityKey][guid] = entity;
             return normedEntities;
           }, { [entityKey]: {} });

--- a/src/frontend/packages/store/src/helpers/entity-schema.ts
+++ b/src/frontend/packages/store/src/helpers/entity-schema.ts
@@ -1,6 +1,7 @@
 import { Schema, schema } from 'normalizr';
-import { EntityCatalogueEntityConfig } from '../../../core/src/core/entity-catalogue/entity-catalogue.types';
+
 import { EntityCatalogueHelpers } from '../../../core/src/core/entity-catalogue/entity-catalogue.helper';
+import { EntityCatalogueEntityConfig } from '../../../core/src/core/entity-catalogue/entity-catalogue.types';
 
 /**
  * Mostly a wrapper around schema.Entity. Allows a lot of uniformity of types through console. Includes some minor per entity type config

--- a/src/frontend/packages/store/src/reducers/api-request-data-reducer/request-data-reducer.factory.ts
+++ b/src/frontend/packages/store/src/reducers/api-request-data-reducer/request-data-reducer.factory.ts
@@ -1,13 +1,13 @@
 import { Action } from '@ngrx/store';
 
+import { entityCatalogue } from '../../../../core/src/core/entity-catalogue/entity-catalogue.service';
+import { getDefaultStateFromEntityCatalogue } from '../../../../core/src/core/entity-catalogue/entity-catalogue.store-setup';
 import { RECURSIVE_ENTITY_SET_DELETED, SetTreeDeleted } from '../../effects/recursive-entity-delete.effect';
 import { deepMergeState } from '../../helpers/reducer.helper';
 import { IFlatTree } from '../../helpers/schema-tree-traverse';
 import { BaseRequestDataState } from '../../types/entity.types';
 import { ISuccessRequestAction } from '../../types/request.types';
 import { IRequestArray } from '../api-request-reducer/types';
-import { entityCatalogue } from '../../../../core/src/core/entity-catalogue/entity-catalogue.service';
-import { getDefaultStateFromEntityCatalogue } from '../../../../core/src/core/entity-catalogue/entity-catalogue.store-setup';
 
 
 export function requestDataReducerFactory(actions: IRequestArray) {

--- a/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer-clear-pagination-of-entity.ts
+++ b/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer-clear-pagination-of-entity.ts
@@ -1,7 +1,7 @@
-import { ClearPaginationOfEntity } from '../../actions/pagination.actions';
-import { PaginationState, PaginationEntityState } from '../../types/pagination.types';
-import { spreadClientPagination } from './pagination-reducer.helper';
 import { EntityCatalogueHelpers } from '../../../../core/src/core/entity-catalogue/entity-catalogue.helper';
+import { ClearPaginationOfEntity } from '../../actions/pagination.actions';
+import { PaginationEntityState, PaginationState } from '../../types/pagination.types';
+import { spreadClientPagination } from './pagination-reducer.helper';
 
 export function paginationClearOfEntity(state: PaginationState, action: ClearPaginationOfEntity) {
   // Remove entities from a pagination list. Used for quickly showing the result of a delete

--- a/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer-create-pagination.ts
+++ b/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer-create-pagination.ts
@@ -1,9 +1,9 @@
+import { EntityCatalogueHelpers } from '../../../../core/src/core/entity-catalogue/entity-catalogue.helper';
+import { EntityCatalogueEntityConfig } from '../../../../core/src/core/entity-catalogue/entity-catalogue.types';
 import { CreatePagination } from '../../actions/pagination.actions';
 import { PaginationEntityState, PaginationState } from '../../types/pagination.types';
 import { spreadClientPagination } from './pagination-reducer.helper';
-import { EntityCatalogueHelpers } from '../../../../core/src/core/entity-catalogue/entity-catalogue.helper';
-import { EntityCatalogueEntityConfig } from '../../../../core/src/core/entity-catalogue/entity-catalogue.types';
-import { RegisterEntitiesAction } from '../../../../core/src/core/entity-catalogue/entity-catalogue.actions';
+
 function getPaginationKey(entityConfig: EntityCatalogueEntityConfig) {
   return EntityCatalogueHelpers.buildEntityKey(entityConfig.endpointType, entityConfig.entityType);
 }

--- a/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer-create-pagination.ts
+++ b/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer-create-pagination.ts
@@ -5,7 +5,7 @@ import { PaginationEntityState, PaginationState } from '../../types/pagination.t
 import { spreadClientPagination } from './pagination-reducer.helper';
 
 function getPaginationKey(entityConfig: EntityCatalogueEntityConfig) {
-  return EntityCatalogueHelpers.buildEntityKey(entityConfig.endpointType, entityConfig.entityType);
+  return EntityCatalogueHelpers.buildEntityKey(entityConfig.entityType, entityConfig.endpointType);
 }
 /**
  * Creates new pagination from default values or a seed pagination section.

--- a/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer-reset-pagination.ts
+++ b/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer-reset-pagination.ts
@@ -1,6 +1,6 @@
+import { EntityCatalogueHelpers } from '../../../../core/src/core/entity-catalogue/entity-catalogue.helper';
 import { ResetPagination } from '../../actions/pagination.actions';
 import { PaginationEntityState, PaginationEntityTypeState, PaginationState } from '../../types/pagination.types';
-import { EntityCatalogueHelpers } from '../../../../core/src/core/entity-catalogue/entity-catalogue.helper';
 
 export const defaultClientPaginationPageSize = 9;
 

--- a/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer-start.ts
+++ b/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer-start.ts
@@ -1,5 +1,5 @@
-import { PaginationEntityState } from '../../types/pagination.types';
 import { EntityCatalogueEntityConfig } from '../../../../core/src/core/entity-catalogue/entity-catalogue.types';
+import { PaginationEntityState } from '../../types/pagination.types';
 
 export function paginationStart(state, action): PaginationEntityState {
   const page = action.apiAction.__forcedPageNumber__ || action.apiAction.pageNumber || state.currentPage;

--- a/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer.helper.ts
+++ b/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer.helper.ts
@@ -13,11 +13,12 @@ import {
   tap,
 } from 'rxjs/operators';
 
+import { entityCatalogue } from '../../../../core/src/core/entity-catalogue/entity-catalogue.service';
 import { sortStringify } from '../../../../core/src/core/utils.service';
 import { PaginationMonitor } from '../../../../core/src/shared/monitors/pagination-monitor';
 import { AddParams, SetInitialParams, SetParams } from '../../actions/pagination.actions';
 import { ValidateEntitiesStart } from '../../actions/request.actions';
-import { GeneralEntityAppState, AppState } from '../../app-state';
+import { AppState, GeneralEntityAppState } from '../../app-state';
 import { populatePaginationFromParent } from '../../helpers/entity-relations/entity-relations';
 import { selectEntities } from '../../selectors/api.selectors';
 import { selectPaginationState } from '../../selectors/pagination.selectors';
@@ -29,8 +30,6 @@ import {
   QParam,
 } from '../../types/pagination.types';
 import { ActionState } from '../api-request-reducer/types';
-import { entityCatalogue } from '../../../../core/src/core/entity-catalogue/entity-catalogue.service';
-import { _YAxis } from '@angular/cdk/scrolling';
 
 export interface PaginationObservables<T> {
   pagination$: Observable<PaginationEntityState>;
@@ -110,17 +109,23 @@ export function getAction(action): PaginatedAction {
   if (!action) {
     return null;
   }
-  if (action.entityConfig) {
-    return action.entityConfig;
-  }
   return action.apiAction ? action.apiAction : action;
 }
 
 // TODO We need types here. This might lead us to tidy up all of our actions.
-export function getActionPaginationEntityKey(action) {
+function getEntityConfigFromAction(action): PaginatedAction {
+  if (action && action.entityConfig) {
+    return action.entityConfig;
+  }
+  return getAction(action);
+}
+
+// TODO We need types here. This might lead us to tidy up all of our actions.
+export function getActionPaginationEntityKey(action): string {
   const apiAction = getAction(action);
-  const entityType = apiAction.proxyPaginationEntityKey || apiAction.entityType;
-  return entityCatalogue.getEntityKey(apiAction.endpointType, entityType);
+  const entityConfig = getEntityConfigFromAction(action);
+  const entityType = apiAction.proxyPaginationEntityKey || entityConfig.entityType;
+  return entityCatalogue.getEntityKey(entityConfig.endpointType, entityType);
 }
 
 export function getPaginationKeyFromAction(action: PaginatedAction) {

--- a/src/frontend/packages/store/src/reducers/pagination-reducer/pagination.reducer.ts
+++ b/src/frontend/packages/store/src/reducers/pagination-reducer/pagination.reducer.ts
@@ -1,3 +1,4 @@
+import { getDefaultStateFromEntityCatalogue } from '../../../../core/src/core/entity-catalogue/entity-catalogue.store-setup';
 import {
   CONNECT_ENDPOINTS_SUCCESS,
   DISCONNECT_ENDPOINTS_SUCCESS,
@@ -44,8 +45,6 @@ import { paginationSuccess } from './pagination-reducer-success';
 import { paginationPageBusy } from './pagination-reducer-update';
 import { paginationFailure } from './pagination-reducer.failure';
 import { getActionPaginationEntityKey, getActionType, getPaginationKeyFromAction } from './pagination-reducer.helper';
-import { REGISTER_ENTITY_ACTION } from '../../../../core/src/core/entity-catalogue/entity-catalogue.actions';
-import { getDefaultStateFromEntityCatalogue } from '../../../../core/src/core/entity-catalogue/entity-catalogue.store-setup';
 
 const getPaginationUpdater = (types: [string, string, string]) => {
   const [requestType, successType, failureType] = types;
@@ -110,7 +109,7 @@ function paginate(action, state = getDefaultStateFromEntityCatalogue(), updatePa
   }
 
   if (action.type === CLEAR_PAGINATION_OF_TYPE) {
-    // TODO we shouldn't be using a 
+    // TODO we shouldn't be using a
     const clearEntityType = action.entityType || 'application';
     return paginationClearAllTypes(state, [clearEntityType], getDefaultPaginationEntityState());
   }


### PR DESCRIPTION
- fixes #3621
- Get lists fully operational. Includes
  - fix list sorting and other similar pagination events (ensure we look for `paginationKey` in correct object in `pagination-reducer.helper.ts`).
  - fix endpoint/cf endpoint data sources overriding the entity config's `endpointType`
- Also fixed some places where `EntityCatalogueHelpers.buildEntityKey(<endpoint type>, <entity type>);` was happening
