### PR TITLE
More fixes to remove CFAppState references

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/store/cloud-foundry.store.module.ts
+++ b/src/frontend/packages/cloud-foundry/src/store/cloud-foundry.store.module.ts
@@ -1,3 +1,4 @@
+import { AppVariablesEffect } from './effects/app-variables.effects';
 import { NgModule } from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
 
@@ -6,6 +7,8 @@ import { CreateAppPageEffects } from './effects/create-app-effects';
 import { DeployAppEffects } from './effects/deploy-app.effects';
 import { GithubEffects } from './effects/github.effects';
 import { PermissionEffects, PermissionsEffects } from './effects/permissions.effect';
+import { CloudFoundryEffects } from './effects/cloud-foundry.effects';
+import { RouteEffect } from './effects/route.effects';
 
 // TODO: Remove commented effects once all CF effects are moved accross (leaving them here helps with tracking)
 @NgModule({
@@ -23,21 +26,21 @@ import { PermissionEffects, PermissionsEffects } from './effects/permissions.eff
       // UpdateAppEffects,
       // PaginationEffects,
       // ActionHistoryEffect,
-      // AppVariablesEffect,
+      AppVariablesEffect,
       // RouterEffect,
       // SystemEffects,
       // SnackBarEffects,
       // SetClientFilterEffect,
       DeployAppEffects,
       GithubEffects,
-      // CloudFoundryEffects,
+      CloudFoundryEffects,
       // MetricsEffect,
       // RequestEffect,
       // UserProfileEffect,
       // UsersRolesEffects,
       // RecursiveDeleteEffect,
       // AppEffects,
-      // RouteEffect,
+      RouteEffect,
       // UserFavoritesEffect,
       PermissionsEffects,
       PermissionEffects

--- a/src/frontend/packages/cloud-foundry/src/store/effects/cloud-foundry.effects.ts
+++ b/src/frontend/packages/cloud-foundry/src/store/effects/cloud-foundry.effects.ts
@@ -4,12 +4,12 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { catchError, flatMap, mergeMap } from 'rxjs/operators';
 
-import { GET_CF_INFO, GetCFInfo } from '../../../cloud-foundry/src/actions/cloud-foundry.actions';
-import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
-import { entityCatalogue } from '../../../core/src/core/entity-catalogue/entity-catalogue.service';
-import { environment } from '../../../core/src/environments/environment.prod';
-import { NormalizedResponse } from '../types/api.types';
-import { StartRequestAction, WrapperRequestActionFailed, WrapperRequestActionSuccess } from '../types/request.types';
+import { GET_CF_INFO, GetCFInfo } from '../../actions/cloud-foundry.actions';
+import { CFAppState } from '../../cf-app-state';
+import { entityCatalogue } from '../../../../core/src/core/entity-catalogue/entity-catalogue.service';
+import { environment } from '../../../../core/src/environments/environment.prod';
+import { NormalizedResponse } from '../../../../store/src/types/api.types';
+import { StartRequestAction, WrapperRequestActionFailed, WrapperRequestActionSuccess } from '../../../../store/src/types/request.types';
 
 @Injectable()
 export class CloudFoundryEffects {

--- a/src/frontend/packages/cloud-foundry/src/store/effects/route.effects.ts
+++ b/src/frontend/packages/cloud-foundry/src/store/effects/route.effects.ts
@@ -3,10 +3,10 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { map } from 'rxjs/operators';
 
-import { RouteEvents, UnmapRoute } from '../../../cloud-foundry/src/actions/route.actions';
-import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
-import { ClearPaginationOfEntity } from '../actions/pagination.actions';
-import { APISuccessOrFailedAction } from '../types/request.types';
+import { RouteEvents, UnmapRoute } from '../../actions/route.actions';
+import { CFAppState } from '../../cf-app-state';
+import { ClearPaginationOfEntity } from '../../../../store/src/actions/pagination.actions';
+import { APISuccessOrFailedAction } from '../../../../store/src/types/request.types';
 
 @Injectable()
 export class RouteEffect {

--- a/src/frontend/packages/store/src/app-state.ts
+++ b/src/frontend/packages/store/src/app-state.ts
@@ -60,6 +60,8 @@ export type AppRoutingOnlyAppState = Pick<AppState, 'routing'>;
 
 export type ListsOnlyAppState = Pick<AppState, 'lists'>;
 
+export type DispatchOnlyAppState = unknown;
+
 // =======================================================================================
 // Internal types below - these should NOT be used outside of the store package
 // =======================================================================================

--- a/src/frontend/packages/store/src/effects/action-history.effects.ts
+++ b/src/frontend/packages/store/src/effects/action-history.effects.ts
@@ -3,9 +3,8 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { map, take } from 'rxjs/operators';
 
-import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
 import { ActionHistoryActions, ActionHistoryDump } from '../actions/action-history.actions';
-
+import { InternalAppState } from '../app-state';
 
 
 @Injectable()
@@ -13,7 +12,7 @@ export class ActionHistoryEffect {
 
   constructor(
     private actions$: Actions,
-    private store: Store<CFAppState>,
+    private store: Store<InternalAppState>,
   ) { }
 
   @Effect({ dispatch: false }) dumpActionHistory$ = this.actions$.pipe(

--- a/src/frontend/packages/store/src/effects/app.effects.ts
+++ b/src/frontend/packages/store/src/effects/app.effects.ts
@@ -6,11 +6,11 @@ import { first, map } from 'rxjs/operators';
 import { GetAppSummaryAction } from '../../../cloud-foundry/src/actions/app-metadata.actions';
 import { ASSIGN_ROUTE_SUCCESS } from '../../../cloud-foundry/src/actions/application-service-routes.actions';
 import { UPDATE_SUCCESS, UpdateExistingApplication } from '../../../cloud-foundry/src/actions/application.actions';
-import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
 import { endpointHasMetrics } from '../../../core/src/features/endpoints/endpoint-helpers';
 import {
   createAppInstancesMetricAction,
 } from '../../../core/src/shared/components/list/list-types/app-instance/cf-app-instances-config.service';
+import { EndpointOnlyAppState } from '../app-state';
 import { APISuccessOrFailedAction } from '../types/request.types';
 
 
@@ -19,7 +19,7 @@ export class AppEffects {
 
   constructor(
     private actions$: Actions,
-    private store: Store<CFAppState>,
+    private store: Store<EndpointOnlyAppState>,
   ) { }
 
   @Effect({ dispatch: false }) updateSummary$ = this.actions$.pipe(

--- a/src/frontend/packages/store/src/effects/auth.effects.ts
+++ b/src/frontend/packages/store/src/effects/auth.effects.ts
@@ -4,7 +4,6 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { catchError, map, mergeMap, switchMap, tap } from 'rxjs/operators';
 
-import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
 import { LoggerService } from '../../../core/src/core/logger.service';
 import { BrowserStandardEncoder } from '../../../core/src/helper';
 import {
@@ -31,6 +30,7 @@ import { GET_ENDPOINTS_SUCCESS, GetAllEndpointsSuccess } from '../actions/endpoi
 import { GetSystemInfo } from '../actions/system.actions';
 import { getDashboardStateSessionId } from '../helpers/store-helpers';
 import { SessionData } from '../types/auth.types';
+import { DispatchOnlyAppState } from '../app-state';
 
 const SETUP_HEADER = 'stratos-setup-required';
 const UPGRADE_HEADER = 'retry-after';
@@ -43,7 +43,7 @@ export class AuthEffect {
   constructor(
     private http: HttpClient,
     private actions$: Actions,
-    private store: Store<CFAppState>,
+    private store: Store<DispatchOnlyAppState>,
     private logger: LoggerService
   ) { }
 
@@ -153,7 +153,7 @@ export class AuthEffect {
     return false;
   }
 
-  private rehydrateDashboardState(store: Store<CFAppState>, sessionData: SessionData) {
+  private rehydrateDashboardState(store: Store<DispatchOnlyAppState>, sessionData: SessionData) {
     const storage = localStorage || window.localStorage;
     // We use the username to key the session storage. We could replace this with the users id?
     if (storage && sessionData.user) {

--- a/src/frontend/packages/store/src/effects/endpoint.effects.ts
+++ b/src/frontend/packages/store/src/effects/endpoint.effects.ts
@@ -4,7 +4,6 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { catchError, mergeMap } from 'rxjs/operators';
 
-import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
 import { STRATOS_ENDPOINT_TYPE } from '../../../core/src/base-entity-schemas';
 import { EntityCatalogueHelpers } from '../../../core/src/core/entity-catalogue/entity-catalogue.helper';
 import { entityCatalogue } from '../../../core/src/core/entity-catalogue/entity-catalogue.service';
@@ -46,6 +45,7 @@ import {
   WrapperRequestActionFailed,
   WrapperRequestActionSuccess,
 } from '../types/request.types';
+import { DispatchOnlyAppState } from './../app-state';
 import { PaginatedAction } from './../types/pagination.types';
 
 
@@ -59,7 +59,7 @@ export class EndpointsEffect {
   constructor(
     private http: HttpClient,
     private actions$: Actions,
-    private store: Store<CFAppState>
+    private store: Store<DispatchOnlyAppState>
   ) { }
 
   @Effect() getAllEndpointsBySystemInfo$ = this.actions$.pipe(

--- a/src/frontend/packages/store/src/effects/metrics.effects.ts
+++ b/src/frontend/packages/store/src/effects/metrics.effects.ts
@@ -4,7 +4,6 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { catchError, map, mergeMap } from 'rxjs/operators';
 
-import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
 import { metricEntityType } from '../../../cloud-foundry/src/cf-entity-factory';
 import {
   METRIC_API_FAILED,
@@ -13,6 +12,7 @@ import {
   MetricsAPIActionSuccess,
 } from '../actions/metrics-api.actions';
 import { getFullMetricQueryQuery, METRICS_START, MetricsAction } from '../actions/metrics.actions';
+import { DispatchOnlyAppState } from '../app-state';
 import { IMetricsResponse } from '../types/base-metric.types';
 import { StartRequestAction, WrapperRequestActionFailed, WrapperRequestActionSuccess } from './../types/request.types';
 
@@ -22,7 +22,7 @@ export class MetricsEffect {
   constructor(
     private actions$: Actions,
     private httpClient: HttpClient,
-    private store: Store<CFAppState>
+    private store: Store<DispatchOnlyAppState>
   ) { }
 
   @Effect() metrics$ = this.actions$.pipe(

--- a/src/frontend/packages/store/src/effects/uaa-setup.effects.ts
+++ b/src/frontend/packages/store/src/effects/uaa-setup.effects.ts
@@ -1,10 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Headers, Http, URLSearchParams } from '@angular/http';
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { Store } from '@ngrx/store';
 import { catchError, map, switchMap } from 'rxjs/operators';
 
-import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
 import {
   SetUAAScope,
   SETUP_UAA,
@@ -20,8 +18,7 @@ export class UAASetupEffect {
 
   constructor(
     private http: Http,
-    private actions$: Actions,
-    private store: Store<CFAppState>
+    private actions$: Actions
   ) { }
 
   baseUrl = '/pp/v1/setup';

--- a/src/frontend/packages/store/src/effects/update-app-effects.ts
+++ b/src/frontend/packages/store/src/effects/update-app-effects.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { Store } from '@ngrx/store';
 import { mergeMap } from 'rxjs/operators';
 
 import {
@@ -11,7 +10,6 @@ import {
   GetAppSummaryAction,
 } from '../../../cloud-foundry/src/actions/app-metadata.actions';
 import { UPDATE_SUCCESS, UpdateExistingApplication } from '../../../cloud-foundry/src/actions/application.actions';
-import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
 import { WrapperRequestActionSuccess } from '../types/request.types';
 
 
@@ -21,8 +19,7 @@ export class UpdateAppEffects {
 
   constructor(
     private http: Http,
-    private actions$: Actions,
-    private store: Store<CFAppState>
+    private actions$: Actions
   ) {
   }
 

--- a/src/frontend/packages/store/src/effects/user-favorites-effect.ts
+++ b/src/frontend/packages/store/src/effects/user-favorites-effect.ts
@@ -4,7 +4,6 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { catchError, first, map, mergeMap, switchMap } from 'rxjs/operators';
 
-import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
 import { userFavoritesEntitySchema } from '../../../core/src/base-entity-schemas';
 import { entityCatalogue } from '../../../core/src/core/entity-catalogue/entity-catalogue.service';
 import { UserFavoriteManager } from '../../../core/src/core/user-favorite-manager';
@@ -28,6 +27,7 @@ import {
   UpdateUserFavoriteMetadataAction,
   UpdateUserFavoriteMetadataSuccessAction,
 } from '../actions/user-favourites-actions/update-user-favorite-metadata-action';
+import { DispatchOnlyAppState } from '../app-state';
 import { NormalizedResponse } from '../types/api.types';
 import { PaginatedAction } from '../types/pagination.types';
 import { WrapperRequestActionSuccess } from '../types/request.types';
@@ -43,7 +43,7 @@ export class UserFavoritesEffect {
   constructor(
     private http: HttpClient,
     private actions$: Actions,
-    private store: Store<CFAppState>,
+    private store: Store<DispatchOnlyAppState>,
     private userFavoriteManager: UserFavoriteManager
   ) {
   }

--- a/src/frontend/packages/store/src/effects/user-profile.effects.ts
+++ b/src/frontend/packages/store/src/effects/user-profile.effects.ts
@@ -4,7 +4,6 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { catchError, mergeMap, switchMap } from 'rxjs/operators';
 
-import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
 import { userProfileEntitySchema } from '../../../core/src/base-entity-schemas';
 import { entityCatalogue } from '../../../core/src/core/entity-catalogue/entity-catalogue.service';
 import { environment } from '../../../core/src/environments/environment';
@@ -18,13 +17,13 @@ import {
 } from '../actions/user-profile.actions';
 import { rootUpdatingKey } from '../reducers/api-request-reducer/types';
 import { UserProfileInfo } from '../types/user-profile.types';
+import { DispatchOnlyAppState } from './../app-state';
 import {
   IRequestAction,
   StartRequestAction,
   WrapperRequestActionFailed,
   WrapperRequestActionSuccess,
 } from './../types/request.types';
-
 
 
 const { proxyAPIVersion } = environment;
@@ -42,7 +41,7 @@ export class UserProfileEffect {
 
   constructor(
     private actions$: Actions,
-    private store: Store<CFAppState>,
+    private store: Store<DispatchOnlyAppState>,
     private httpClient: HttpClient,
   ) { }
 

--- a/src/frontend/packages/store/src/helpers/entity-relations/entity-relations-validate.spec.ts
+++ b/src/frontend/packages/store/src/helpers/entity-relations/entity-relations-validate.spec.ts
@@ -1,6 +1,11 @@
 import { inject, TestBed } from '@angular/core/testing';
 import { Store } from '@ngrx/store';
 
+import { GetOrganization } from '../../../../cloud-foundry/src/actions/organization.actions';
+import {
+  FetchRelationPaginatedAction,
+  FetchRelationSingleAction,
+} from '../../../../cloud-foundry/src/actions/relation.actions';
 import {
   cfEntityFactory,
   organizationEntityType,
@@ -9,14 +14,12 @@ import {
   spaceEntityType,
 } from '../../../../cloud-foundry/src/cf-entity-factory';
 import { createBasicStoreModule, getInitialTestStoreState } from '../../../../core/test-framework/store-test-helper';
-import { GetOrganization } from '../../../../cloud-foundry/src/actions/organization.actions';
 import { SetInitialParams } from '../../actions/pagination.actions';
-import { FetchRelationPaginatedAction, FetchRelationSingleAction } from '../../../../cloud-foundry/src/actions/relation.actions';
 import { APIResponse } from '../../actions/request.actions';
-import { CFAppState, IRequestTypeState } from '../../app-state';
+import { InternalAppState, IRequestTypeState } from '../../app-state';
 import { getDefaultRequestState } from '../../reducers/api-request-reducer/types';
-import { BaseRequestDataState } from '../../types/entity.types';
 import { IRequestAction, RequestEntityLocation, WrapperRequestActionSuccess } from '../../types/request.types';
+import { BaseRequestDataState } from './../../app-state';
 import { EntityTreeRelation } from './entity-relation-tree';
 import { validateEntityRelations } from './entity-relations';
 import {
@@ -36,12 +39,12 @@ describe('Entity Relations - validate', () => {
   const orgGuid = 'validateEntityRelations-org';
   const spaceGuid = 'validateEntityRelations-space';
 
-  let store: CFAppState;
+  let store: InternalAppState;
   let allEntities: BaseRequestDataState;
   let apiResponse: APIResponse;
   let newEntities: IRequestTypeState;
 
-  function noOp(iStore: Store<CFAppState>, includeRelations: string[], done: () => void) {
+  function noOp(iStore: Store<InternalAppState>, includeRelations: string[], done: () => void) {
     const dispatchSpy = spyOn(iStore, 'dispatch').and.callThrough();
     const res = validateEntityRelations({
       cfGuid,
@@ -71,7 +74,7 @@ describe('Entity Relations - validate', () => {
   }
 
   function testEverythingMissingNothingRequired(done: () => void) {
-    inject([Store], (iStore: Store<CFAppState>) => {
+    inject([Store], (iStore: Store<InternalAppState>) => {
       noOp(iStore, [], done);
     })();
   }
@@ -103,7 +106,7 @@ describe('Entity Relations - validate', () => {
     );
 
 
-    inject([Store], (iStore: Store<CFAppState>) => {
+    inject([Store], (iStore: Store<InternalAppState>) => {
       const dispatchSpy = spyOn(iStore, 'dispatch').and.callThrough();
 
       const res = validateEntityRelations({
@@ -128,13 +131,13 @@ describe('Entity Relations - validate', () => {
   }
 
   function testListExistsListRequired(done: () => void) {
-    inject([Store], (iStore: Store<CFAppState>) => {
+    inject([Store], (iStore: Store<InternalAppState>) => {
       noOp(iStore, [createEntityRelationKey(organizationEntityType, spaceEntityType)], done);
     })();
   }
 
   function testListExistsListNotRequired(done: () => void) {
-    inject([Store], (iStore: Store<CFAppState>) => {
+    inject([Store], (iStore: Store<InternalAppState>) => {
       noOp(iStore, [], done);
     })();
   }
@@ -165,7 +168,7 @@ describe('Entity Relations - validate', () => {
       entityRelationMissingQuotaUrl
     );
 
-    inject([Store], (iStore: Store<CFAppState>) => {
+    inject([Store], (iStore: Store<InternalAppState>) => {
       const dispatchSpy = spyOn(iStore, 'dispatch').and.callThrough();
 
       const res = validateEntityRelations({
@@ -275,7 +278,7 @@ describe('Entity Relations - validate', () => {
         true
       );
 
-      inject([Store], (iStore: Store<CFAppState>) => {
+      inject([Store], (iStore: Store<InternalAppState>) => {
         const dispatchSpy = spyOn(iStore, 'dispatch').and.callThrough();
 
         const res = validateEntityRelations({
@@ -308,7 +311,7 @@ describe('Entity Relations - validate', () => {
         [createEntityRelationKey(organizationEntityType, quotaDefinitionEntityType)],
         populateMissing);
 
-      inject([Store], (iStore: Store<CFAppState>) => {
+      inject([Store], (iStore: Store<InternalAppState>) => {
         const dispatchSpy = spyOn(iStore, 'dispatch').and.callThrough();
 
         const res = validateEntityRelations({
@@ -342,7 +345,7 @@ describe('Entity Relations - validate', () => {
         [createEntityRelationKey(organizationEntityType, quotaDefinitionEntityType)],
         true);
 
-      inject([Store], (iStore: Store<CFAppState>) => {
+      inject([Store], (iStore: Store<InternalAppState>) => {
         const dispatchSpy = spyOn(iStore, 'dispatch').and.callThrough();
 
         const res = validateEntityRelations({
@@ -402,7 +405,7 @@ describe('Entity Relations - validate', () => {
         endpointType: 'cf'
       } as IRequestAction, 'fetch', 1, 1);
 
-      inject([Store], (iStore: Store<CFAppState>) => {
+      inject([Store], (iStore: Store<InternalAppState>) => {
         const dispatchSpy = spyOn(iStore, 'dispatch').and.callThrough();
 
         const res = validateEntityRelations({

--- a/src/frontend/packages/store/src/reducers/auth.reducer.ts
+++ b/src/frontend/packages/store/src/reducers/auth.reducer.ts
@@ -1,4 +1,3 @@
-import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
 import {
   LOGIN,
   LOGIN_FAILED,
@@ -11,6 +10,7 @@ import {
 } from '../actions/auth.actions';
 import { RouterActions, RouterNav } from '../actions/router.actions';
 import { GET_SYSTEM_INFO_SUCCESS } from '../actions/system.actions';
+import { AuthOnlyAppState } from '../app-state';
 import { SessionData } from '../types/auth.types';
 import { RouterRedirect } from './routing.reducer';
 
@@ -102,5 +102,5 @@ export function authReducer(state: AuthState = defaultState, action): AuthState 
 }
 
 export function selectSessionData() {
-  return (state: CFAppState) => state.auth.sessionData;
+  return (state: AuthOnlyAppState) => state.auth.sessionData;
 }

--- a/src/frontend/packages/store/src/store.module.ts
+++ b/src/frontend/packages/store/src/store.module.ts
@@ -5,17 +5,14 @@ import { EffectsModule } from '@ngrx/effects';
 
 import { ActionHistoryEffect } from './effects/action-history.effects';
 import { APIEffect } from './effects/api.effects';
-import { AppVariablesEffect } from '../../cloud-foundry/src/store/effects/app-variables.effects';
 import { AppEffects } from './effects/app.effects';
 import { AuthEffect } from './effects/auth.effects';
-import { CloudFoundryEffects } from '../../cloud-foundry/src/store/effects/cloud-foundry.effects';
 import { EndpointApiError } from './effects/endpoint-api-errors.effects';
 import { EndpointsEffect } from './effects/endpoint.effects';
 import { MetricsEffect } from './effects/metrics.effects';
 import { PaginationEffects } from './effects/pagination.effects';
 import { RecursiveDeleteEffect } from './effects/recursive-entity-delete.effect';
 import { RequestEffect } from './effects/request.effects';
-import { RouteEffect } from '../../cloud-foundry/src/store/effects/route.effects';
 import { RouterEffect } from './effects/router.effects';
 import { SetClientFilterEffect } from './effects/set-client-filter.effect';
 import { SnackBarEffects } from './effects/snackBar.effects';

--- a/src/frontend/packages/store/src/store.module.ts
+++ b/src/frontend/packages/store/src/store.module.ts
@@ -8,14 +8,14 @@ import { APIEffect } from './effects/api.effects';
 import { AppVariablesEffect } from '../../cloud-foundry/src/store/effects/app-variables.effects';
 import { AppEffects } from './effects/app.effects';
 import { AuthEffect } from './effects/auth.effects';
-import { CloudFoundryEffects } from './effects/cloud-foundry.effects';
+import { CloudFoundryEffects } from '../../cloud-foundry/src/store/effects/cloud-foundry.effects';
 import { EndpointApiError } from './effects/endpoint-api-errors.effects';
 import { EndpointsEffect } from './effects/endpoint.effects';
 import { MetricsEffect } from './effects/metrics.effects';
 import { PaginationEffects } from './effects/pagination.effects';
 import { RecursiveDeleteEffect } from './effects/recursive-entity-delete.effect';
 import { RequestEffect } from './effects/request.effects';
-import { RouteEffect } from './effects/route.effects';
+import { RouteEffect } from '../../cloud-foundry/src/store/effects/route.effects';
 import { RouterEffect } from './effects/router.effects';
 import { SetClientFilterEffect } from './effects/set-client-filter.effect';
 import { SnackBarEffects } from './effects/snackBar.effects';
@@ -41,19 +41,16 @@ import { AppReducersModule } from './reducers.module';
       UpdateAppEffects,
       PaginationEffects,
       ActionHistoryEffect,
-      AppVariablesEffect,
       RouterEffect,
       SystemEffects,
       SnackBarEffects,
       SetClientFilterEffect,
-      CloudFoundryEffects,
       MetricsEffect,
       RequestEffect,
       UserProfileEffect,
       UsersRolesEffects,
       RecursiveDeleteEffect,
       AppEffects,
-      RouteEffect,
       UserFavoritesEffect,
     ]),
   ]


### PR DESCRIPTION
This PR removes more references to CFAppState to avoid the store package referencing the Cloud Foundry package.

The remaining references are:

```
src/effects/api.effects.ts:import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
src/effects/api.effects.ts:    private store: Store<CFAppState>,
src/effects/api.effects.ts:  private doApiRequest(action: ICFAction | PaginatedAction, state: CFAppState) {
src/effects/pagination.effects.ts:import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
src/effects/pagination.effects.ts:    private store: Store<CFAppState>
src/effects/users-roles.effects.ts:import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
src/effects/users-roles.effects.ts:    private store: Store<CFAppState>,
src/effects/request.effects.ts:import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
src/effects/request.effects.ts:    private store: Store<CFAppState>,
src/helpers/paginated-request-helpers.ts:import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
src/helpers/paginated-request-helpers.ts:  store: Store<CFAppState>,
src/selectors/users-roles.selector.ts:import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
src/selectors/users-roles.selector.ts:export const selectUsersRoles = (state: CFAppState): UsersRolesState => state.manageUsersRoles;
```