### PR TITLE
Fix domain dropdown on route creation

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/actions/organization.actions.ts
+++ b/src/frontend/packages/cloud-foundry/src/actions/organization.actions.ts
@@ -2,7 +2,6 @@ import { RequestMethod, RequestOptions, URLSearchParams } from '@angular/http';
 
 import { IUpdateOrganization } from '../../../core/src/core/cf-api.types';
 import { getActions } from '../../../store/src/actions/action.helper';
-import { entityFactory } from '../../../store/src/helpers/entity-factory';
 import {
   createEntityRelationPaginationKey,
   EntityInlineChildAction,
@@ -121,7 +120,7 @@ export class GetAllOrganizationDomains extends CFStartAction implements Paginate
     this.parentGuid = orgGuid;
   }
   actions = [GET_ORGANIZATION_DOMAINS, GET_ORGANIZATION_DOMAINS_SUCCESS, GET_ORGANIZATION_DOMAINS_FAILED];
-  entity = entityFactory(domainEntityType);
+  entity = cfEntityFactory(domainEntityType);
   entityType = domainEntityType;
   options: RequestOptions;
   flattenPagination = true;

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application.service.ts
@@ -265,18 +265,19 @@ export class ApplicationService {
     this.orgDomains$ = this.appOrg$.pipe(
       switchMap(org => {
         const domainsAction = new GetAllOrganizationDomains(org.metadata.guid, this.cfGuid);
+        const paginationMonitor = this.paginationMonitorFactory.create(
+          domainsAction.paginationKey,
+          domainsAction
+        );
         return getPaginationObservables<APIResource<IDomain>>(
           {
             store: this.store,
             action: domainsAction,
-            paginationMonitor: this.paginationMonitorFactory.create(
-              domainsAction.paginationKey,
-              action
-            )
+            paginationMonitor
           },
           true
         ).entities$;
-      }),
+      })
     );
 
   }

--- a/src/frontend/packages/core/src/shared/monitors/pagination-monitor.ts
+++ b/src/frontend/packages/core/src/shared/monitors/pagination-monitor.ts
@@ -152,7 +152,6 @@ export class PaginationMonitor<T = any, Y extends AppState = GeneralEntityAppSta
       this.currentPage$ = this.createPageObservable(this.pagination$, schema);
     }
     this.currentPageError$ = this.createErrorObservable(this.pagination$);
-
   }
 
   private createPaginationObservable(

--- a/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer.helper.ts
+++ b/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer.helper.ts
@@ -132,7 +132,7 @@ export function getPaginationKeyFromAction(action: PaginatedAction) {
   return apiAction.paginationKey;
 }
 
-// TODO: This needs to be a service not just a function!
+// TODO: This needs to be a service not just a function! - #3802
 export const getPaginationObservables = <T = any, Y extends AppState = AppState>(
   { store, action, paginationMonitor }: {
     store: Store<Y>,

--- a/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer.helper.ts
+++ b/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer.helper.ts
@@ -132,6 +132,7 @@ export function getPaginationKeyFromAction(action: PaginatedAction) {
   return apiAction.paginationKey;
 }
 
+// TODO: This needs to be a service not just a function!
 export const getPaginationObservables = <T = any, Y extends AppState = AppState>(
   { store, action, paginationMonitor }: {
     store: Store<Y>,
@@ -143,7 +144,6 @@ export const getPaginationObservables = <T = any, Y extends AppState = AppState>
   const baseAction = Array.isArray(action) ? action[0] : action;
   const paginationKey = paginationMonitor.paginationKey;
   const entityKey = paginationMonitor.schema.key;
-
   // FIXME: This will reset pagination every time regardless of if we need to (or just want the pag settings/entities from pagination
   // section)
   if (baseAction.initialParams) {


### PR DESCRIPTION
When creating a new route the domain dropdown is always empty. This was because the wrong action was being used to fetch the domain.