### PR TITLE
Fix minor issues on v3-master

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/users/manage-users/cf-roles.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/users/manage-users/cf-roles.service.ts
@@ -38,7 +38,6 @@ import { CfUserService } from '../../../../shared/data-services/cf-user.service'
 import { createDefaultOrgRoles, createDefaultSpaceRoles } from '../../../../store/reducers/users-roles.reducer';
 import { CfUser, IUserPermissionInOrg, UserRoleInOrg, UserRoleInSpace } from '../../../../store/types/user.types';
 import { CfRoleChange, CfUserRolesSelected } from '../../../../store/types/users-roles.types';
-import { ActiveRouteCfOrgSpace } from '../../cf-page.types';
 import { canUpdateOrgSpaceRoles } from '../../cf.helpers';
 
 @Injectable()
@@ -96,7 +95,6 @@ export class CfRolesService {
     private entityServiceFactory: EntityServiceFactory,
     private paginationMonitorFactory: PaginationMonitorFactory,
     private userPerms: CurrentUserPermissionsService,
-    private activeRouteCfOrgSpace: ActiveRouteCfOrgSpace
   ) {
     this.existingRoles$ = this.store.select(selectUsersRolesPicked).pipe(
       combineLatestOperators(this.store.select(selectUsersRolesCf)),

--- a/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/users/manage-users/manage-users-confirm/manage-users-confirm.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/users/manage-users/manage-users-confirm/manage-users-confirm.component.ts
@@ -97,7 +97,7 @@ export class UsersRolesConfirmComponent implements OnInit, AfterContentInit {
     const schema = isSpace ? cfEntityFactory(spaceEntityType) : cfEntityFactory(organizationEntityType);
     const guid = isSpace ? row.spaceGuid : row.orgGuid;
     return {
-      entityKey: schema.key,
+      entityKey: entityCatalogue.getEntityKey(schema),
       schema,
       monitorState: AppMonitorComponentTypes.UPDATE,
       updateKey: ChangeUserRole.generateUpdatingKey(row.role, row.userGuid),

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/cf-org-space-service.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/cf-org-space-service.service.ts
@@ -166,12 +166,11 @@ export class CfOrgSpaceDataService implements OnDestroy {
       this.paginationAction.paginationKey,
       cfEntityFactory(this.paginationAction.entityType)
     )
-  });
+  }, true);
   private allOrgsLoading$ = this.allOrgs.pagination$.pipe(map(
     pag => getCurrentPageRequestInfo(pag).busy
   ));
 
-  private getEndpointsAndOrgs$: Observable<any>;
   private selectMode = CfOrgSpaceSelectMode.FIRST_ONLY;
   private subs: Subscription[] = [];
 

--- a/src/frontend/packages/core/src/core/entity-catalogue/entity-catalogue.types.ts
+++ b/src/frontend/packages/core/src/core/entity-catalogue/entity-catalogue.types.ts
@@ -12,6 +12,12 @@ export interface EntityCatalogueEntityConfig {
   subType?: string;
   schemaKey?: string;
 }
+
+export const extractEntityCatalogueEntityConfig = (ecec: Partial<EntityCatalogueEntityConfig>): EntityCatalogueEntityConfig => {
+  const { entityType, endpointType, subType, schemaKey } = ecec;
+  return { entityType, endpointType, subType, schemaKey };
+};
+
 export interface EntityCatalogueSchemas {
   default: EntitySchema;
   [schemaKey: string]: EntitySchema;

--- a/src/frontend/packages/store/src/actions/pagination.actions.ts
+++ b/src/frontend/packages/store/src/actions/pagination.actions.ts
@@ -1,6 +1,9 @@
 import { Action } from '@ngrx/store';
 
-import { EntityCatalogueEntityConfig } from '../../../core/src/core/entity-catalogue/entity-catalogue.types';
+import {
+  EntityCatalogueEntityConfig,
+  extractEntityCatalogueEntityConfig,
+} from '../../../core/src/core/entity-catalogue/entity-catalogue.types';
 import { PaginationClientFilter, PaginationParam } from '../types/pagination.types';
 
 export const CLEAR_PAGINATION_OF_TYPE = '[Pagination] Clear all pages of type';
@@ -26,48 +29,62 @@ export function getPaginationKey(type: string, id: string, endpointGuid?: string
   return endpointGuid ? `${endpointGuid}:${key}` : key;
 }
 
-export class ClearPaginationOfType implements Action {
-  constructor(public entityConfig: EntityCatalogueEntityConfig) {
+abstract class BasePaginationAction {
+  public entityConfig: EntityCatalogueEntityConfig;
+
+  constructor(pEntityConfig: Partial<EntityCatalogueEntityConfig>) {
+    this.entityConfig = extractEntityCatalogueEntityConfig(pEntityConfig);
+  }
+}
+
+export class ClearPaginationOfType extends BasePaginationAction implements Action {
+  constructor(pEntityConfig: Partial<EntityCatalogueEntityConfig>) {
+    super(pEntityConfig);
   }
   type = CLEAR_PAGINATION_OF_TYPE;
 }
 
-export class ClearPaginationOfEntity implements Action {
-  constructor(public entityConfig: EntityCatalogueEntityConfig, public entityGuid: string, public paginationKey?: string) {
+export class ClearPaginationOfEntity extends BasePaginationAction implements Action {
+  constructor(pEntityConfig: Partial<EntityCatalogueEntityConfig>, public entityGuid: string, public paginationKey?: string) {
+    super(pEntityConfig);
   }
   type = CLEAR_PAGINATION_OF_ENTITY;
 }
 
-export class ResetPagination implements Action {
-  constructor(public entityConfig: EntityCatalogueEntityConfig, public paginationKey: string) {
+export class ResetPagination extends BasePaginationAction implements Action {
+  constructor(pEntityConfig: Partial<EntityCatalogueEntityConfig>, public paginationKey: string) {
+    super(pEntityConfig);
   }
   type = RESET_PAGINATION;
 }
 
-export class CreatePagination {
+export class CreatePagination extends BasePaginationAction implements Action {
   /**
    * @param seed The pagination key for the section we should use as a seed when creating the new pagination section.
    */
-  constructor(public entityConfig: EntityCatalogueEntityConfig, public paginationKey: string, public seed?: string) {
+  constructor(pEntityConfig: Partial<EntityCatalogueEntityConfig>, public paginationKey: string, public seed?: string) {
+    super(pEntityConfig);
   }
   type = CREATE_PAGINATION;
 }
 
 
-export class ClearPages {
-  constructor(public entityConfig: EntityCatalogueEntityConfig, public paginationKey: string) {
+export class ClearPages extends BasePaginationAction implements Action {
+  constructor(pEntityConfig: Partial<EntityCatalogueEntityConfig>, public paginationKey: string) {
+    super(pEntityConfig);
   }
   type = CLEAR_PAGES;
 }
 
-export class SetPage {
+export class SetPage extends BasePaginationAction implements Action {
   constructor(
-    public entityConfig: EntityCatalogueEntityConfig,
+    pEntityConfig: Partial<EntityCatalogueEntityConfig>,
     public paginationKey: string,
     public pageNumber: number,
     public keepPages = false,
     public forceLocalPage = false
   ) {
+    super(pEntityConfig);
     if (forceLocalPage) {
       keepPages = true;
     }
@@ -75,89 +92,97 @@ export class SetPage {
   type = SET_PAGE;
 }
 
-export class SetResultCount {
+export class SetResultCount extends BasePaginationAction implements Action {
   constructor(
-    public entityConfig: EntityCatalogueEntityConfig,
+    pEntityConfig: Partial<EntityCatalogueEntityConfig>,
     public paginationKey: string,
     public count: number
   ) {
+    super(pEntityConfig);
   }
   type = SET_RESULT_COUNT;
 }
 
-export class SetClientPageSize {
+export class SetClientPageSize extends BasePaginationAction implements Action {
   constructor(
-    public entityConfig: EntityCatalogueEntityConfig,
+    pEntityConfig: Partial<EntityCatalogueEntityConfig>,
     public paginationKey: string,
     public pageSize: number,
   ) {
+    super(pEntityConfig);
   }
   type = SET_CLIENT_PAGE_SIZE;
 }
 
-export class SetClientPage {
+export class SetClientPage extends BasePaginationAction implements Action {
   constructor(
-    public entityConfig: EntityCatalogueEntityConfig,
+    pEntityConfig: Partial<EntityCatalogueEntityConfig>,
     public paginationKey: string,
     public pageNumber: number,
   ) {
+    super(pEntityConfig);
   }
   type = SET_CLIENT_PAGE;
 }
 
-export class SetClientFilter {
+export class SetClientFilter extends BasePaginationAction implements Action {
   constructor(
-    public entityConfig: EntityCatalogueEntityConfig,
+    pEntityConfig: Partial<EntityCatalogueEntityConfig>,
     public paginationKey: string,
     public filter: PaginationClientFilter,
   ) {
+    super(pEntityConfig);
   }
   type = SET_CLIENT_FILTER;
 }
 
-export class SetParams {
+export class SetParams extends BasePaginationAction implements Action {
   constructor(
-    public entityConfig: EntityCatalogueEntityConfig,
+    pEntityConfig: Partial<EntityCatalogueEntityConfig>,
     public paginationKey: string,
     public params: PaginationParam,
     public keepPages = false,
     public overwrite = false,
   ) {
+    super(pEntityConfig);
   }
   type = SET_PARAMS;
 }
 
-export class SetInitialParams implements SetParams {
+export class SetInitialParams extends BasePaginationAction implements Action, SetParams {
   constructor(
-    public entityConfig: EntityCatalogueEntityConfig,
+    pEntityConfig: Partial<EntityCatalogueEntityConfig>,
     public paginationKey: string,
     public params: PaginationParam,
     public keepPages = false,
     public overwrite = false,
   ) {
+    super(pEntityConfig);
   }
   type = SET_INITIAL_PARAMS;
 }
 
-export class AddParams {
+export class AddParams extends BasePaginationAction implements Action {
   constructor(
-    public entityConfig: EntityCatalogueEntityConfig,
+    pEntityConfig: Partial<EntityCatalogueEntityConfig>,
     public paginationKey: string,
     public params: PaginationParam,
     public keepPages = false
   ) {
+    super(pEntityConfig);
   }
   type = ADD_PARAMS;
 }
 
-export class RemoveParams {
+export class RemoveParams extends BasePaginationAction implements Action {
   constructor(
-    public entityConfig: EntityCatalogueEntityConfig,
+    pEntityConfig: Partial<EntityCatalogueEntityConfig>,
     public paginationKey: string,
     public params: string[],
     public qs: string[],
     public keepPages = false
   ) {
+    super(pEntityConfig);
   }
   type = REMOVE_PARAMS;
 }

--- a/src/frontend/packages/store/src/effects/users-roles.effects.ts
+++ b/src/frontend/packages/store/src/effects/users-roles.effects.ts
@@ -4,6 +4,7 @@ import { Store } from '@ngrx/store';
 import { combineLatest as observableCombineLatest, Observable, of as observableOf } from 'rxjs';
 import { filter, first, map, mergeMap, pairwise, withLatestFrom } from 'rxjs/operators';
 
+import { CF_ENDPOINT_TYPE } from '../../../cloud-foundry/cf-types';
 import {
   UsersRolesActions,
   UsersRolesClearUpdateState,
@@ -12,13 +13,13 @@ import {
 import { AddUserRole, ChangeUserRole, RemoveUserRole } from '../../../cloud-foundry/src/actions/users.actions';
 import { CFAppState } from '../../../cloud-foundry/src/cf-app-state';
 import { organizationEntityType, spaceEntityType } from '../../../cloud-foundry/src/cf-entity-factory';
+import { OrgUserRoleNames } from '../../../cloud-foundry/src/store/types/user.types';
+import { CfRoleChange } from '../../../cloud-foundry/src/store/types/users-roles.types';
 import { entityCatalogue } from '../../../core/src/core/entity-catalogue/entity-catalogue.service';
 import { selectSessionData } from '../reducers/auth.reducer';
 import { selectUsersRoles } from '../selectors/users-roles.selector';
 import { SessionDataEndpoint } from '../types/auth.types';
 import { ICFAction, UpdateCfAction } from '../types/request.types';
-import { OrgUserRoleNames } from '../../../cloud-foundry/src/store/types/user.types';
-import { CfRoleChange } from '../../../cloud-foundry/src/store/types/users-roles.types';
 
 
 @Injectable()
@@ -34,13 +35,15 @@ export class UsersRolesEffects {
     mergeMap(action => {
       const actions = [];
       action.changedRoles.forEach(change => {
-        const apiAction = {
+        const apiAction: ICFAction = {
           guid: change.spaceGuid ? change.spaceGuid : change.orgGuid,
+          endpointType: CF_ENDPOINT_TYPE,
           entityType: change.spaceGuid ? spaceEntityType : organizationEntityType,
           updatingKey: ChangeUserRole.generateUpdatingKey(change.role, change.userGuid),
           options: null,
-          actions: []
-        } as ICFAction;
+          actions: [],
+          type: ''
+        };
         actions.push(new UpdateCfAction(apiAction, false, ''));
       });
       return actions;

--- a/src/frontend/packages/store/src/helpers/schema-tree-traverse.ts
+++ b/src/frontend/packages/store/src/helpers/schema-tree-traverse.ts
@@ -59,7 +59,8 @@ export class EntitySchemaTreeBuilder {
     // Delete route, unbind route
     [routeEntityType]: [
       domainEntityType,
-      applicationEntityType
+      applicationEntityType,
+      spaceEntityType
     ],
     // Unbind service instance
     [serviceBindingEntityType]: [

--- a/src/frontend/packages/store/src/reducers/pagination-reducer/pagination.reducer.ts
+++ b/src/frontend/packages/store/src/reducers/pagination-reducer/pagination.reducer.ts
@@ -157,9 +157,7 @@ function enterPaginationReducer(state: PaginationState, action, updatePagination
   if (actionType && entityKey && paginationKey) {
     const newState = { ...state };
     if (!newState[entityKey]) {
-      logMissing(`entity type ''`, Object.keys(newState))
-    } else if (!newState[entityKey][paginationKey]) {
-      logMissing(`pagination section '${paginationKey}' for entity type '${entityKey}'`, Object.keys(newState[entityKey]))
+      logMissing(`entity type ''`, Object.keys(newState));
     }
     const updatedPaginationState = updatePagination(newState[entityKey][paginationKey], action, actionType);
     if (state[entityKey][paginationKey] === updatedPaginationState) {


### PR DESCRIPTION
Slow Lists
- Actions were being dispatched with large objects as type `EntityCatalogueEntityConfig`
- DevTools struggled to serialise them
- I've had a look where this might else occur, was only in one set of actions

Manage Users Stepper
- entityType & endpointType updates

Cf/Org/Space Filters
- previously this was not fetching all organisations (not flattened/de-paginated)

Delete Route 
- now, on delete of route, the cf routes table should still show values