### PR TITLE
Fix errored endpoint pipeline

### DIFF
--- a/src/frontend/packages/store/src/entity-request-pipeline/pagination-request-base-handlers/pagination-iterator.pipe.ts
+++ b/src/frontend/packages/store/src/entity-request-pipeline/pagination-request-base-handlers/pagination-iterator.pipe.ts
@@ -83,7 +83,7 @@ export class PaginationPageIterator<R = any, E = any> {
   }
 
   private handleRequests(initialResponse: JetstreamResponse<R>, action: PaginatedAction, totalPages: number, totalResults: number) {
-    f(totalResults > 0) {
+    if (totalResults > 0) {
       const maxCount = action.flattenPaginationMax;
       // We're maxed so only respond with the first page of results.
       if (maxCount < totalResults) {


### PR DESCRIPTION
When an endpoint errors we end up with an out of memory error in the browser.