### PR TITLE
Reduce running time of `fullMinusLongSuite` e2e job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,21 +61,26 @@ jobs:
   - name: Helm Chart Unit Tests
     script:
     - "./deploy/ci/travis/helm-chart-unit-tests.sh"
-  - name: E2E Tests - Long Suite 1
+  - name: E2E Tests - Long Suites
     before_script:
     - "./deploy/ci/travis/job-e2e-before_script.sh"
     script:
     - "./deploy/ci/travis/job-e2e-script.sh longSuite"
-  - name: E2E Tests - Long Suite 2
+  - name: E2E Tests - Manage Users
     before_script:
     - "./deploy/ci/travis/job-e2e-before_script.sh true"
     script:
-    - "./deploy/ci/travis/job-e2e-script.sh longSuite2"
+    - "./deploy/ci/travis/job-e2e-script.sh manageUsers"
+  - name: E2E Tests - Core
+    before_script:
+    - "./deploy/ci/travis/job-e2e-before_script.sh true"
+    script:
+    - "./deploy/ci/travis/job-e2e-script.sh core"
   - name: E2E Tests - All Other Suite
     before_script:
     - "./deploy/ci/travis/job-e2e-before_script.sh"
     script:
-    - "./deploy/ci/travis/job-e2e-script.sh fullMinusLongSuite"
+    - "./deploy/ci/travis/job-e2e-script.sh fullMinusOtherSuites"
 notifications:
   slack:
     secure: s5SFnFKwzfxLrjGR5lJ2AJG1FSWCKtHdQi8K2Kmx5ZhrYL/7P+KLc/ks18WnzCPoy705LbHCBSULcnWbLjqCpnkKxNjsFAyFl2nZZPxBjl2/mHpulbr3gmultDOrMDbmYL4oWPKBlxKResElz9nQwknlLWZ/L94AIx8zuMfRIWdEt1bJBDAQts4fx2D4cIEx0yZUq7JGAKjSiXKR9eDyMWFb+SWw6mvr5WtFM8uq35rPvRVEfm56LIgSuMUpVeYtnYiY2JP7W8iKX0gD+54wAiSXRZiQVCLJq606/TlJo7j8Na9Dn1Q5XDkX3b3XzcgmEZThoO1GFtv3yNYOVxv+50p2tSnc8CT0VEVOYOGJuz17AESZAYK+AyjEmeZmDiroj1czmIq8/ZYKbmvDYSZgGuDcSkQurX/6BPac6ra69WmSQmwv0tS3A/IzDw7X+CuC+3QubQ7GfaiVe25PUU+tRSEDM4PMUJY8QRF5Q+oeN5NjjWmJBqf/ic2TO2xTU1j+qysdqK34qIV1qyVcPMUIiYW+5ltH71qiy05TSvvfGS+oatRBMzINRl3zl2gOV1CKNU801XehRKCx9XDCw5NL1HSx5HD5psOyBRpAMYYBOqa+rv9VAza9MsfpslCoibg5rdrq4rZqqUgRhayNp/LKzlhe/g62+qbGNT+iFuHtB+Y=

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -78,7 +78,7 @@ const longSuite = globby.sync([
   './src/test-e2e/cloud-foundry/space-level/space-users-list-e2e.spec.ts'
 ])
 
-const longSuite2 = globby.sync([
+const manageUsersSuite = globby.sync([
   './src/test-e2e/cloud-foundry/manage-users-stepper-e2e.spec.ts',
   './src/test-e2e/cloud-foundry/cf-level/cf-users-removal-e2e.spec.ts',
   './src/test-e2e/cloud-foundry/org-level/org-users-removal-e2e.spec.ts',
@@ -88,10 +88,23 @@ const longSuite2 = globby.sync([
   './src/test-e2e/cloud-foundry/space-level/space-invite-user-e2e.spec.ts'
 ])
 
-const fullMinusLongSuites = globby.sync([
+const coreSuite = globby.sync([
+  './src/test-e2e/check/check-login-e2e.spec.ts',
+  './src/test-e2e/endpoints/endpoints-connect-e2e.spec.ts',
+  './src/test-e2e/endpoints/endpoints-e2e.spec.ts',
+  './src/test-e2e/endpoints/endpoints-register-e2e.spec.ts',
+  './src/test-e2e/endpoints/endpoints-unregister-e2e.spec.ts',
+  './src/test-e2e/home/home-e2e.spec.ts',
+  './src/test-e2e/login/login-e2e.spec.ts',
+  './src/test-e2e/login/login-sso-e2e.spec.ts',
+  './src/test-e2e/metrics/metrics-registration-e2e.spec.ts',
+])
+
+const fullMinusOtherSuites = globby.sync([
   ...fullSuite,
   ...longSuite.map(file => '!' + file),
-  ...longSuite2.map(file => '!' + file),
+  ...manageUsersSuite.map(file => '!' + file),
+  ...coreSuite.map(file => '!' + file),
 ])
 
 exports.config = {
@@ -110,12 +123,16 @@ exports.config = {
       ...longSuite,
       ...excludeTests
     ]),
-    longSuite2: globby.sync([
-      ...longSuite2,
+    manageUsers: globby.sync([
+      ...manageUsersSuite,
       ...excludeTests
     ]),
-    fullMinusLongSuite: globby.sync([
-      ...fullMinusLongSuites,
+    core: globby.sync([
+      ...coreSuite,
+      ...excludeTests
+    ]),
+    fullMinusOtherSuites: globby.sync([
+      ...fullMinusOtherSuites,
       ...excludeTests
     ]),
     sso: globby.sync([


### PR DESCRIPTION
- This was hitting the 50 minute limit, specifically in the afternoon when the env runs slower
- So pulled out some basic e2e tests from full suite into new core suite
- Also tweaked job names to make more sense
