### PR TITLE
Helm: Add apache2 utils to nginx base image

### DIFF
--- a/deploy/stratos-base-images/Dockerfile.stratos-nginx-base.tmpl
+++ b/deploy/stratos-base-images/Dockerfile.stratos-nginx-base.tmpl
@@ -1,7 +1,12 @@
 FROM {{BASE_IMAGE}}
 {{#IS_SLE}}
 RUN zypper addrepo -G -t yum -c 'http://nginx.org/packages/sles/12' nginx
+RUN zypper addrepo -t rpm-md -G -c '{{SMT_INTERNAL_SERVER}}' smt_internal_server
 {{/IS_SLE}}
 RUN zypper -n ref && \
     zypper -n up && \
-    zypper in -y nginx
+    zypper in -y nginx apache2-utils
+
+{{#IS_SLE}}
+RUN zypper rr smt_internal_server
+{{/IS_SLE}}    


### PR DESCRIPTION
The nginx base image is used by the metrics helm chart - the base image needs the apache2 utils package.