### PR TITLE
Autoscaler updates following UX review

### DIFF
--- a/src/frontend/packages/cf-autoscaler/src/core/autoscaler-helpers/autoscaler-available.ts
+++ b/src/frontend/packages/cf-autoscaler/src/core/autoscaler-helpers/autoscaler-available.ts
@@ -6,13 +6,6 @@ import { APIResource, EntityInfo } from '../../../../store/src/types/api.types';
 import { GetAppAutoscalerInfoAction } from '../../store/app-autoscaler.actions';
 import { AutoscalerInfo } from '../../store/app-autoscaler.types';
 
-export const isAutoscalerEnabled = (endpointGuid: string, esf: EntityServiceFactory): Observable<boolean> => {
-  return fetchAutoscalerInfo(endpointGuid, esf).pipe(
-    map(entityInfo => !entityInfo.entityRequestInfo.error),
-    startWith(false)
-  );
-};
-
 export const fetchAutoscalerInfo = (
   endpointGuid: string,
   esf: EntityServiceFactory): Observable<EntityInfo<APIResource<AutoscalerInfo>>> => {
@@ -29,3 +22,9 @@ export const fetchAutoscalerInfo = (
   );
 };
 
+export const isAutoscalerEnabled = (endpointGuid: string, esf: EntityServiceFactory): Observable<boolean> => {
+  return fetchAutoscalerInfo(endpointGuid, esf).pipe(
+    map(entityInfo => !entityInfo.entityRequestInfo.error),
+    startWith(false)
+  );
+};

--- a/src/frontend/packages/cf-autoscaler/src/core/autoscaler-helpers/autoscaler-available.ts
+++ b/src/frontend/packages/cf-autoscaler/src/core/autoscaler-helpers/autoscaler-available.ts
@@ -1,0 +1,31 @@
+import { Observable } from 'rxjs';
+import { filter, map, publishReplay, refCount, startWith } from 'rxjs/operators';
+
+import { EntityServiceFactory } from '../../../../core/src/core/entity-service-factory.service';
+import { APIResource, EntityInfo } from '../../../../store/src/types/api.types';
+import { GetAppAutoscalerInfoAction } from '../../store/app-autoscaler.actions';
+import { AutoscalerInfo } from '../../store/app-autoscaler.types';
+
+export const isAutoscalerEnabled = (endpointGuid: string, esf: EntityServiceFactory): Observable<boolean> => {
+  return fetchAutoscalerInfo(endpointGuid, esf).pipe(
+    map(entityInfo => !entityInfo.entityRequestInfo.error),
+    startWith(false)
+  );
+};
+
+export const fetchAutoscalerInfo = (
+  endpointGuid: string,
+  esf: EntityServiceFactory): Observable<EntityInfo<APIResource<AutoscalerInfo>>> => {
+  const action = new GetAppAutoscalerInfoAction(endpointGuid);
+  const entityService = esf.create<APIResource<AutoscalerInfo>>(action.entityKey, action.entity, endpointGuid, action);
+  return entityService.entityObs$.pipe(
+    filter(entityInfo =>
+      !!entityInfo &&
+      !!entityInfo.entityRequestInfo &&
+      !entityInfo.entityRequestInfo.fetching
+    ),
+    publishReplay(1),
+    refCount()
+  );
+};
+

--- a/src/frontend/packages/cf-autoscaler/src/core/autoscaler-helpers/autoscaler-util.ts
+++ b/src/frontend/packages/cf-autoscaler/src/core/autoscaler-helpers/autoscaler-util.ts
@@ -106,28 +106,28 @@ export class AutoscalerConstants {
 }
 
 export const PolicyAlert = {
-  alertInvalidPolicyMinimumRange: 'The Minimum Instance Count must be a integer less than the Maximum Instance Count.',
-  alertInvalidPolicyMaximumRange: 'The Maximum Instance Count must be a integer greater than the Minimum Instance Count.',
+  alertInvalidPolicyMinimumRange: 'The Minimum Instance Count must be an integer less than the Maximum Instance Count.',
+  alertInvalidPolicyMaximumRange: 'The Maximum Instance Count must be an integer greater than the Minimum Instance Count.',
   alertInvalidPolicyInitialMaximumRange:
-    'The Initial Minimum Instance Count must be a integer in the range of Minimum Instance Count to Maximum Instance Count.',
+    'The Initial Minimum Instance Count must be an integer between Minimum Instance Count and Maximum Instance Count.',
   alertInvalidPolicyTriggerUpperThresholdRange: 'The Upper Threshold value must be an integer greater than the Lower Threshold value.',
-  alertInvalidPolicyTriggerLowerThresholdRange: 'The Lower Threshold value must be an integer in the range of 1 to (Upper Threshold-1).',
+  alertInvalidPolicyTriggerLowerThresholdRange: 'The Lower Threshold value must be an integer between 1 and (Upper Threshold-1).',
   alertInvalidPolicyTriggerThreshold100: 'The Lower/Upper Threshold value of memoryutil must be an integer below or equal to 100.',
-  alertInvalidPolicyTriggerStepPercentageRange: 'The Instance Step Up/Down percentage must be a integer greater than 1.',
-  alertInvalidPolicyTriggerStepRange: 'The Instance Step Up/Down value must be a integer in the range of 1 to (Maximum Instance-1).',
+  alertInvalidPolicyTriggerStepPercentageRange: 'The Instance Step Up/Down percentage must be an integer greater than 1.',
+  alertInvalidPolicyTriggerStepRange: 'The Instance Step Up/Down value must be an integer between 1 and (Maximum Instance-1).',
   alertInvalidPolicyTriggerBreachDurationRange:
-    `The breach duration value must be an integer in the range of ${AutoscalerConstants.PolicyDefaultSetting.breach_duration_secs_min} to
+    `The breach duration value must be an integer between ${AutoscalerConstants.PolicyDefaultSetting.breach_duration_secs_min} and
     ${AutoscalerConstants.PolicyDefaultSetting.breach_duration_secs_max} seconds.`,
   alertInvalidPolicyTriggerCooldownRange:
-    `The cooldown period value must be an integer in the range of ${AutoscalerConstants.PolicyDefaultSetting.cool_down_secs_min} to
+    `The cooldown period value must be an integer between ${AutoscalerConstants.PolicyDefaultSetting.cool_down_secs_min} and
     ${AutoscalerConstants.PolicyDefaultSetting.breach_duration_secs_max} seconds.`,
-  alertInvalidPolicyScheduleDateBeforeNow: 'Start/End date should be after or equal to current date.',
+  alertInvalidPolicyScheduleDateBeforeNow: 'Start/End date should be after or equal to the current date.',
   alertInvalidPolicyScheduleEndDateBeforeStartDate: 'Start date must be earlier than the end date.',
   alertInvalidPolicyScheduleEndTimeBeforeStartTime: 'Start time must be earlier than the end time.',
   alertInvalidPolicyScheduleRepeatOn: 'Please select at least one "Repeat On" day.',
   alertInvalidPolicyScheduleEndDateTimeBeforeStartDateTime: 'Start date and time must be earlier than the end date and time.',
-  alertInvalidPolicyScheduleStartDateTimeBeforeNow: 'Start date and time must be after or equal to current date time.',
-  alertInvalidPolicyScheduleEndDateTimeBeforeNow: 'End date and time must be after or equal the current date and time.',
+  alertInvalidPolicyScheduleStartDateTimeBeforeNow: 'Start date and time must be after or equal to the current date time.',
+  alertInvalidPolicyScheduleEndDateTimeBeforeNow: 'End date and time must be after or equal to the current date and time.',
   alertInvalidPolicyScheduleRecurringConflict: 'Recurring schedule configuration conflict occurs.',
   alertInvalidPolicyScheduleSpecificConflict: 'Specific date configuration conflict occurs.',
   alertInvalidPolicyTriggerScheduleEmpty: 'At least one Scaling Rule or Schedule should be defined.',

--- a/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.html
@@ -1,52 +1,29 @@
+<app-page-sub-nav>
+  <ng-container *ngIf="appAutoscalerPolicy$ | async as policy; else noPolicy">
+    <button mat-button name="edit" (click)="updatePolicyPage()" class="nav-button-with-text">
+      <span class="nav-button-with-text__span">
+        <mat-icon class="nav-button-with-text__icon">edit</mat-icon> Edit Policy
+      </span>
+    </button>
+    <button mat-button name="delete" (click)="disableAutoscaler()" class="nav-button-with-text">
+      <span class="nav-button-with-text__span">
+        <mat-icon class="nav-button-with-text__icon">delete</mat-icon> Delete Policy
+      </span>
+    </button>
+  </ng-container>
+  <ng-template #noPolicy>
+    <button mat-button name="add" (click)="updatePolicyPage(true)" class="nav-button-with-text">
+      <span class="nav-button-with-text__span">
+        <mat-icon class="nav-button-with-text__icon">add</mat-icon> Create Policy
+      </span>
+    </button>
+  </ng-template>
+</app-page-sub-nav>
 <div class="autoscaler-tab">
   <app-tile-grid class="app-autoscaler-tile-grid-100">
-    <app-tile-group *ngIf="!(appAutoscalerPolicy$ | async)">
-      <app-tile>
-        <mat-card>
-          <mat-card-header>
-            <mat-card-title>Status</mat-card-title>
-          </mat-card-header>
-          <mat-card-content>
-            <div class="app-metadata">
-              <div class="app-metadata__two-cols">
-                <mat-slide-toggle checked="false" (click)="updatePolicyPage()">Disabled</mat-slide-toggle>
-              </div>
-            </div>
-          </mat-card-content>
-        </mat-card>
-      </app-tile>
-      <app-tile>
-        <app-card-app-instances></app-card-app-instances>
-      </app-tile>
-    </app-tile-group>
     <app-tile-group *ngIf="appAutoscalerPolicy$ | async as policy">
-
-      <app-tile>
-        <mat-card>
-          <mat-card-header>
-            <mat-card-title>Status</mat-card-title>
-          </mat-card-header>
-          <mat-card-content>
-            <div class="app-metadata">
-              <div class="app-metadata__two-cols">
-                <mat-slide-toggle *ngIf="policy.enabled && detachConfirmOk == 0" checked="true"
-                  (click)="disableAutoscaler()">Enabled</mat-slide-toggle>
-                <mat-slide-toggle *ngIf="policy.enabled && detachConfirmOk == 1" checked="true"
-                  (click)="disableAutoscaler()">Enabled</mat-slide-toggle>
-                <mat-slide-toggle *ngIf="policy.enabled && detachConfirmOk == 2" checked="false"
-                  (click)="updatePolicyPage()">Disabled</mat-slide-toggle>
-                <mat-slide-toggle *ngIf="!policy.enabled" checked="false" (click)="updatePolicyPage()">Disabled
-                </mat-slide-toggle>
-              </div>
-            </div>
-          </mat-card-content>
-        </mat-card>
-      </app-tile>
-      <app-tile *ngIf="!policy.enabled">
-        <app-card-app-instances></app-card-app-instances>
-      </app-tile>
       <app-tile *ngIf="policy.enabled">
-        <app-card-autoscaler-default [onUpdate]="updatePolicyPage"></app-card-autoscaler-default>
+        <app-card-autoscaler-default></app-card-autoscaler-default>
       </app-tile>
       <app-tile *ngIf="policy.enabled" class="autoscaler-tab__latest-metrics">
         <app-card-app-usage *ngIf="policy.scaling_rules.length == 0"></app-card-app-usage>
@@ -59,7 +36,6 @@
               <div class="app-metadata__two-cols" *ngFor="let metricName of appAutoscalerAppMetricNames$ | async">
                 <app-metadata-item *ngIf="appAutoscalerAppMetrics[metricName] | async as metricData"
                   label={{metricName}}>
-                  <!-- {{ metricData[0].entity.latest.length > 0 && metricData[0].entity.latest[0].value ? metricData[0].entity.latest[0].value + " " + metricData[0].entity.unit : "NaN"}} -->
                   <ngx-charts-gauge [view]="[80, 80]" [margin]="[5, 5, 0, 5]"
                     [customColors]="[metricData[0].entity.latest.colorTarget[0]]"
                     [results]="[metricData[0].entity.latest.target[0]]" [animations]="true" [textValue]=""
@@ -113,11 +89,6 @@
                 </div>
               </div>
             </mat-card-content>
-            <mat-card-actions class="autoscaler-tab__actions">
-              <button (click)="updatePolicyPage()" mat-icon-button>
-                <mat-icon>edit</mat-icon>
-              </button>
-            </mat-card-actions>
           </mat-card>
         </app-tile>
         <app-tile>
@@ -204,17 +175,15 @@
                   No recurring schedule.</div>
               </div>
             </mat-card-content>
-            <mat-card-actions class="autoscaler-tab__actions">
-              <button (click)="updatePolicyPage()" mat-icon-button>
-                <mat-icon>edit</mat-icon>
-              </button>
-            </mat-card-actions>
           </mat-card>
         </app-tile>
       </app-tile-group>
     </div>
-    <app-tile-group class="autoscaler-tile-events" *ngIf="appAutoscalerScalingHistory$ | async as scalingHistory">
-      <app-tile>
+    <app-tile-group class="autoscaler-tile-events" *ngIf="showAutoscalerHistory$ | async">
+      <span *ngIf="!(appAutoscalerPolicy$ | async)" class="autoscaler-tile-events__no-policy">
+        {{noPolicyMessageFirstLine}}. {{noPolicyMessageSecondLine.text}}
+      </span>
+      <app-tile *ngIf="appAutoscalerScalingHistory$ | async as scalingHistory">
         <mat-card>
           <mat-card-header class="autoscaler-tile-events__header">
             <mat-card-title>Latest Events </mat-card-title>
@@ -259,5 +228,8 @@
         </mat-card>
       </app-tile>
     </app-tile-group>
+    <app-no-content-message *ngIf="showNoPolicyMessage$ | async" [icon]="'meter'" [iconFont]="'stratos-icons'"
+      [firstLine]="noPolicyMessageFirstLine" [secondLine]="noPolicyMessageSecondLine">
+    </app-no-content-message>
   </app-tile-grid>
 </div>

--- a/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.scss
+++ b/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.scss
@@ -22,11 +22,12 @@
   }
 }
 
+
 .app-metadata {
   display: flex;
   flex-direction: row;
   &__two-cols {
-    flex: 1;
+    padding-right: 40px;
     app-metadata-item:first-child {
       margin-top: 0;
     }

--- a/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.scss
+++ b/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.scss
@@ -17,6 +17,7 @@
   }
 
   &__latest-metrics {
+    flex: 2;
     min-height: 200px;
   }
 }
@@ -52,6 +53,13 @@ table {
 }
 
 .autoscaler-tile-events {
+  &__no-policy {
+    align-items: center;
+    display: flex;
+    margin-bottom: 12px;
+    padding: 14px;
+  }
+
   &__header {
     display: flex;
     flex: 1;
@@ -67,5 +75,18 @@ table {
       margin-right: -10px;
       margin-top: -10px;
     }
+  }
+}
+.nav-button-with-text {
+  margin: 0 10px 0 0;
+  padding: 0 5px;
+
+  &__span {
+    align-items: center;
+    display: flex;
+  }
+
+  &__icon {
+    margin-right: 5px;
   }
 }

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-service.ts
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-service.ts
@@ -8,7 +8,7 @@ import { entityFactory } from '../../../../store/src/helpers/entity-factory';
 import { EntityInfo } from '../../../../store/src/types/api.types';
 import { autoscalerTransformArrayToMap } from '../../core/autoscaler-helpers/autoscaler-transform-policy';
 import { GetAppAutoscalerPolicyAction } from '../../store/app-autoscaler.actions';
-import { AppAutoscalerPolicy, AppAutoscalerPolicyLocal } from '../../store/app-autoscaler.types';
+import { AppAutoscalerPolicyLocal } from '../../store/app-autoscaler.types';
 import { appAutoscalerPolicySchemaKey } from '../../store/autoscaler.store.module';
 
 @Injectable()
@@ -47,13 +47,13 @@ export class EditAutoscalerPolicyService {
       first(),
     ).subscribe((({ entity }) => {
       if (entity && entity.entity) {
-        this.stateSubject.next(entity.entity);
+        this.setState(entity.entity);
       }
     }));
   }
 
   setState(state: AppAutoscalerPolicyLocal) {
-    const {...newState} = state;
+    const newState = JSON.parse(JSON.stringify(state));
     this.stateSubject.next(newState);
   }
 

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step1/edit-autoscaler-policy-step1.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step1/edit-autoscaler-policy-step1.component.html
@@ -1,4 +1,6 @@
 <div *ngIf="appAutoscalerPolicy$ | async as policy">
+  Use minimum and maximum instance counts to provide default values for your policy.
+  <!-- Instance counts are used to define the default minimal and maximal instance number of your application. -->
   <form [formGroup]="editLimitForm" validate class="stepper-form">
     <mat-form-field>
       <input matInput placeholder="Minimum Instance Count" formControlName="instance_min_count" type="number" required>

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step2/edit-autoscaler-policy-step2.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step2/edit-autoscaler-policy-step2.component.html
@@ -36,7 +36,10 @@
                 <mat-form-field>
                   <input matInput placeholder="Threshold" type="number" formControlName="threshold" required>
                 </mat-form-field>
-                {{getMetricUnit(rule.metric_type)}} for
+                <span class="autoscaler-policy-edit-trigger-item__unit">
+                  {{metricUnit$ | async}}
+                </span>
+                for
                 <mat-form-field>
                   <input matInput placeholder="Breach Duration" type="number" formControlName="breach_duration_secs">
                 </mat-form-field>

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step2/edit-autoscaler-policy-step2.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step2/edit-autoscaler-policy-step2.component.html
@@ -1,4 +1,6 @@
 <div *ngIf="appAutoscalerPolicy$ | async as policy">
+  <p>Add scaling rules that work with built-in metrics to scale your application. Metrics are averaged over all the
+    instances of your application.</p>
   <app-tile-grid class="app-autoscaler-tile-grid-100">
     <app-tile-group *ngFor="let rule of policy.scaling_rules_form; let index = index">
       <app-tile>
@@ -38,7 +40,7 @@
                 <mat-form-field>
                   <input matInput placeholder="Breach Duration" type="number" formControlName="breach_duration_secs">
                 </mat-form-field>
-                seconsds, then {{editScaleType=='upper'?'add':'remove'}}
+                seconds, then {{editScaleType=='upper'?'add':'remove'}}
                 <mat-form-field>
                   <input matInput placeholder="Adjustment" type="number" formControlName="adjustment" required>
                 </mat-form-field>

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step2/edit-autoscaler-policy-step2.component.scss
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step2/edit-autoscaler-policy-step2.component.scss
@@ -19,6 +19,10 @@
   .autoscaler-policy-edit-trigger-item-desc {
     margin-bottom: .5em;
   }
+  .autoscaler-policy-edit-trigger-item__unit {
+    display: inline-block;
+    width: 23px;
+  }
   mat-error {
     font-size: 85%;
   }

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step3/edit-autoscaler-policy-step3.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step3/edit-autoscaler-policy-step3.component.html
@@ -1,4 +1,6 @@
 <div *ngIf="appAutoscalerPolicy$ | async as policy">
+  <p>Add schedules that reoccur to overwrite the default instance limits for specific time periods. During these time
+    periods, all dynamic scaling rules are still effective.</p>
   <app-tile-grid class="app-autoscaler-tile-grid-100">
     <app-tile-group *ngFor="let rule of policy.schedules && policy.schedules.recurring_schedule; let index = index">
       <app-tile>

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step4/edit-autoscaler-policy-step4.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step4/edit-autoscaler-policy-step4.component.html
@@ -1,4 +1,6 @@
 <div *ngIf="appAutoscalerPolicy$ | async as policy">
+  <p>Add schedules for specific dates and times that overwrite the default instance limits. Like reoccuring schedules,
+    during these time periods all dynamic scaling rules are still effective.</p>
   <app-tile-grid class="app-autoscaler-tile-grid-100">
     <app-tile-group *ngFor="let rule of policy.schedules && policy.schedules.specific_date; let index = index">
       <app-tile>

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step4/edit-autoscaler-policy-step4.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step4/edit-autoscaler-policy-step4.component.ts
@@ -20,10 +20,11 @@ import {
 } from '../../../core/autoscaler-helpers/autoscaler-validation';
 import { UpdateAppAutoscalerPolicyAction } from '../../../store/app-autoscaler.actions';
 import {
+  AppAutoscalerInvalidPolicyError,
   AppAutoscalerPolicy,
   AppAutoscalerPolicyLocal,
   AppSpecificDate,
-  AppAutoscalerInvalidPolicyError } from '../../../store/app-autoscaler.types';
+} from '../../../store/app-autoscaler.types';
 import { appAutoscalerPolicySchemaKey } from '../../../store/autoscaler.store.module';
 import { EditAutoscalerPolicy } from '../edit-autoscaler-policy-base-step';
 import { EditAutoscalerPolicyService } from '../edit-autoscaler-policy-service';
@@ -91,19 +92,12 @@ export class EditAutoscalerPolicyStep4Component extends EditAutoscalerPolicy imp
     const waitForAppAutoscalerUpdateStatus$ = this.updateAppAutoscalerPolicyService.entityMonitor.entityRequest$.pipe(
       filter(request => {
         if (request.message && request.message.indexOf('fetch policy') >= 0) {
-          request.message = '';
           return false;
         } else {
           return !!request.error || !!request.response;
         }
       }),
-      map(request => {
-        const msg = request.message;
-        request.error = false;
-        request.response = null;
-        request.message = '';
-        return msg;
-      }),
+      map(request => request.message),
       distinctUntilChanged(),
     ).pipe(map(
       errorMessage => {
@@ -127,7 +121,7 @@ export class EditAutoscalerPolicyStep4Component extends EditAutoscalerPolicy imp
   }
 
   addSpecificDate = () => {
-    const {...newSchedule} = AutoscalerConstants.PolicyDefaultSpecificDate;
+    const { ...newSchedule } = AutoscalerConstants.PolicyDefaultSpecificDate;
     this.currentPolicy.schedules.specific_date.push(newSchedule);
     this.editSpecificDate(this.currentPolicy.schedules.specific_date.length - 1);
   }

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy.component.html
@@ -1,6 +1,7 @@
 <div class="autoscaler-policy-edit-steppers">
   <app-page-header>
-    <h1>Edit AutoScaler Policy: {{ (applicationService.application$ | async)?.app.entity.name }} </h1>
+    <h1>{{isCreate ? 'Create' : 'Edit' }} AutoScaler Policy:
+      {{ (applicationService.application$ | async)?.app.entity.name }} </h1>
     <div class="page-header-right">
       <button mat-icon-button mat-button routerLink="{{parentUrl}}">
         <mat-icon>clear</mat-icon>
@@ -11,10 +12,12 @@
     <app-step [title]="'Default Instance Limits'" [valid]="step1.editLimitForm.valid" [onNext]="step1.onNext">
       <app-edit-autoscaler-policy-step1 #step1></app-edit-autoscaler-policy-step1>
     </app-step>
-    <app-step [title]="'Scaling Rules'" [disablePrevious]="step2.editIndex!=-1" [valid]="step2.editIndex==-1" [onNext]="step2.onNext">
+    <app-step [title]="'Scaling Rules'" [disablePrevious]="step2.editIndex!=-1" [valid]="step2.editIndex==-1"
+      [onNext]="step2.onNext">
       <app-edit-autoscaler-policy-step2 #step2></app-edit-autoscaler-policy-step2>
     </app-step>
-    <app-step [title]="'Recurring Schedules'" [disablePrevious]="step3.editIndex!=-1" [valid]="step3.editIndex==-1" [onNext]="step3.onNext">
+    <app-step [title]="'Recurring Schedules'" [disablePrevious]="step3.editIndex!=-1" [valid]="step3.editIndex==-1"
+      [onNext]="step3.onNext">
       <app-edit-autoscaler-policy-step3 #step3></app-edit-autoscaler-policy-step3>
     </app-step>
     <app-step [title]="'Specific Dates'" [disablePrevious]="step4.editIndex!=-1" [onNext]="step4.updatePolicy"

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy.component.scss
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy.component.scss
@@ -1,16 +1,3 @@
 .autoscaler-policy-edit-steppers {
   height: 100%;
-  app-edit-autoscaler-policy-step1 {
-    width: 50%;
-  }
-  app-edit-autoscaler-policy-step2 {
-    width: 100%;
-  }
-  app-edit-autoscaler-policy-step3 {
-    width: 100%;
-  }
-  app-edit-autoscaler-policy-step4 {
-    width: 100%;
-  }
 }
-

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit } from '@angular/core';
+import { ErrorStateMatcher, ShowOnDirtyErrorStateMatcher } from '@angular/material';
+import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { map, publishReplay, refCount } from 'rxjs/operators';
-import { ErrorStateMatcher, ShowOnDirtyErrorStateMatcher } from '@angular/material';
 
 import { ApplicationService } from '../../../../core/src/features/applications/application.service';
 import { EditAutoscalerPolicyService } from './edit-autoscaler-policy-service';
@@ -19,9 +20,11 @@ export class EditAutoscalerPolicyComponent implements OnInit {
 
   parentUrl = `/applications/${this.applicationService.cfGuid}/${this.applicationService.appGuid}/autoscale`;
   applicationName$: Observable<string>;
+  isCreate = false;
 
   constructor(
     public applicationService: ApplicationService,
+    private route: ActivatedRoute
   ) {
   }
 
@@ -31,6 +34,7 @@ export class EditAutoscalerPolicyComponent implements OnInit {
       publishReplay(1),
       refCount()
     );
+    this.isCreate = this.route.snapshot.queryParams.create;
   }
 
 }

--- a/src/frontend/packages/cf-autoscaler/src/shared/card-autoscaler-default/card-autoscaler-default.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/shared/card-autoscaler-default/card-autoscaler-default.component.html
@@ -1,48 +1,27 @@
 <mat-card class="card-autoscaler-default">
-  <div class="card-autoscaler-default__left">
-    <mat-card-header>
-      <mat-card-title>Instances</mat-card-title>
-    </mat-card-header>
-    <mat-card-content>
-      <div class="app-metadata">
-        <div class="app-metadata__two-cols">
-          <app-metadata-item label="Current">
-            <app-running-instances [instances]="applicationInstances$ | async" [cfGuid]="appService.cfGuid"
-              [appGuid]="this.appService.appGuid">
-            </app-running-instances>
-          </app-metadata-item>
+  <mat-card-header>
+    <mat-card-title>Instances</mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <app-metadata-item label="Current">
+      <app-running-instances [instances]="applicationInstances$ | async" [cfGuid]="appService.cfGuid"
+        [appGuid]="this.appService.appGuid">
+      </app-running-instances>
+    </app-metadata-item>
+    <div class="card-autoscaler-default__min-max">
+      <app-metadata-item label="Minimum">
+        <div *ngIf="appAutoscalerPolicy$ | async as policy">
+          <div>{{ policy.instance_min_count }}</div>
         </div>
-      </div>
-    </mat-card-content>
-  </div>
-  <div class="card-autoscaler-default__right">
-    <mat-card-header>
-      <mat-card-title>Limits</mat-card-title>
-    </mat-card-header>
-    <mat-card-content>
-      <div class="app-metadata">
-        <div class="app-metadata__two-cols">
-          <app-metadata-item label="Minimum">
-            <div *ngIf="appAutoscalerPolicy$ | async as policy">
-              <div>{{ policy.instance_min_count }}</div>
-            </div>
-            <div *ngIf="!(appAutoscalerPolicy$ | async)">-</div>
-          </app-metadata-item>
+        <div *ngIf="!(appAutoscalerPolicy$ | async)">-</div>
+      </app-metadata-item>
+      <app-metadata-item label="Maximum">
+        <div *ngIf="appAutoscalerPolicy$ | async as policy">
+          <div>{{ policy.instance_max_count }}</div>
         </div>
-        <div class="app-metadata__two-cols">
-          <app-metadata-item label="Maximum">
-            <div *ngIf="appAutoscalerPolicy$ | async as policy">
-              <div>{{ policy.instance_max_count }}</div>
-            </div>
-            <div *ngIf="!(appAutoscalerPolicy$ | async)">-</div>
-          </app-metadata-item>
-        </div>
-      </div>
-    </mat-card-content>
-  </div>
-  <mat-card-actions *ngIf="(appAutoscalerPolicy$ | async)" class="card-autoscaler-default__actions">
-    <button (click)="onUpdate()" mat-icon-button>
-      <mat-icon>edit</mat-icon>
-    </button>
-  </mat-card-actions>
+        <div *ngIf="!(appAutoscalerPolicy$ | async)">-</div>
+      </app-metadata-item>
+    </div>
+  </mat-card-content>
+
 </mat-card>

--- a/src/frontend/packages/cf-autoscaler/src/shared/card-autoscaler-default/card-autoscaler-default.component.scss
+++ b/src/frontend/packages/cf-autoscaler/src/shared/card-autoscaler-default/card-autoscaler-default.component.scss
@@ -1,52 +1,10 @@
 .card-autoscaler-default {
-  &__left {
-    border-right: 1px solid #808080;
-    display: inline-block;
-    padding-right: 1em;
-  }
+  &__min-max {
+    display: flex;
+    flex-direction: row;
 
-  &__right {
-    display: inline-block;
-    padding-left: 1em;
-  }
-
-  &__actions {
-    bottom: 24px;
-    padding-top: 0;
-    position: absolute;
-    right: 24px;
-    text-align: right;
-  }
-
-  app-metadata-item {
-    .metadata-item__content {
-      flex-direction: row;
-    }
-  }
-
-  .metadata-item__content {
-    display: inline;
-  }
-
-  .metadata-item__value {
-    display: inline;
-    margin-right: 10px;
-  }
-
-  .metadata-item__label {
-    display: inline;
-    margin-right: 10px;
-  }
-}
-
-.app-metadata {
-  display: flex;
-  flex-direction: row;
-  &__two-cols {
-    flex: 1;
-    margin-right: 1em;
-    app-metadata-item:first-child {
-      margin-top: 0;
+    app-metadata-item {
+      padding-right: 10px;
     }
   }
 }

--- a/src/frontend/packages/cf-autoscaler/src/store/app-autoscaler.actions.ts
+++ b/src/frontend/packages/cf-autoscaler/src/store/app-autoscaler.actions.ts
@@ -9,6 +9,7 @@ import { AppAutoscalerPolicyLocal, AppScalingTrigger } from './app-autoscaler.ty
 import {
   appAutoscalerAppMetricSchemaKey,
   appAutoscalerHealthSchemaKey,
+  appAutoscalerInfoSchemaKey,
   appAutoscalerPolicySchemaKey,
   appAutoscalerPolicyTriggerSchemaKey,
   appAutoscalerScalingHistorySchemaKey,
@@ -45,14 +46,28 @@ export const DETACH_APP_AUTOSCALER_POLICY = '[New App Autoscaler] Detach policy'
 export const APP_AUTOSCALER_HEALTH = '[New App Autoscaler] Fetch Health';
 export const APP_AUTOSCALER_SCALING_HISTORY = '[New App Autoscaler] Fetch Scaling History';
 export const FETCH_APP_AUTOSCALER_METRIC = '[New App Autoscaler] Fetch Metric';
+export const AUTOSCALER_INFO = '[Autoscaler] Fetch Info';
 
 export const UPDATE_APP_AUTOSCALER_POLICY_STEP = '[Edit Autoscaler Policy] Step';
 
-export class GetAppAutoscalerHealthAction implements IRequestAction {
+export class GetAppAutoscalerInfoAction implements IRequestAction {
+  public guid: string;
   constructor(
-    public guid: string,
     public endpointGuid: string,
   ) {
+    this.guid = endpointGuid;
+  }
+  type = AUTOSCALER_INFO;
+  entity = entityFactory(appAutoscalerInfoSchemaKey);
+  entityKey = appAutoscalerInfoSchemaKey;
+}
+
+export class GetAppAutoscalerHealthAction implements IRequestAction {
+  public guid: string;
+  constructor(
+    public endpointGuid: string,
+  ) {
+    this.guid = endpointGuid;
   }
   type = APP_AUTOSCALER_HEALTH;
   entity = entityFactory(appAutoscalerHealthSchemaKey);

--- a/src/frontend/packages/cf-autoscaler/src/store/app-autoscaler.types.ts
+++ b/src/frontend/packages/cf-autoscaler/src/store/app-autoscaler.types.ts
@@ -1,5 +1,12 @@
 import { AutoscalerQuery } from './app-autoscaler.actions';
 
+export interface AutoscalerInfo {
+  name: string;
+  build: string;
+  support: string;
+  description: string;
+}
+
 export interface AppAutoscalerPolicy {
   instance_min_count: number;
   instance_max_count: number;

--- a/src/frontend/packages/cf-autoscaler/src/store/autoscaler.effects.ts
+++ b/src/frontend/packages/cf-autoscaler/src/store/autoscaler.effects.ts
@@ -12,7 +12,7 @@ import {
   resultPerPageParamDefault,
 } from '../../../store/src/reducers/pagination-reducer/pagination-reducer.types';
 import { selectPaginationState } from '../../../store/src/selectors/pagination.selectors';
-import { APIResource, NormalizedResponse } from '../../../store/src/types/api.types';
+import { APIResource, NormalizedResponse, PaginationResponse } from '../../../store/src/types/api.types';
 import { PaginatedAction, PaginationEntityState, PaginationParam } from '../../../store/src/types/pagination.types';
 import {
   StartRequestAction,
@@ -30,28 +30,29 @@ import {
   APP_AUTOSCALER_POLICY,
   APP_AUTOSCALER_POLICY_TRIGGER,
   APP_AUTOSCALER_SCALING_HISTORY,
+  AUTOSCALER_INFO,
+  AutoscalerPaginationParams,
   AutoscalerQuery,
   DETACH_APP_AUTOSCALER_POLICY,
   DetachAppAutoscalerPolicyAction,
   FETCH_APP_AUTOSCALER_METRIC,
   GetAppAutoscalerHealthAction,
+  GetAppAutoscalerInfoAction,
   GetAppAutoscalerMetricAction,
   GetAppAutoscalerPolicyAction,
   GetAppAutoscalerPolicyTriggerAction,
   GetAppAutoscalerScalingHistoryAction,
   UPDATE_APP_AUTOSCALER_POLICY,
   UpdateAppAutoscalerPolicyAction,
-  AutoscalerPaginationParams,
 } from './app-autoscaler.actions';
 import {
-  AppAutoscalerFetchPolicyFailedResponse,
-  AppAutoscalerMetricDataLocal,
-  AppScalingTrigger,
-  AppAutoscalerMetricData,
-  AppAutoscalerPolicyLocal,
   AppAutoscalerEvent,
+  AppAutoscalerFetchPolicyFailedResponse,
+  AppAutoscalerMetricData,
+  AppAutoscalerMetricDataLocal,
+  AppAutoscalerPolicyLocal,
+  AppScalingTrigger,
 } from './app-autoscaler.types';
-import { PaginationResponse } from '../../../store/src/types/api.types';
 
 const { proxyAPIVersion } = environment;
 const commonPrefix = `/pp/${proxyAPIVersion}/autoscaler`;
@@ -67,6 +68,35 @@ export class AutoscalerEffects {
     private actions$: Actions,
     private store: Store<AppState>,
   ) { }
+
+  @Effect()
+  fetchAutoscalerInfo$ = this.actions$.pipe(
+    ofType<GetAppAutoscalerInfoAction>(AUTOSCALER_INFO),
+    mergeMap(action => {
+      const actionType = 'fetch';
+      this.store.dispatch(new StartRequestAction(action, actionType));
+      const options = new RequestOptions();
+      options.url = `${commonPrefix}/info`;
+      options.method = 'get';
+      options.headers = this.addHeaders(action.endpointGuid);
+      return this.http
+        .request(new Request(options)).pipe(
+          mergeMap(response => {
+            console.log(response);
+            const autoscalerInfo = response.json();
+            const mappedData = {
+              entities: { [action.entityKey]: {} },
+              result: []
+            } as NormalizedResponse;
+            this.transformData(action.entityKey, mappedData, action.endpointGuid, autoscalerInfo);
+            return [
+              new WrapperRequestActionSuccess(mappedData, action, actionType)
+            ];
+          }),
+          catchError(err => [
+            new WrapperRequestActionFailed(createAutoscalerRequestMessage('fetch autoscaler info', err), action, actionType)
+          ]));
+    }));
 
   @Effect()
   fetchAppAutoscalerHealth$ = this.actions$.pipe(
@@ -86,7 +116,7 @@ export class AutoscalerEffects {
               entities: { [action.entityKey]: {} },
               result: []
             } as NormalizedResponse;
-            this.transformData(action.entityKey, mappedData, action.guid, healthInfo);
+            this.transformData(action.entityKey, mappedData, action.endpointGuid, healthInfo);
             return [
               new WrapperRequestActionSuccess(mappedData, action, actionType)
             ];
@@ -348,14 +378,14 @@ export class AutoscalerEffects {
     mappedData.result.push(id);
   }
 
-  transformData(key: string, mappedData: NormalizedResponse, appGuid: string, data: any) {
-    mappedData.entities[key][appGuid] = {
+  transformData(key: string, mappedData: NormalizedResponse, guid: string, data: any) {
+    mappedData.entities[key][guid] = {
       entity: data,
       metadata: {
-        guid: appGuid
+        guid
       }
     };
-    mappedData.result.push(appGuid);
+    mappedData.result.push(guid);
   }
 
   transformEventData(key: string, mappedData: NormalizedResponse, appGuid: string, data: PaginationResponse<AppAutoscalerEvent>) {

--- a/src/frontend/packages/cf-autoscaler/src/store/autoscaler.effects.ts
+++ b/src/frontend/packages/cf-autoscaler/src/store/autoscaler.effects.ts
@@ -82,7 +82,6 @@ export class AutoscalerEffects {
       return this.http
         .request(new Request(options)).pipe(
           mergeMap(response => {
-            console.log(response);
             const autoscalerInfo = response.json();
             const mappedData = {
               entities: { [action.entityKey]: {} },

--- a/src/frontend/packages/cf-autoscaler/src/store/autoscaler.store.module.ts
+++ b/src/frontend/packages/cf-autoscaler/src/store/autoscaler.store.module.ts
@@ -6,12 +6,18 @@ import { ExtensionEntitySchema } from '../../../core/src/core/extension/extensio
 import { getAPIResourceGuid } from '../../../store/src/selectors/api.selectors';
 
 export const appAutoscalerHealthSchemaKey = 'autoscalerHealth';
+export const appAutoscalerInfoSchemaKey = 'autoscalerInfo';
 export const appAutoscalerPolicySchemaKey = 'autoscalerPolicy';
 export const appAutoscalerPolicyTriggerSchemaKey = 'autoscalerPolicyTrigger';
 export const appAutoscalerScalingHistorySchemaKey = 'autoscalerScalingHistory';
 export const appAutoscalerAppMetricSchemaKey = 'autoscalerAppMetric';
 
 export const autoscalerEntities: ExtensionEntitySchema[] = [
+  {
+    entityKey: appAutoscalerInfoSchemaKey,
+    definition: {},
+    options: { idAttribute: getAPIResourceGuid }
+  },
   {
     entityKey: appAutoscalerPolicySchemaKey,
     definition: {},

--- a/src/frontend/packages/core/src/shared/components/cards/card-cf-info/card-cf-info.component.html
+++ b/src/frontend/packages/core/src/shared/components/cards/card-cf-info/card-cf-info.component.html
@@ -8,21 +8,29 @@
         <div class="app-metadata__two-cols">
           <app-metadata-item icon="title" label="Description">{{ (description$ | async) }}</app-metadata-item>
           <app-metadata-item icon="link" label="Instance Address">{{ apiUrl }}</app-metadata-item>
-          <app-metadata-item icon="info_outline" label="CF API Version">{{ (cfEndpointService.info$ | async)?.entity.entity.api_version }}</app-metadata-item>
+          <app-metadata-item icon="info_outline" label="CF API Version">
+            {{ (cfEndpointService.info$ | async)?.entity.entity.api_version }}</app-metadata-item>
+          <app-metadata-item *ngIf="autoscalerVersion$ | async as autoscalerVersion" icon="meter"
+            iconFont="stratos-icons" label="Autoscaler Version">
+            {{ autoscalerVersion }}</app-metadata-item>
         </div>
         <div class="app-metadata__two-cols">
-          <app-metadata-item icon="person" label="Account Username">{{ (cfEndpointService.endpoint$ | async )?.entity.user.name }}
+          <app-metadata-item icon="person" label="Account Username">
+            {{ (cfEndpointService.endpoint$ | async )?.entity.user.name }}
             <span *ngIf="(cfEndpointService.endpoint$ | async )?.entity.user.admin"> (Administrator)</span>
           </app-metadata-item>
-          <app-metadata-item icon="developer_mode" label="SSH Access">{{ (cfEndpointService.hasSSHAccess$ | async) ? 'Available' : 'Not available'}}</app-metadata-item>
+          <app-metadata-item icon="developer_mode" label="SSH Access">
+            {{ (cfEndpointService.hasSSHAccess$ | async) ? 'Available' : 'Not available'}}</app-metadata-item>
           <app-metadata-item icon="email" label="User Invitation Support">
             <div class="user-invites">
               <ng-container *ngIf="(userInviteService.canConfigure$ | async) else cannotConfigure">
                 <ng-container *ngIf="(userInviteService.configured$ | async); else inviteNotConfigured">
-                  Configured - <button color="primary" mat-button (click)="deConfigureUserInvites()" [disabled]="userInviteBusy">Disable</button>
+                  Configured - <button color="primary" mat-button (click)="deConfigureUserInvites()"
+                    [disabled]="userInviteBusy">Disable</button>
                 </ng-container>
                 <ng-template #inviteNotConfigured>
-                  Not Configured - <button color="primary" mat-button (click)="configureUserInvites()">Configure</button>
+                  Not Configured - <button color="primary" mat-button
+                    (click)="configureUserInvites()">Configure</button>
                 </ng-template>
               </ng-container>
               <ng-template #cannotConfigure>

--- a/src/frontend/packages/core/src/shared/components/cards/card-cf-info/card-cf-info.component.ts
+++ b/src/frontend/packages/core/src/shared/components/cards/card-cf-info/card-cf-info.component.ts
@@ -3,8 +3,10 @@ import { MatDialog } from '@angular/material';
 import { Observable, Subscription } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 
+import { fetchAutoscalerInfo } from '../../../../../../cf-autoscaler/src/core/autoscaler-helpers/autoscaler-available';
 import { APIResource, EntityInfo } from '../../../../../../store/src/types/api.types';
 import { ICfV2Info } from '../../../../core/cf-api.types';
+import { EntityServiceFactory } from '../../../../core/entity-service-factory.service';
 import { CloudFoundryEndpointService } from '../../../../features/cloud-foundry/services/cloud-foundry-endpoint.service';
 import {
   UserInviteConfigurationDialogComponent,
@@ -17,13 +19,15 @@ import { UserInviteService } from '../../../../features/cloud-foundry/user-invit
   styleUrls: ['./card-cf-info.component.scss']
 })
 export class CardCfInfoComponent implements OnInit, OnDestroy {
-  apiUrl: string;
-  subs: Subscription[] = [];
+  public apiUrl: string;
+  private subs: Subscription[] = [];
+  public autoscalerVersion$: Observable<string>;
 
   constructor(
     public cfEndpointService: CloudFoundryEndpointService,
     public userInviteService: UserInviteService,
     private dialog: MatDialog,
+    private esf: EntityServiceFactory
   ) { }
 
   description$: Observable<string>;
@@ -38,6 +42,12 @@ export class CardCfInfoComponent implements OnInit, OnDestroy {
 
     this.description$ = this.cfEndpointService.info$.pipe(
       map(entity => this.getDescription(entity))
+    );
+
+    this.autoscalerVersion$ = fetchAutoscalerInfo(this.cfEndpointService.cfGuid, this.esf).pipe(
+      map(e => e.entityRequestInfo.error ?
+        null :
+        e.entity ? e.entity.entity.build : ''),
     );
   }
 

--- a/src/jetstream/plugins/autoscaler/autoscaler.go
+++ b/src/jetstream/plugins/autoscaler/autoscaler.go
@@ -7,6 +7,15 @@ import (
 	"github.com/labstack/echo"
 )
 
+func (a *Autoscaler) getAutoscalerInfo(echoContext echo.Context) error {
+	healthURL, _ := url.Parse("/v1/info")
+	responses, err := a.portalProxy.ProxyRequest(echoContext, healthURL)
+	if err != nil {
+		return err
+	}
+	return a.portalProxy.SendProxiedResponse(echoContext, responses)
+}
+
 func (a *Autoscaler) getAutoscalerHealth(echoContext echo.Context) error {
 	healthURL, _ := url.Parse("/health")
 	responses, err := a.portalProxy.ProxyRequest(echoContext, healthURL)

--- a/src/jetstream/plugins/autoscaler/main.go
+++ b/src/jetstream/plugins/autoscaler/main.go
@@ -39,6 +39,7 @@ func (a *Autoscaler) AddAdminGroupRoutes(echoGroup *echo.Group) {
 
 // AddSessionGroupRoutes adds the session routes for this plugin to the Echo server
 func (a *Autoscaler) AddSessionGroupRoutes(echoGroup *echo.Group) {
+	echoGroup.GET("/autoscaler/info", a.getAutoscalerInfo)
 	echoGroup.GET("/autoscaler/health", a.getAutoscalerHealth)
 	echoGroup.GET("/autoscaler/apps/:appId/policy", a.getAutoscalerPolicy)
 	echoGroup.PUT("/autoscaler/apps/:appId/policy", a.attachAutoscalerPolicy)


### PR DESCRIPTION
- Move create/edit/delete policy buttons into tab header
- Show standard 'no content' style message when no policy attached
- Show scaling history only when there's history OR there's a policy
- Don't show error snack bar for no policy
- Tweak card layouts and widths
- Tweak some error messages
- Add brief text for each step
- Show Create/Edit in stepper given create/edit

Update
- Determine if app autoscaler tab should show depending on autoscaler v1/info request rather than 
 a per app request for it's policy
- Also show autoscaler version in cf summary page