### PR TITLE
Add commented out defaults for cf dev & update local go-env to fetch latest changes

### DIFF
--- a/deploy/ci/travis/upload-e2e-test-report.sh
+++ b/deploy/ci/travis/upload-e2e-test-report.sh
@@ -13,6 +13,8 @@ chmod +x mc
 
 echo "Uploading test report...."
 
+./mc -install -y
+
 echo "Configuring upload client"
 ./mc config host add s3 ${AWS_ENDPOINT} ${AWS_ACCESS_KEY_ID} ${AWS_SECRET_ACCESS_KEY} --insecure
 

--- a/deploy/tools/init-cf-for-e2e.sh
+++ b/deploy/tools/init-cf-for-e2e.sh
@@ -13,11 +13,13 @@ USER_PASS="pass"
 REMOVE_USER="e2e-remove-user"
 SKIP_LOGIN="false"
 CF_API_ENDPOINT="https://api.local.pcfdev.io"
+#(CFDEV)CF_API_ENDPOINT="https://api.dev.cfdev.sh"
 DEFAULT_ORG="e2e"
 DEFAULT_SPACE="e2e"
 SETUP_INVITE_USER="true"
 UAA_CLI_CMD="uaac"
 UAA_ENDPOINT="https://uaa.local.pcfdev.io"
+#(CFDEV)UAA_ENDPOINT="https://uaa.dev.cfdev.sh"
 #(SCF)UAA_ENDPOINT="https://uaa.cf.capbristol.com"
 ADMIN_CLIENT_SECRET="admin-client-secret"
 #(SCF)ADMIN_CLIENT_SECRET="<snip>"
@@ -108,8 +110,12 @@ function cloneRepo() {
     mkdir -p cfpushtemp
     pushd cfpushtemp
     git clone https://github.com/$PROJECT/$REPO
-    popd
+  else
+    echo "Rebasing: $PROJECT/$REPO"
+    pushd cfpushtemp/$REPO
+    git pull --rebase
   fi
+  popd
 }
 
 function addInviteUserUaaClient() {


### PR DESCRIPTION
- cf-stratos/go-env has recently been updated to remove the hardcoded stack
- when running locally and the cfpushtemp dir already existed this change was not being fetched