### PR TITLE
Fix several service related bugs, some related to space scoped services

### DIFF
--- a/src/frontend/packages/core/src/features/service-catalog/service-summary/service-summary.component.spec.ts
+++ b/src/frontend/packages/core/src/features/service-catalog/service-summary/service-summary.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
 import { BaseTestModules } from '../../../../test-framework/cloud-foundry-endpoint-service.helper';
 import { ServicesService } from '../services.service';
 import { ServicesServiceMock } from '../services.service.mock';

--- a/src/frontend/packages/core/src/features/service-catalog/service-tabs-base/service-tabs-base.component.ts
+++ b/src/frontend/packages/core/src/features/service-catalog/service-tabs-base/service-tabs-base.component.ts
@@ -72,7 +72,7 @@ export class ServiceTabsBaseComponent {
 
   getServiceLabel = (): Observable<string> => {
     return this.servicesService.service$.pipe(
-      map((s) => !!s.entity.extra ? JSON.parse(s.entity.extra).displayName : s.entity.label),
+      map((s) => !!s.entity.extra ? JSON.parse(s.entity.extra).displayName || s.entity.label : s.entity.label),
       publishReplay(1),
       refCount()
     );

--- a/src/frontend/packages/core/src/shared/components/add-service-instance/create-service-instance-helper.service.ts
+++ b/src/frontend/packages/core/src/shared/components/add-service-instance/create-service-instance-helper.service.ts
@@ -1,7 +1,7 @@
 import { Inject } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
-import { filter, map, publishReplay, refCount, share, switchMap } from 'rxjs/operators';
+import { filter, map, publishReplay, refCount, switchMap } from 'rxjs/operators';
 
 import { GetServiceInstances } from '../../../../../store/src/actions/service-instances.actions';
 import { GetServicePlanVisibilities } from '../../../../../store/src/actions/service-plan-visibility.actions';
@@ -204,7 +204,8 @@ export class CreateServiceInstanceHelper {
       )
     }, true)
       .entities$.pipe(
-        share()
+        publishReplay(1),
+        refCount()
       );
   }
 

--- a/src/frontend/packages/core/src/shared/components/add-service-instance/select-plan-step/select-plan-step.component.ts
+++ b/src/frontend/packages/core/src/shared/components/add-service-instance/select-plan-step/select-plan-step.component.ts
@@ -24,10 +24,7 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 
-import {
-  SetCreateServiceInstanceCFDetails,
-  SetCreateServiceInstanceServicePlan,
-} from '../../../../../../store/src/actions/create-service-instance.actions';
+import { SetCreateServiceInstanceServicePlan } from '../../../../../../store/src/actions/create-service-instance.actions';
 import { AppState } from '../../../../../../store/src/app-state';
 import { selectCreateServiceInstance } from '../../../../../../store/src/selectors/create-service-instance.selectors';
 import { APIResource } from '../../../../../../store/src/types/api.types';
@@ -78,10 +75,6 @@ export class SelectPlanStepComponent implements OnDestroy {
     this.stepperForm = new FormGroup({
       servicePlans: new FormControl('', Validators.required),
     });
-
-    if (modeService.isMarketplaceMode()) {
-      this.store.dispatch(new SetCreateServiceInstanceCFDetails(activatedRoute.snapshot.params.endpointId));
-    }
 
     this.servicePlans$ = this.store.select(selectCreateServiceInstance).pipe(
       filter(p => !!p.orgGuid && !!p.spaceGuid && !!p.serviceGuid),

--- a/src/frontend/packages/core/src/shared/components/cards/service-broker-card/service-broker-card.component.html
+++ b/src/frontend/packages/core/src/shared/components/cards/service-broker-card/service-broker-card.component.html
@@ -21,7 +21,7 @@
   <app-meta-card-item>
     <app-meta-card-key>Space Scoped</app-meta-card-key>
     <app-meta-card-value>
-      <app-boolean-indicator [isTrue]="(serviceBroker$ | async)?.entity.space_guid" type="yes-no">
+      <app-boolean-indicator [isTrue]="!!(serviceBroker$ | async)?.entity.space_guid" type="yes-no">
       </app-boolean-indicator>
     </app-meta-card-value>
   </app-meta-card-item>

--- a/src/frontend/packages/core/src/shared/components/cards/service-broker-card/service-broker-card.component.ts
+++ b/src/frontend/packages/core/src/shared/components/cards/service-broker-card/service-broker-card.component.ts
@@ -1,6 +1,6 @@
-import { Component } from '@angular/core';
-import { Observable } from 'rxjs';
-import { filter, first, map, switchMap, take } from 'rxjs/operators';
+import { Component, OnDestroy } from '@angular/core';
+import { Observable, Subscription } from 'rxjs';
+import { filter, map, switchMap, take, tap } from 'rxjs/operators';
 
 import { GetSpace } from '../../../../../../store/src/actions/space.actions';
 import { entityFactory, spaceSchemaKey, spaceWithOrgKey } from '../../../../../../store/src/helpers/entity-factory';
@@ -8,6 +8,7 @@ import { APIResource } from '../../../../../../store/src/types/api.types';
 import { IServiceBroker } from '../../../../core/cf-api-svc.types';
 import { ISpace } from '../../../../core/cf-api.types';
 import { EntityServiceFactory } from '../../../../core/entity-service-factory.service';
+import { safeUnsubscribe } from '../../../../core/utils.service';
 import { ServicesService } from '../../../../features/service-catalog/services.service';
 
 @Component({
@@ -15,43 +16,48 @@ import { ServicesService } from '../../../../features/service-catalog/services.s
   templateUrl: './service-broker-card.component.html',
   styleUrls: ['./service-broker-card.component.scss']
 })
-export class ServiceBrokerCardComponent {
+export class ServiceBrokerCardComponent implements OnDestroy {
 
   spaceName: string;
   spaceLink: string[];
   serviceBroker$: Observable<APIResource<IServiceBroker>>;
+  subs: Subscription[] = [];
+
   constructor(
     servicesService: ServicesService,
     entityServiceFactory: EntityServiceFactory
   ) {
     this.serviceBroker$ = servicesService.serviceBroker$;
 
-    this.serviceBroker$.pipe(
+    this.subs.push(this.serviceBroker$.pipe(
       filter(o => !!o),
       map(o => o.entity.space_guid),
       take(1),
       filter(o => !!o),
       // Broker is space scoped
-      switchMap(spaceGuid => {
-        const spaceService = entityServiceFactory.create<APIResource<ISpace>>(spaceSchemaKey,
+      switchMap(spaceGuid =>
+        entityServiceFactory.create<APIResource<ISpace>>(spaceSchemaKey,
           entityFactory(spaceWithOrgKey),
           spaceGuid,
           new GetSpace(spaceGuid, servicesService.cfGuid),
           true
-        );
-        return spaceService.waitForEntity$;
-      }),
-      first()
-    ).subscribe(space => {
-      this.spaceLink = ['/cloud-foundry',
-        servicesService.cfGuid,
-        'organizations',
-        space.entity.entity.organization_guid,
-        'spaces',
-        space.entity.metadata.guid,
-        'summary'
-      ];
-      this.spaceName = space.entity.entity.name;
-    });
+        ).waitForEntity$
+      ),
+      tap(space => {
+        this.spaceLink = ['/cloud-foundry',
+          servicesService.cfGuid,
+          'organizations',
+          space.entity.entity.organization_guid,
+          'spaces',
+          space.entity.metadata.guid,
+          'summary'
+        ];
+        this.spaceName = space.entity.entity.name;
+      })
+    ).subscribe());
+  }
+
+  ngOnDestroy() {
+    safeUnsubscribe(...this.subs);
   }
 }

--- a/src/frontend/packages/core/src/shared/components/cards/service-broker-card/service-broker-card.component.ts
+++ b/src/frontend/packages/core/src/shared/components/cards/service-broker-card/service-broker-card.component.ts
@@ -1,16 +1,14 @@
 import { Component } from '@angular/core';
-import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
-import { filter, map, switchMap, take, tap } from 'rxjs/operators';
+import { filter, first, map, switchMap, take } from 'rxjs/operators';
 
+import { GetSpace } from '../../../../../../store/src/actions/space.actions';
+import { entityFactory, spaceSchemaKey, spaceWithOrgKey } from '../../../../../../store/src/helpers/entity-factory';
+import { APIResource } from '../../../../../../store/src/types/api.types';
 import { IServiceBroker } from '../../../../core/cf-api-svc.types';
 import { ISpace } from '../../../../core/cf-api.types';
 import { EntityServiceFactory } from '../../../../core/entity-service-factory.service';
 import { ServicesService } from '../../../../features/service-catalog/services.service';
-import { APIResource } from '../../../../../../store/src/types/api.types';
-import { AppState } from '../../../../../../store/src/app-state';
-import { spaceSchemaKey, entityFactory, spaceWithOrgKey } from '../../../../../../store/src/helpers/entity-factory';
-import { GetSpace } from '../../../../../../store/src/actions/space.actions';
 
 @Component({
   selector: 'app-service-broker-card',
@@ -23,11 +21,10 @@ export class ServiceBrokerCardComponent {
   spaceLink: string[];
   serviceBroker$: Observable<APIResource<IServiceBroker>>;
   constructor(
-    private servicesService: ServicesService,
-    private store: Store<AppState>,
-    private entityServiceFactory: EntityServiceFactory
+    servicesService: ServicesService,
+    entityServiceFactory: EntityServiceFactory
   ) {
-    this.serviceBroker$ = this.servicesService.serviceBroker$;
+    this.serviceBroker$ = servicesService.serviceBroker$;
 
     this.serviceBroker$.pipe(
       filter(o => !!o),
@@ -36,25 +33,25 @@ export class ServiceBrokerCardComponent {
       filter(o => !!o),
       // Broker is space scoped
       switchMap(spaceGuid => {
-        const spaceService = this.entityServiceFactory.create<APIResource<ISpace>>(spaceSchemaKey,
+        const spaceService = entityServiceFactory.create<APIResource<ISpace>>(spaceSchemaKey,
           entityFactory(spaceWithOrgKey),
           spaceGuid,
-          new GetSpace(spaceGuid, this.servicesService.cfGuid),
+          new GetSpace(spaceGuid, servicesService.cfGuid),
           true
         );
         return spaceService.waitForEntity$;
       }),
-      tap(space => {
-        this.spaceLink = ['/cloud-foundry',
-          this.servicesService.cfGuid,
-          'organizations',
-          space.entity.entity.organization_guid,
-          'spaces',
-          space.entity.metadata.guid,
-          'summary'
-        ];
-        this.spaceName = space.entity.entity.name;
-      })
-    ).subscribe();
+      first()
+    ).subscribe(space => {
+      this.spaceLink = ['/cloud-foundry',
+        servicesService.cfGuid,
+        'organizations',
+        space.entity.entity.organization_guid,
+        'spaces',
+        space.entity.metadata.guid,
+        'summary'
+      ];
+      this.spaceName = space.entity.entity.name;
+    });
   }
 }

--- a/src/frontend/packages/core/src/shared/components/cards/service-recent-instances-card/service-recent-instances-card.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/cards/service-recent-instances-card/service-recent-instances-card.component.spec.ts
@@ -1,12 +1,16 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ServiceRecentInstancesCardComponent } from './service-recent-instances-card.component';
-import { BaseTestModulesNoShared, MetadataCardTestComponents } from '../../../../../test-framework/cloud-foundry-endpoint-service.helper';
-import { StatefulIconComponent } from '../../../../core/stateful-icon/stateful-icon.component';
-import { CompactServiceInstanceCardComponent } from '../compact-service-instance-card/compact-service-instance-card.component';
+import {
+  BaseTestModulesNoShared,
+  MetadataCardTestComponents,
+} from '../../../../../test-framework/cloud-foundry-endpoint-service.helper';
 import { ServicesService } from '../../../../features/service-catalog/services.service';
 import { ServicesServiceMock } from '../../../../features/service-catalog/services.service.mock';
 import { AppChipsComponent } from '../../chips/chips.component';
+import {
+  CompactServiceInstanceCardComponent,
+} from '../compact-service-instance-card/compact-service-instance-card.component';
+import { ServiceRecentInstancesCardComponent } from './service-recent-instances-card.component';
 
 describe('ServiceRecentInstancesCardComponent', () => {
   let component: ServiceRecentInstancesCardComponent;

--- a/src/frontend/packages/core/src/shared/components/cards/service-summary-card/service-summary-card.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/cards/service-summary-card/service-summary-card.component.spec.ts
@@ -1,12 +1,16 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import {
+  BaseTestModulesNoShared,
+  MetadataCardTestComponents,
+} from '../../../../../test-framework/cloud-foundry-endpoint-service.helper';
 import { ServicesService } from '../../../../features/service-catalog/services.service';
 import { ServicesServiceMock } from '../../../../features/service-catalog/services.service.mock';
-import { BaseTestModulesNoShared, MetadataCardTestComponents } from '../../../../../test-framework/cloud-foundry-endpoint-service.helper';
+import { EntityMonitorFactory } from '../../../monitors/entity-monitor.factory.service';
 import { BooleanIndicatorComponent } from '../../boolean-indicator/boolean-indicator.component';
 import { AppChipsComponent } from '../../chips/chips.component';
 import { ServiceIconComponent } from '../../service-icon/service-icon.component';
 import { ServiceSummaryCardComponent } from './service-summary-card.component';
-import { EntityMonitorFactory } from '../../../monitors/entity-monitor.factory.service';
 
 
 describe('ServiceSummaryCardComponent', () => {

--- a/src/frontend/packages/core/src/shared/components/list/list-types/cf-services/cf-user-service-instances-list-config.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/cf-services/cf-user-service-instances-list-config.ts
@@ -137,11 +137,15 @@ export class CfUserServiceInstancesListConfigBase implements IListConfig<APIReso
 
   private listActionEdit: IListAction<APIResource> = {
     action: (item: APIResource<IUserProvidedServiceInstance>) =>
-      this.serviceActionHelperService.editServiceBinding(item.metadata.guid, item.entity.cfGuid, {
-        [CANCEL_SPACE_ID_PARAM]: item.entity.space_guid,
-        [CANCEL_ORG_ID_PARAM]: item.entity.space.entity.organization_guid,
-        [CANCEL_USER_PROVIDED]: true
-      }, true),
+      this.serviceActionHelperService.editServiceBinding(
+        item.metadata.guid,
+        item.entity.cfGuid,
+        {
+          [CANCEL_SPACE_ID_PARAM]: item.entity.space_guid,
+          [CANCEL_ORG_ID_PARAM]: item.entity.space.entity.organization_guid,
+          [CANCEL_USER_PROVIDED]: true
+        },
+        true),
     label: 'Edit',
     description: 'Edit Service Instance',
     createVisible: (row$: Observable<APIResource<IUserProvidedServiceInstance>>) =>

--- a/src/frontend/packages/core/src/shared/components/list/list-types/service-instances/service-instances-data-source.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/service-instances/service-instances-data-source.ts
@@ -1,14 +1,20 @@
 import { Store } from '@ngrx/store';
 
+import { GetServiceInstances } from '../../../../../../../store/src/actions/service-instances.actions';
+import { AppState } from '../../../../../../../store/src/app-state';
+import {
+  entityFactory,
+  serviceInstancesSchemaKey,
+  serviceInstancesWithSpaceSchemaKey,
+} from '../../../../../../../store/src/helpers/entity-factory';
+import {
+  createEntityRelationPaginationKey,
+} from '../../../../../../../store/src/helpers/entity-relations/entity-relations.types';
+import { APIResource } from '../../../../../../../store/src/types/api.types';
+import { PaginationEntityState } from '../../../../../../../store/src/types/pagination.types';
 import { getRowMetadata } from '../../../../../features/cloud-foundry/cf.helpers';
 import { ListDataSource } from '../../data-sources-controllers/list-data-source';
 import { IListConfig } from '../../list.component.types';
-import { APIResource } from '../../../../../../../store/src/types/api.types';
-import { AppState } from '../../../../../../../store/src/app-state';
-import { createEntityRelationPaginationKey } from '../../../../../../../store/src/helpers/entity-relations/entity-relations.types';
-import { serviceInstancesSchemaKey, entityFactory } from '../../../../../../../store/src/helpers/entity-factory';
-import { GetServiceInstances } from '../../../../../../../store/src/actions/service-instances.actions';
-import { PaginationEntityState } from '../../../../../../../store/src/types/pagination.types';
 
 export class ServiceInstancesDataSource extends ListDataSource<APIResource> {
   constructor(cfGuid: string, serviceGuid: string, store: Store<AppState>, listConfig?: IListConfig<APIResource>) {
@@ -18,7 +24,7 @@ export class ServiceInstancesDataSource extends ListDataSource<APIResource> {
     super({
       store,
       action,
-      schema: entityFactory(serviceInstancesSchemaKey),
+      schema: entityFactory(serviceInstancesWithSpaceSchemaKey),
       getRowUniqueId: getRowMetadata,
       paginationKey,
       isLocal: true,

--- a/src/frontend/packages/core/src/shared/components/schema-form/schema-form.component.scss
+++ b/src/frontend/packages/core/src/shared/components/schema-form/schema-form.component.scss
@@ -14,6 +14,8 @@
   }
 
   &__form {
+    margin-top: 10px;
+
     &--data-bad {
       margin: 10px 0;
       padding: 10px;

--- a/src/frontend/packages/core/src/shared/data-services/service-action-helper.service.ts
+++ b/src/frontend/packages/core/src/shared/data-services/service-action-helper.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 
 import { RouterNav, RouterQueryParams } from '../../../../store/src/actions/router.actions';
+import { DeleteServiceBinding } from '../../../../store/src/actions/service-bindings.actions';
 import { DeleteServiceInstance } from '../../../../store/src/actions/service-instances.actions';
 import { DeleteUserProvidedInstance } from '../../../../store/src/actions/user-provided-service.actions';
 import { AppState } from '../../../../store/src/app-state';
@@ -13,7 +14,6 @@ import {
 } from '../components/add-service-instance/add-service-instance-base-step/add-service-instance.types';
 import { ConfirmationDialogConfig } from '../components/confirmation-dialog.config';
 import { ConfirmationDialogService } from '../components/confirmation-dialog.service';
-import { DeleteServiceBinding } from '../../../../store/src/actions/service-bindings.actions';
 
 
 @Injectable()


### PR DESCRIPTION
- Tested using https://github.com/mattmcneeney/overview-broker
- Fix service instance name when `extra` data does not contain display name
- Fix some observable based bugs
- Fix issue where space scoped services could not be created
- Fix space scoped indicator in service summary service broker card
- Fixed display of service plans in create space scoped service instance
- Improved json schema form spacing
- Fixes #3863 (failed to show service plans in stepper due to space scoped service bug)