### PR TITLE
Fix setup detection for local users

### DIFF
--- a/src/jetstream/repository/interfaces/structs.go
+++ b/src/jetstream/repository/interfaces/structs.go
@@ -255,8 +255,41 @@ type ConsoleConfig struct {
 	UseSSO                bool     `json:"use_sso" configName:"SSO_LOGIN"`
 }
 
+const defaultAdminScope = "stratos.admin"
+
 // IsSetupComplete indicates if we have enough config
 func (consoleConfig *ConsoleConfig) IsSetupComplete() bool {
+
+	// Local user - check setup complete
+	if AuthEndpointTypes[consoleConfig.AuthEndpointType] == Local {
+
+		// Need LocalUser and LocalUserPassword
+		if len(consoleConfig.LocalUser) == 0 || len(consoleConfig.LocalUserPassword) == 0 {
+			return false
+		}
+
+		// Also, we will make sure that admin scopes are set up for admin, if not specified
+		if len(consoleConfig.LocalUserScope) == 0 {
+			if len(consoleConfig.ConsoleAdminScope) == 0 {
+				// Neither set, so use default for both
+				consoleConfig.LocalUserScope = defaultAdminScope
+				consoleConfig.ConsoleAdminScope = defaultAdminScope
+			} else {
+				// admin scope set, so just use that
+				consoleConfig.LocalUserScope = consoleConfig.ConsoleAdminScope
+			}
+		} else {
+			if len(consoleConfig.ConsoleAdminScope) == 0 {
+				// Console admin scope not set, so use local user scope
+				consoleConfig.ConsoleAdminScope = consoleConfig.LocalUserScope
+			}
+		}
+
+		// Setup is complete if we have LocalUser and LocalUserPassword set
+		return true
+	}
+
+	// UAA - check setup complete for UAA
 	if consoleConfig.UAAEndpoint == nil {
 		return false
 	}


### PR DESCRIPTION
Setup detection does not consider local user auth config - so if UAA_ENDPOINT is not set, you will see the setup screen, even if you have configured local user auth.