### PR TITLE
Added fav reducers back

### DIFF
--- a/src/frontend/packages/core/src/base-entity-types.ts
+++ b/src/frontend/packages/core/src/base-entity-types.ts
@@ -1,9 +1,13 @@
 import {
+  addOrUpdateUserFavoriteMetadataReducer,
+  deleteUserFavoriteMetadataReducer,
+} from '../../store/src/reducers/favorite.reducer';
+import {
   endpointEntitySchema,
   STRATOS_ENDPOINT_TYPE,
+  systemInfoEntitySchema,
   userFavoritesEntitySchema,
   userProfileEntitySchema,
-  systemInfoEntitySchema,
 } from './base-entity-schemas';
 import { StratosCatalogueEndpointEntity, StratosCatalogueEntity } from './core/entity-catalogue/entity-catalogue-entity';
 import { BaseEndpointAuth } from './features/endpoints/endpoint-auth';
@@ -42,6 +46,11 @@ class UserFavoriteCatalogueEntity extends StratosCatalogueEntity {
       schema: userFavoritesEntitySchema,
       type: userFavoritesEntitySchema.entityType,
       endpoint: stratosType,
+    }, {
+      dataReducers: [
+        addOrUpdateUserFavoriteMetadataReducer,
+        deleteUserFavoriteMetadataReducer,
+      ]
     });
   }
 }


### PR DESCRIPTION
With entity catalogue migration fav reducers were left without attaching
it to the `UserFavoriteCatalogueEntity`.

This patch simply added it back using `dataReducers` attribute.

Signed-off-by: Vítor Avelino <vavelino@suse.com>