### PR TITLE
Endpoint register tiles render priority

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/cf-entity-generator.ts
+++ b/src/frontend/packages/cloud-foundry/src/cf-entity-generator.ts
@@ -150,6 +150,7 @@ export function generateCFEntities(): StratosBaseCatalogueEntity[] {
     logoUrl: '/core/assets/endpoint-icons/cloudfoundry.png',
     authTypes: [BaseEndpointAuth.UsernamePassword, BaseEndpointAuth.SSO],
     listDetailsComponent: CfEndpointDetailsComponent,
+    renderPriority: 1,
     globalPreRequest: (request, action) => {
       return addCfRelationParams(request, action);
     },

--- a/src/frontend/packages/core/src/base-entity-types.ts
+++ b/src/frontend/packages/core/src/base-entity-types.ts
@@ -52,11 +52,11 @@ class UserFavoriteCatalogueEntity extends StratosCatalogueEntity {
       type: userFavoritesEntitySchema.entityType,
       endpoint: stratosType,
     }, {
-      dataReducers: [
-        addOrUpdateUserFavoriteMetadataReducer,
-        deleteUserFavoriteMetadataReducer,
-      ]
-    });
+        dataReducers: [
+          addOrUpdateUserFavoriteMetadataReducer,
+          deleteUserFavoriteMetadataReducer,
+        ]
+      });
   }
 }
 
@@ -93,7 +93,8 @@ export function generateStratosEntities() {
       labelPlural: 'Metrics',
       tokenSharing: true,
       logoUrl: '/core/assets/endpoint-icons/metrics.svg',
-      authTypes: [BaseEndpointAuth.UsernamePassword, BaseEndpointAuth.None]
+      authTypes: [BaseEndpointAuth.UsernamePassword, BaseEndpointAuth.None],
+      renderPriority: 1
     },
       metadata => `/endpoints/metrics/${metadata.guid}`
     )


### PR DESCRIPTION
We now use the endpoint definition's renderPriority or compare the endpoint definition's label value to prioritise the tiles in the register endpoint view.

🤞it won't break any E2E tests.