### PR TITLE
Allow always showing cf endpoint nav items to be customized

### DIFF
--- a/src/frontend/packages/core/src/app.routing.ts
+++ b/src/frontend/packages/core/src/app.routing.ts
@@ -49,6 +49,7 @@ const appRoutes: Routes = [
           stratosNavigation: {
             label: 'Applications',
             matIcon: 'apps',
+            requiresEndpointType: 'cf',
             position: 20
           }
         },
@@ -78,6 +79,7 @@ const appRoutes: Routes = [
           stratosNavigation: {
             label: 'Marketplace',
             matIcon: 'store',
+            requiresEndpointType: 'cf',
             position: 30
           }
         },
@@ -89,6 +91,7 @@ const appRoutes: Routes = [
             label: 'Services',
             matIcon: 'service',
             matIconFont: 'stratos-icons',
+            requiresEndpointType: 'cf',
             position: 40
           }
         },
@@ -100,6 +103,7 @@ const appRoutes: Routes = [
             label: 'Cloud Foundry',
             matIcon: 'cloud_foundry',
             matIconFont: 'stratos-icons',
+            requiresEndpointType: 'cf',
             position: 50
           }
         },

--- a/src/frontend/packages/core/src/core/customizations.types.ts
+++ b/src/frontend/packages/core/src/core/customizations.types.ts
@@ -9,6 +9,7 @@ export interface CustomizationsMetadata {
   logoText?: string;
   aboutInfoComponent?: any;
   supportInfoComponent?: any;
+  alwaysShowNavForEndpointTypes?: (epType) => boolean;
 }
 
 export const Customizations = new InjectionToken<CustomizationsMetadata>('Stratos customizations');


### PR DESCRIPTION
At the moment, we always show:

- Applications
- Services
- Marketplace
- Cloud Foundry

regardless of whether you have any CF endpoints registered and connected.

This PR allows a downstream fork to customise this behaviour.