### PR TITLE
Fix endpoint unregister

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/cf-entity-generator.ts
+++ b/src/frontend/packages/cloud-foundry/src/cf-entity-generator.ts
@@ -124,6 +124,7 @@ import { CFResponse } from './store/types/cf-api.types';
 import { GitBranch, GitCommit, GitRepo } from './store/types/git.types';
 import { CfUser } from './store/types/user.types';
 import { applicationEventActionBuilders } from './entity-action-builders/application-event.action-builders';
+import { urlValidationExpression } from '../../core/src/core/utils.service';
 
 export interface CFBasePipelineRequestActionMeta {
   includeRelations?: string[];
@@ -138,6 +139,7 @@ export function registerCFEntities() {
 
 export function generateCFEntities(): StratosBaseCatalogueEntity[] {
   const endpointDefinition: StratosEndpointExtensionDefinition = {
+    urlValidationRegexString: urlValidationExpression,
     type: CF_ENDPOINT_TYPE,
     label: 'Cloud Foundry',
     labelPlural: 'Cloud Foundry',

--- a/src/frontend/packages/store/src/reducers/api-request-data-reducer/request-data-reducer.factory.ts
+++ b/src/frontend/packages/store/src/reducers/api-request-data-reducer/request-data-reducer.factory.ts
@@ -19,7 +19,7 @@ export function requestDataReducerFactory(actions: IRequestArray): ActionReducer
       case successAction:
         const success = action as ISuccessRequestAction;
         if (!success.apiAction.updatingKey && success.requestType === 'delete') {
-          const entityKey = entityCatalogue.getEntity(success.apiAction.endpointType, success.apiAction.entityType).entityKey;
+          const entityKey = entityCatalogue.getEntity(success.apiAction).entityKey;
           return deleteEntity(state, entityKey, success.apiAction.guid);
         } else if (success.response) {
           return deepMergeState(state, success.response.entities);


### PR DESCRIPTION
The unregister endpoint action does not have an endpoint type. This is handled in the entity catalogue if an entityConfig is passed in. ApiAction is of type entityConfig.