### PR TITLE
Ensure we remove X-Forward-* HTTP headers that can cause problems proxying API requests

### DIFF
--- a/src/jetstream/passthrough.go
+++ b/src/jetstream/passthrough.go
@@ -189,9 +189,10 @@ func fwdCNSIStandardHeaders(cnsiRequest *interfaces.CNSIRequest, req *http.Reque
 		//  - "Referer" causes CF to fail with a 403
 		//  - "Connection", "X-Cap-*" and "Cookie" are consumed by us
 		//  - "Accept-Encoding" must be excluded otherwise the transport will expect us to handle the encoding/compression
-		//  - X-Forward headers - these will confuse Cloud Foundry in some cases (e.g. load balancers)
-		case k == "Connection", k == "Cookie", k == "Referer", k == "Accept-Encoding", strings.HasPrefix(strings.ToLower(k), "x-cap-"),
-			k == "X-Forwarded-Host", k == "X-Forwarded-Port":
+		//  - X-Forwarded-* headers - these will confuse Cloud Foundry in some cases (e.g. load balancers)
+		case k == "Connection", k == "Cookie", k == "Referer", k == "Accept-Encoding",
+			strings.HasPrefix(strings.ToLower(k), "x-cap-"),
+			strings.HasPrefix(strings.ToLower(k), "x-forwarded-"):
 
 		// Forwarding everything else
 		default:

--- a/src/jetstream/passthrough.go
+++ b/src/jetstream/passthrough.go
@@ -188,8 +188,10 @@ func fwdCNSIStandardHeaders(cnsiRequest *interfaces.CNSIRequest, req *http.Reque
 		// Skip these
 		//  - "Referer" causes CF to fail with a 403
 		//  - "Connection", "X-Cap-*" and "Cookie" are consumed by us
-		// - "Accept-Encoding" must be excluded otherwise the transport will expect us to handle the encoding/compression
-		case k == "Connection", k == "Cookie", k == "Referer", k == "Accept-Encoding", strings.HasPrefix(strings.ToLower(k), "x-cap-"):
+		//  - "Accept-Encoding" must be excluded otherwise the transport will expect us to handle the encoding/compression
+		//  - X-Forward headers - these will confuse Cloud Foundry in some cases (e.g. load balancers)
+		case k == "Connection", k == "Cookie", k == "Referer", k == "Accept-Encoding", strings.HasPrefix(strings.ToLower(k), "x-cap-"),
+			k == "X-Forwarded-For", k == "X-Forwarded-Port":
 
 		// Forwarding everything else
 		default:

--- a/src/jetstream/passthrough.go
+++ b/src/jetstream/passthrough.go
@@ -191,7 +191,7 @@ func fwdCNSIStandardHeaders(cnsiRequest *interfaces.CNSIRequest, req *http.Reque
 		//  - "Accept-Encoding" must be excluded otherwise the transport will expect us to handle the encoding/compression
 		//  - X-Forward headers - these will confuse Cloud Foundry in some cases (e.g. load balancers)
 		case k == "Connection", k == "Cookie", k == "Referer", k == "Accept-Encoding", strings.HasPrefix(strings.ToLower(k), "x-cap-"),
-			k == "X-Forwarded-For", k == "X-Forwarded-Port":
+			k == "X-Forwarded-Host", k == "X-Forwarded-Port":
 
 		// Forwarding everything else
 		default:


### PR DESCRIPTION
Load balancers can add headers - X-Forwarded-Host and X-Forwarded-Port - these cause problems when we proxy requests to Cloud Foundry when Stratos is behind a load balancer