### PR TITLE
Ensure both private and shared domains are included in domain lists

### DIFF
--- a/src/frontend/packages/core/src/core/cf-api.types.ts
+++ b/src/frontend/packages/core/src/core/cf-api.types.ts
@@ -182,8 +182,11 @@ export interface IOrganization<spaceT = APIResource<ISpace>[]> {
 
 export interface IDomain {
   name: string;
-  router_group_guid?: any;
-  router_group_type?: any;
+  router_group_guid?: string;
+  router_group_type?: string;
+  owning_organization_guid?: string;
+  owning_organization_url?: string;
+  shared_organizations_url?: string;
 }
 
 export interface ICfV2Info {

--- a/src/frontend/packages/core/src/features/applications/application/application-tabs-base/tabs/routes-tab/routes-tab/routes-tab.component.ts
+++ b/src/frontend/packages/core/src/features/applications/application/application-tabs-base/tabs/routes-tab/routes-tab/routes-tab.component.ts
@@ -2,22 +2,17 @@ import { DatePipe } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Subscription } from 'rxjs';
+import { first } from 'rxjs/operators';
 
+import { AppState } from '../../../../../../../../../store/src/app-state';
 import { CurrentUserPermissionsService } from '../../../../../../../core/current-user-permissions.service';
 import { ConfirmationDialogService } from '../../../../../../../shared/components/confirmation-dialog.service';
 import {
   CfAppRoutesListConfigService,
 } from '../../../../../../../shared/components/list/list-types/app-route/cf-app-routes-list-config.service';
 import { ListConfig } from '../../../../../../../shared/components/list/list.component.types';
-import { PaginationMonitorFactory } from '../../../../../../../shared/monitors/pagination-monitor.factory';
-import { first } from 'rxjs/operators';
-import { AppState } from '../../../../../../../../../store/src/app-state';
-import { ApplicationService } from '../../../../../application.service';
-import { APIResource } from '../../../../../../../../../store/src/types/api.types';
-import { FetchAllDomains } from '../../../../../../../../../store/src/actions/domains.actions';
-import { getPaginationObservables } from '../../../../../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
-import { entityFactory, domainSchemaKey } from '../../../../../../../../../store/src/helpers/entity-factory';
 import { CfOrgSpaceDataService } from '../../../../../../../shared/data-services/cf-org-space-service.service';
+import { ApplicationService } from '../../../../../application.service';
 
 @Component({
   selector: 'app-routes-tab',
@@ -44,25 +39,11 @@ export class RoutesTabComponent implements OnInit {
 
   paginationSubscription: Subscription;
   constructor(
-    private store: Store<AppState>,
     private appService: ApplicationService,
-    private paginationMonitorFactory: PaginationMonitorFactory
   ) {
   }
   ngOnInit() {
-    const { cfGuid } = this.appService;
-    const action = new FetchAllDomains(cfGuid);
-    getPaginationObservables<APIResource>(
-      {
-        store: this.store,
-        action,
-        paginationMonitor: this.paginationMonitorFactory.create(
-          action.paginationKey,
-          entityFactory(domainSchemaKey)
-        )
-      },
-      true
-    ).entities$.pipe(
+    this.appService.orgDomains$.pipe(
       first()
     ).subscribe();
   }

--- a/src/frontend/packages/core/src/features/applications/deploy-application/deploy-application-options-step/deploy-application-options-step.component.ts
+++ b/src/frontend/packages/core/src/features/applications/deploy-application/deploy-application-options-step/deploy-application-options-step.component.ts
@@ -7,7 +7,7 @@ import { combineLatest, Observable, of as observableOf, Subscription } from 'rxj
 import { filter, first, map, share, startWith, switchMap } from 'rxjs/operators';
 
 import { SaveAppOverrides } from '../../../../../../store/src/actions/deploy-applications.actions';
-import { FetchAllDomains } from '../../../../../../store/src/actions/domains.actions';
+import { GetAllOrganizationDomains } from '../../../../../../store/src/actions/organization.actions';
 import { GetAllStacks } from '../../../../../../store/src/actions/stack.action';
 import { AppState } from '../../../../../../store/src/app-state';
 import { entityFactory } from '../../../../../../store/src/helpers/entity-factory';
@@ -103,7 +103,7 @@ export class DeployApplicationOptionsStepComponent implements OnInit, OnDestroy 
     // Create the domains list for the domains drop down
     this.domains$ = cfDetails$.pipe(
       switchMap(cfDetails => {
-        const action = new FetchAllDomains(cfDetails.cloudFoundry);
+        const action = new GetAllOrganizationDomains(cfDetails.org, cfDetails.cloudFoundry);
         return getPaginationObservables<APIResource<IDomain>>(
           {
             store: this.store,

--- a/src/frontend/packages/core/src/features/applications/routes/map-routes/map-routes.component.ts
+++ b/src/frontend/packages/core/src/features/applications/routes/map-routes/map-routes.component.ts
@@ -1,20 +1,17 @@
-import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { BehaviorSubject, Subscription } from 'rxjs';
-import { filter, tap } from 'rxjs/operators';
+import { tap } from 'rxjs/operators';
 
+import { AppState } from '../../../../../../store/src/app-state';
+import { APIResource } from '../../../../../../store/src/types/api.types';
 import {
   CfAppMapRoutesListConfigService,
 } from '../../../../shared/components/list/list-types/app-route/cf-app-map-routes-list-config.service';
 import { CfAppRoutesDataSource } from '../../../../shared/components/list/list-types/app-route/cf-app-routes-data-source';
 import { ListConfig } from '../../../../shared/components/list/list.component.types';
 import { PaginationMonitorFactory } from '../../../../shared/monitors/pagination-monitor.factory';
-import { APIResource } from '../../../../../../store/src/types/api.types';
-import { AppState } from '../../../../../../store/src/app-state';
 import { ApplicationService } from '../../application.service';
-import { FetchAllDomains } from '../../../../../../store/src/actions/domains.actions';
-import { getPaginationObservables } from '../../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
-import { entityFactory, domainSchemaKey } from '../../../../../../store/src/helpers/entity-factory';
 
 @Component({
   selector: 'app-map-routes',
@@ -53,18 +50,7 @@ export class MapRoutesComponent implements OnInit, OnDestroy {
       )
       .subscribe();
 
-    const action = new FetchAllDomains(this.appService.cfGuid);
-    this.paginationSubscription = getPaginationObservables<APIResource>(
-      {
-        store: this.store,
-        action,
-        paginationMonitor: this.paginationMonitorFactory.create(
-          action.paginationKey,
-          entityFactory(domainSchemaKey)
-        )
-      },
-      true
-    ).entities$.subscribe();
+    this.paginationSubscription = this.appService.orgDomains$.subscribe();
   }
 
   ngOnDestroy(): void {

--- a/src/frontend/packages/core/test-framework/application-service-helper.ts
+++ b/src/frontend/packages/core/test-framework/application-service-helper.ts
@@ -1,18 +1,22 @@
 import { Store } from '@ngrx/store';
-import { APIResource, EntityInfo } from '../../store/src/types/api.types';
-import { ApplicationData, ApplicationService } from '../src/features/applications/application.service';
-import { RequestInfoState } from '../../store/src/reducers/api-request-reducer/types';
-import { AppStat } from '../../store/src/types/app-metadata.types';
-import {
-  EnvVarStratosProject,
-  ApplicationEnvVarsHelper
-} from '../src/features/applications/application/application-tabs-base/tabs/build-tab/application-env-vars.service';
-import { ApplicationStateData, ApplicationStateService } from '../src/shared/components/application-state/application-state.service';
-import { ISpace, IApp, IAppSummary } from '../src/core/cf-api.types';
-import { AppState } from '../../store/src/app-state';
-import { EntityServiceFactory } from '../src/core/entity-service-factory.service';
-import { PaginationMonitorFactory } from '../src/shared/monitors/pagination-monitor.factory';
 import { Observable, of as observableOf } from 'rxjs';
+
+import { AppState } from '../../store/src/app-state';
+import { RequestInfoState } from '../../store/src/reducers/api-request-reducer/types';
+import { APIResource, EntityInfo } from '../../store/src/types/api.types';
+import { AppStat } from '../../store/src/types/app-metadata.types';
+import { IApp, IAppSummary, IDomain, ISpace } from '../src/core/cf-api.types';
+import { EntityServiceFactory } from '../src/core/entity-service-factory.service';
+import { ApplicationData, ApplicationService } from '../src/features/applications/application.service';
+import {
+  ApplicationEnvVarsHelper,
+  EnvVarStratosProject,
+} from '../src/features/applications/application/application-tabs-base/tabs/build-tab/application-env-vars.service';
+import {
+  ApplicationStateData,
+  ApplicationStateService,
+} from '../src/shared/components/application-state/application-state.service';
+import { PaginationMonitorFactory } from '../src/shared/monitors/pagination-monitor.factory';
 
 function createEntity<T>(entity: T): APIResource<T> {
   return {
@@ -77,6 +81,7 @@ export class ApplicationServiceMock {
   });
   appSpace$: Observable<APIResource<ISpace>> = observableOf(createEntity<ISpace>({} as ISpace));
   applicationRunning$: Observable<boolean> = observableOf(false);
+  orgDomains$: Observable<APIResource<IDomain>[]> = observableOf([]);
 }
 
 export function generateTestApplicationServiceProvider(appGuid, cfGuid) {

--- a/src/frontend/packages/store/src/actions/domains.actions.ts
+++ b/src/frontend/packages/store/src/actions/domains.actions.ts
@@ -17,7 +17,7 @@ export class FetchDomain extends CFStartAction implements ICFAction {
   constructor(public guid: string, public endpointGuid: string) {
     super();
     this.options = new RequestOptions();
-    this.options.url = `shared_domains/${guid}`;
+    this.options.url = `domains/${guid}`;
     this.options.method = 'get';
     this.options.params = new URLSearchParams();
   }
@@ -30,7 +30,7 @@ export class FetchAllDomains extends CFStartAction implements PaginatedAction {
   constructor(public endpointGuid: string, public flattenPagination = true) {
     super();
     this.options = new RequestOptions();
-    this.options.url = 'shared_domains';
+    this.options.url = 'domains';
     this.options.method = 'get';
     this.options.params = new URLSearchParams();
     this.paginationKey = createEntityRelationPaginationKey(endpointSchemaKey, endpointGuid);

--- a/src/frontend/packages/store/src/actions/organization.actions.ts
+++ b/src/frontend/packages/store/src/actions/organization.actions.ts
@@ -44,9 +44,9 @@ export const GET_ORGANIZATION_USERS_FAILED = '[Organization] Get all org users f
 
 export class GetOrganization extends CFStartAction implements ICFAction, EntityInlineParentAction {
   constructor(public guid: string,
-    public endpointGuid: string,
-    public includeRelations: string[] = [],
-    public populateMissing = true) {
+              public endpointGuid: string,
+              public includeRelations: string[] = [],
+              public populateMissing = true) {
     super();
     this.options = new RequestOptions();
     this.options.url = `organizations/${guid}`;
@@ -101,7 +101,7 @@ export class GetAllOrganizationDomains extends CFStartAction implements Paginate
   ) {
     super();
     if (!this.paginationKey) {
-      this.paginationKey = createEntityRelationPaginationKey(organizationSchemaKey, orgGuid)
+      this.paginationKey = createEntityRelationPaginationKey(organizationSchemaKey, orgGuid);
     }
     this.options = new RequestOptions();
     this.options.url = `organizations/${orgGuid}/domains`;

--- a/src/frontend/packages/store/src/actions/organization.actions.ts
+++ b/src/frontend/packages/store/src/actions/organization.actions.ts
@@ -1,8 +1,18 @@
-import { RequestOptions, URLSearchParams, RequestMethod } from '@angular/http';
+import { RequestMethod, RequestOptions, URLSearchParams } from '@angular/http';
 
 import { IUpdateOrganization } from '../../../core/src/core/cf-api.types';
-import { cfUserSchemaKey, entityFactory, organizationSchemaKey, spaceSchemaKey } from '../helpers/entity-factory';
-import { EntityInlineChildAction, EntityInlineParentAction } from '../helpers/entity-relations/entity-relations.types';
+import {
+  cfUserSchemaKey,
+  domainSchemaKey,
+  entityFactory,
+  organizationSchemaKey,
+  spaceSchemaKey,
+} from '../helpers/entity-factory';
+import {
+  createEntityRelationPaginationKey,
+  EntityInlineChildAction,
+  EntityInlineParentAction,
+} from '../helpers/entity-relations/entity-relations.types';
 import { PaginatedAction } from '../types/pagination.types';
 import { CFStartAction, ICFAction } from '../types/request.types';
 import { getActions } from './action.helper';
@@ -20,6 +30,10 @@ export const GET_ORGANIZATION_SPACES = '[Space] Get all org spaces';
 export const GET_ORGANIZATION_SPACES_SUCCESS = '[Space] Get all org spaces success';
 export const GET_ORGANIZATION_SPACES_FAILED = '[Space] Get all org spaces failed';
 
+export const GET_ORGANIZATION_DOMAINS = '[Space] Get all org spaces';
+export const GET_ORGANIZATION_DOMAINS_SUCCESS = '[Space] Get all org spaces success';
+export const GET_ORGANIZATION_DOMAINS_FAILED = '[Space] Get all org spaces failed';
+
 export const DELETE_ORGANIZATION = '[Organization] Delete organization';
 export const DELETE_ORGANIZATION_SUCCESS = '[Organization] Delete organization success';
 export const DELETE_ORGANIZATION_FAILED = '[Organization] Delete organization failed';
@@ -30,9 +44,9 @@ export const GET_ORGANIZATION_USERS_FAILED = '[Organization] Get all org users f
 
 export class GetOrganization extends CFStartAction implements ICFAction, EntityInlineParentAction {
   constructor(public guid: string,
-              public endpointGuid: string,
-              public includeRelations: string[] = [],
-              public populateMissing = true) {
+    public endpointGuid: string,
+    public includeRelations: string[] = [],
+    public populateMissing = true) {
     super();
     this.options = new RequestOptions();
     this.options.url = `organizations/${guid}`;
@@ -66,6 +80,37 @@ export class GetAllOrganizationSpaces extends CFStartAction implements Paginated
   actions = [GET_ORGANIZATION_SPACES, GET_ORGANIZATION_SPACES_SUCCESS, GET_ORGANIZATION_SPACES_FAILED];
   entity = entityFactory(spaceSchemaKey);
   entityKey = spaceSchemaKey;
+  options: RequestOptions;
+  flattenPagination = true;
+  initialParams = {
+    'results-per-page': 100,
+    'order-direction': 'desc',
+    'order-direction-field': 'name'
+  };
+  parentGuid: string;
+  parentEntitySchema = entityFactory(organizationSchemaKey);
+}
+
+export class GetAllOrganizationDomains extends CFStartAction implements PaginatedAction, EntityInlineParentAction, EntityInlineChildAction {
+  constructor(
+    public orgGuid: string,
+    public endpointGuid: string,
+    public paginationKey: string = null,
+    public includeRelations = [],
+    public populateMissing = true
+  ) {
+    super();
+    if (!this.paginationKey) {
+      this.paginationKey = createEntityRelationPaginationKey(organizationSchemaKey, orgGuid)
+    }
+    this.options = new RequestOptions();
+    this.options.url = `organizations/${orgGuid}/domains`;
+    this.options.method = 'get';
+    this.parentGuid = orgGuid;
+  }
+  actions = [GET_ORGANIZATION_DOMAINS, GET_ORGANIZATION_DOMAINS_SUCCESS, GET_ORGANIZATION_DOMAINS_FAILED];
+  entity = entityFactory(domainSchemaKey);
+  entityKey = domainSchemaKey;
   options: RequestOptions;
   flattenPagination = true;
   initialParams = {

--- a/src/frontend/packages/store/src/actions/organization.actions.ts
+++ b/src/frontend/packages/store/src/actions/organization.actions.ts
@@ -30,9 +30,9 @@ export const GET_ORGANIZATION_SPACES = '[Space] Get all org spaces';
 export const GET_ORGANIZATION_SPACES_SUCCESS = '[Space] Get all org spaces success';
 export const GET_ORGANIZATION_SPACES_FAILED = '[Space] Get all org spaces failed';
 
-export const GET_ORGANIZATION_DOMAINS = '[Space] Get all org spaces';
-export const GET_ORGANIZATION_DOMAINS_SUCCESS = '[Space] Get all org spaces success';
-export const GET_ORGANIZATION_DOMAINS_FAILED = '[Space] Get all org spaces failed';
+export const GET_ORGANIZATION_DOMAINS = '[Organization] Get all org domains';
+export const GET_ORGANIZATION_DOMAINS_SUCCESS = '[Organization] Get all org domains success';
+export const GET_ORGANIZATION_DOMAINS_FAILED = '[Organization] Get all org domains failed';
 
 export const DELETE_ORGANIZATION = '[Organization] Delete organization';
 export const DELETE_ORGANIZATION_SUCCESS = '[Organization] Delete organization success';


### PR DESCRIPTION
- Before we were using `shared_domains` to fetch domains. This fetched all shared domains of the cf and did not include private domains (those that are bound to orgs)
- In a lot of cases we just needed the domains available to a specific org
- So the following usages have been updated to use `organization/<guid>/domain`
  - app routes table
  - app create/bind stepper create form
  - app create/bind stepper bind form
  - deploy app stepper overrides step
- Note - The create app stepper worked before as it fetched them directly from the org entity
- fixes #3685